### PR TITLE
Data.String: bugfix infinite loop in scan()

### DIFF
--- a/autoload/vital/__latest__/Data/String.vim
+++ b/autoload/vital/__latest__/Data/String.vim
@@ -47,15 +47,7 @@ endfunction
 
 function! s:scan(str, pattern)
   let list = []
-  let pos = 0
-  let len = len(a:str)
-  while 0 <= pos && pos < len
-    let matched = matchstr(a:str, a:pattern, pos)
-    let pos = matchend(a:str, a:pattern, pos)
-    if !empty(matched)
-      call add(list, matched)
-    endif
-  endwhile
+  call substitute(a:str, a:pattern, '\=add(list, submatch(0)) == [] ? "" : ""', 'g')
   return list
 endfunction
 

--- a/spec/data/string.vim
+++ b/spec/data/string.vim
@@ -69,6 +69,8 @@ Context Data.String.scan()
     Should g:S.scan('neo compl cache', 'c\w\+') == ['compl', 'cache']
     Should g:S.scan('[](){}', '[{()}]') == ['(', ')', '{', '}']
     Should g:S.scan('string', '.*') == ['string']
+    Should g:S.scan('string', '.\zs') == ['', '', '', '', '', '']
+    Should g:S.scan('string', '') == ['', '', '', '', '', '', '']
   End
 End
 


### PR DESCRIPTION
bugfix infinite loop in scan() when matched string is empty.
And improve performance.

パフォーマンス向上のためにsubstitute()使うようにしました。
ついでに無限ループバグも修正されます。
substituteの第3引数がちょっとあれな気はしますが、他に思い浮かびませんでした。
なにかご意見あればコメントいただけると助かります。
