### PR TITLE
DateTime の timezone 取得処理方法を変えてみました

### DIFF
--- a/autoload/vital/__latest__/date_time.vim
+++ b/autoload/vital/__latest__/date_time.vim
@@ -25,7 +25,7 @@ function! s:_vital_loaded(V)
 
   if s:V.is_windows()
     let s:win_tz = 0
-    let regs = split(vimproc#system('reg query "HKLM\System\CurrentControlSet\Control\TimeZoneInformation" /v Bias'), "\n")
+    let regs = split(s:V.system('reg query "HKLM\System\CurrentControlSet\Control\TimeZoneInformation" /v Bias'), "\n")
     for reg in regs
       if reg =~# 'REG_DWORD'
         let s:win_tz = -1 * split(reg)[-1] * 60


### PR DESCRIPTION
vimproc で  "| findstr REG_DWORD"  があるとエラーが出るようになりました。

vimproc 側の直し方が分からなかったので
date_time.vim  の方を見なおしてみました。
