### PR TITLE
Data.String: fix infinite loop if a:from is part of a:to

### DIFF
--- a/autoload/vital/__latest__/data/string.vim
+++ b/autoload/vital/__latest__/data/string.vim
@@ -24,7 +24,7 @@ function! s:replace(str, from, to)
     let left  = idx ==# 0 ? '' : str[: idx - 1]
     let right = str[idx + strlen(a:from) :]
     let str = left . a:to . right
-    let idx = stridx(str, a:from)
+    let idx = stridx(str, a:from, idx + strlen(a:to))
   endwhile
   return str
 endfunction


### PR DESCRIPTION
こんにちは

Data.Stringのreplaceで、引数のfromがtoの一部だと無限ループするので修正しました。

例えば、以下の様なケース

``` vim
" fromとtoが同じ場合
call s:String.replace('hogehoge', 'hoge', 'hoge')

" fromがtoの一部の場合
call s:String.replace('hogehoge', 'hoge', 'hoge1')
```
