### PR TITLE
Cygwin + symlink 環境で vital#of() がエラーになる

### DIFF
--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -70,7 +70,7 @@ function! s:_scripts()
 endfunction
 
 function! s:_unify_path(path)
-  return fnamemodify(resolve(a:path), ':p:gs?\\\+?/?')
+  return resolve(fnamemodify(a:path, ':p:gs?\\\+?/?'))
 endfunction
 
 function! s:_build_module(sid)


### PR DESCRIPTION
neobundle.vim を使っているのですが、
Cygwin 環境で ~/.vim が symlink のときに以下のエラーが発生します。

```
Error detected while processing $HOME/.vim/bundle/neobundle.vim/autoload/vital/_b8e8d8.vim:
line   12:
E127: Cannot redefine function <SNR>6_import: It is in use
```

詳しくはコミットログに書きました。
よろしくお願いします。
