### PR TITLE
Prelude : fixed how to find the location of svn repository.

### DIFF
--- a/autoload/vital/__latest__/prelude.vim
+++ b/autoload/vital/__latest__/prelude.vim
@@ -304,7 +304,10 @@ function! s:path2project_directory(path, ...)
             \ fnamemodify(directory, ':h'))
 
       if parent_directory != ''
-        let directory = parent_directory
+        let d = finddir(vcs, parent_directory . ';')
+        if d != ''
+          let directory = s:path2project_directory(parent_directory)
+        endif
       endif
     endif
   endfor


### PR DESCRIPTION
s:path2project_directory() の svn リポジトリの探索方法を修正しました。

before
「.svn が存在するディレクトリの一つ上のディレクトリ」を返す

after
「.svn が存在する最上位のディレクトリ」を返す

恐らく svn のリポジトリを探す方法としてはこちらの方が適切かと思います。
