### PR TITLE
fix path glob on cygwin.

### DIFF
--- a/autoload/vital/__latest__/system/filepath.vim
+++ b/autoload/vital/__latest__/system/filepath.vim
@@ -35,8 +35,12 @@ function! s:which(command, ...)
   \              !a:0                  ? split($PATH, s:path_separator) :
   \              type(a:1) == type([]) ? copy(a:1) :
   \                                      split(a:1, s:path_separator)
-  if s:is_windows
-    let pathext = map(split($PATHEXT, s:path_separator), 'tolower(v:val)')
+  if s:is_windows || s:is_cygwin
+    if s:is_windows
+      let pathext = map(split($PATHEXT, s:path_separator), 'tolower(v:val)')
+    else
+      let pathext = ['', '.exe']
+    endif
     if index(pathext, '.' . tolower(fnamemodify(a:command, ':e'))) != -1
       let pathext = ['']
     endif
@@ -49,7 +53,10 @@ function! s:which(command, ...)
     for ext in pathext
       let full = fnamemodify(dir . dirsep . a:command . ext, ':p')
       if filereadable(full)
-        return glob(substitute(toupper(full), '\u:\@!', '[\0\L\0]', 'g'), 1)
+        let full = glob(substitute(toupper(full), '\u:\@!', '[\0\L\0]', 'g'), 1)
+        if full != ''
+          return full
+        endif
       endif
     endfor
   endfor


### PR DESCRIPTION
cygwin (1.7.15 で確認) で glob('/usr/bin/[Ll][Ss]') すると空になります。
おそらく cygwin 側の .exe 補完がいけてないのかと。
ディレクトリは展開できます。
*.exe が存在しないスクリプトやシンボリックリンクの場合は展開できます。
cygwin では $PATHEXT は参照されず、.exe のみ補完されます。

``` vim
echo isdirectory('/usr/bin') " -> 1
echo glob('/[Uu][Ss][R]/[Bb][Ii][Nn]') " -> '/usr/bin'

echo filereadable('/usr/bin/ls') " -> 1
echo filereadable('/usr/bin/ls.exe') " -> 1
echo glob('/[Uu][Ss][R]/[Bb][Ii][Nn]/ls') " -> '/usr/bin/ls'
echo glob('/[Uu][Ss][R]/[Bb][Ii][Nn]/[Ll][Ss]') " -> ''
echo glob('/[Uu][Ss][R]/[Bb][Ii][Nn]/[Ll][Ss].[Ee][Xx][Ee]') " -> '/usr/bin/ls.exe'

echo filereadable('/usr/bin/view') " -> 1
echo filereadable('/usr/bin/view.exe') " -> 0
echo glob('/[Uu][Ss][R]/[Bb][Ii][Nn]/[Vv][Ii][Ee][Ww]') " -> '/usr/bin/view'
```
