### PR TITLE
Data.List: add with_index()

### DIFF
--- a/autoload/vital/__latest__/data/list.vim
+++ b/autoload/vital/__latest__/data/list.vim
@@ -227,6 +227,11 @@ function! s:zip(...)
   return map(range(min(map(copy(a:000), 'len(v:val)'))), "map(copy(a:000), 'v:val['.v:val.']')")
 endfunction
 
+" Inspired by Ruby's with_index method.
+function! s:with_index(list, ...)
+  let base = a:0 > 0 ? a:1 : 0
+  return s:zip(a:list, range(base, len(a:list)+base-1))
+endfunction
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/doc/vital-data-list.txt
+++ b/doc/vital-data-list.txt
@@ -227,5 +227,27 @@ zip(...)				*Vital.Data.List.zip()*
 	:echo List.zip([1, 2, 3], [4, 5, 6], [7, 8, 9])
 	[[1, 4, 7], [2, 5, 8], [3, 6, 9]]
 <
+
+with_index({list} [, {offset}])		*Vital.Data.List.with_index()*
+	Returns {list} with index. {offset} means the base of index.
+	If you specify {offset}, index starts with {offset}.
+>
+	:echo List.with_index(['a', 'b', 'c'])
+	[['a', 0], ['b', 1], ['c', 2]]
+<
+	This function is useful when used with |:for|.
+	For example, when you have lines as a list of string and you want to
+	output a line with a line number to each line, you may write as below.
+>
+	for idx in range(1, len(lines))
+		echo idx.': '.lines[idx]
+	endfor
+<
+	This procedure can be rewritten using with_index() as below.
+>
+	for [line, idx] in List.with_index(lines, 1)
+		echo idx.': '.line
+	endfor
+<
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/spec/data/list.vim
+++ b/spec/data/list.vim
@@ -254,3 +254,10 @@ Context Data.List.zip()
     Should g:L.zip([1,2,3],[4,5],[7,8,9]) ==# [[1,4,7],[2,5,8]]
   End
 End
+
+Context Data.List.with_index()
+  It return list with index
+    Should g:L.with_index(['a', 'b', 'c']) ==# [['a', 0], ['b', 1], ['c', 2]]
+    Should g:L.with_index(['a', 'b', 'c'], 3) ==# [['a', 3], ['b', 4], ['c', 5]]
+  End
+End


### PR DESCRIPTION
hi.
I suggest adding with_index() function which is inspired by Ruby's
with_index method.

with_index({list} [, {offset}])

Returns {list} with index. {offset} means the base of index.
If you specify {offset}, index starts with {offset}.

```
:echo List.with_index(['a', 'b', 'c'])
[['a', 0], ['b', 1], ['c', 2]]
```

This function is useful when used with |:for|.
For example, when you have lines as a list of string and you want to
output a line with a line number to each line, you may write as below.

```
for idx in range(1, len(lines))
    echo idx.': '.lines[idx]
endfor
```

This procedure can be rewritten using with_index() as below.

```
for [line, idx] in List.with_index(lines, 1)
    echo idx.': '.line
endfor
```
