### PR TITLE
ProcessManager: trivial bug fix in status()

### DIFF
--- a/autoload/vital/__latest__/process_manager.vim
+++ b/autoload/vital/__latest__/process_manager.vim
@@ -94,10 +94,10 @@ function! s:status(i)
   let stat= p.kill(0)
 
   if stat
-    return 'active'
+    return 'inactive'
   endif
 
-  return 'inactive'
+  return 'active'
 endfunction
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
status()の戻り値が、active/inactive逆になっていたのを修正しました。
