### PR TITLE
Web.Http: fix default_settings.headers

### DIFF
--- a/autoload/vital/__latest__/web/http.vim
+++ b/autoload/vital/__latest__/web/http.vim
@@ -105,6 +105,7 @@ function! s:request(...)
     endif
     unlet arg
   endfor
+  let s:default_settings.headers = {}
   call extend(settings, s:default_settings, 'keep')
   let settings.method = toupper(settings.method)
   if !has_key(settings, 'url')


### PR DESCRIPTION
settings.contentType を指定して, request() を呼び出すと,
headers の dictionary が使いまわされているために, デフォルト値が変わってしまうバグを修正しました.
どう修正すべきか迷ったのですが, タイプ数が少なそうな方法をとりました.
