### PR TITLE
ProcessManager: check status() before reading or writing.

### DIFF
--- a/autoload/vital/__latest__/process_manager.vim
+++ b/autoload/vital/__latest__/process_manager.vim
@@ -48,6 +48,9 @@ function! s:read_wait(i, wait, endpatterns)
   if !has_key(s:_processes, a:i)
     throw printf("ProcessManager doesn't know about %s", a:i)
   endif
+  if s:status(a:i) ==# 'inactive'
+    return ['', '', 'inactive']
+  endif
 
   let p = s:_processes[a:i]
   let out_memo = ''
@@ -76,9 +79,14 @@ function! s:write(i, str)
   if !has_key(s:_processes, a:i)
     throw printf("ProcessManager doesn't know about %s", a:i)
   endif
+  if s:status(a:i) ==# 'inactive'
+    return 'inactive'
+  endif
 
   let p = s:_processes[a:i]
   call p.stdin.write(a:str)
+
+  return 'active'
 endfunction
 
 function! s:writeln(i, str)


### PR DESCRIPTION
プロセスが異常終了している場合に、read_wait()やwrite()では、次の現象が起こる。
- read_wait() - timedoutが発生する
- write() - 例外が発生する

なので、読み書きを行う前にプロセスの状態をチェックし、inactiveの場合には即座に処理を返すようにした。
