### PR TITLE
System.File: remove redirect

### DIFF
--- a/autoload/vital/__latest__/system/file.vim
+++ b/autoload/vital/__latest__/system/file.vim
@@ -129,7 +129,7 @@ elseif has('unix')
     let option = ''
     let option .= flags =~# 'f' ? ' -f' : ''
     let option .= flags =~# 'r' ? ' -r' : ''
-    let ret = system("/bin/rm" . option . ' ' . shellescape(a:path) . ' 2>&1')
+    let ret = system("/bin/rm" . option . ' ' . shellescape(a:path))
     if v:shell_error
       throw substitute(iconv(ret, 'char', &encoding), '\n', '', 'g')
     endif


### PR DESCRIPTION
Vitalize でカレントディレクトリに空ファイル "1" が作られる、または、ファイル "1" が存在する場合にはファイルが壊されるバグを修正しました。

ファイルを壊されるよりはエラーメッセージがでるほうが良いと思います。
