### PR TITLE
Data.String: bugfix in diffidx()

### DIFF
--- a/autoload/vital/__latest__/Data/String.vim
+++ b/autoload/vital/__latest__/Data/String.vim
@@ -213,7 +213,7 @@ endfunction
 " If a ==# b, returns -1.
 " If a !=# b, returns first index of diffrent character.
 function! s:diffidx(a, b)
-  return return a:a ==# a:b ? -1 : s:common_head([a:a, a:b])
+  return a:a ==# a:b ? -1 : strlen(s:common_head([a:a, a:b]))
 endfunction
 
 function! s:substitute_last(expr, pat, sub)


### PR DESCRIPTION
bugfix double return and call strlen() around common_head().

returnが2つ重なっていたので修正したのと、common_headは文字列なので
strlen()で文字列長(異なる文字が出現するはじめのindex)を返すように修正しました。
