### PR TITLE
Data.String: performance: use sort() instead of use loop

### DIFF
--- a/autoload/vital/__latest__/Data/String.vim
+++ b/autoload/vital/__latest__/Data/String.vim
@@ -43,18 +43,13 @@ function! s:common_head(strs)
   if empty(a:strs)
     return ''
   endif
-  let head = a:strs[0]
-  for str in a:strs[1 :]
-    if empty(str)
-      return ''
-    endif
-    let pat = substitute(str, '.', '[\0]', 'g')
-    let head = matchstr(head, '^\%[' . pat . ']')
-    if head ==# ''
-      break
-    endif
-  endfor
-  return head
+  let len = len(a:strs)
+  if len == 1
+    return a:strs[0]
+  endif
+  let strs = len == 2 ? a:strs : sort(copy(a:strs))
+  let pat = substitute(strs[0], '.', '[\0]', 'g')
+  return pat == '' ? '' : matchstr(strs[-1], '^\%[' . pat . ']')
 endfunction
 
 " Split to two elements of List. ([left, right])

--- a/spec/data/string.vim
+++ b/spec/data/string.vim
@@ -97,6 +97,12 @@ Context Data.String.common_head()
     Should g:S.common_head(['neocomplcache', 'neosnippet', 'neobundle']) ==# 'neo'
     Should g:S.common_head(['neocomplcache', 'vimshell']) ==# ''
   End
+  It returns an empty string if empty string in list
+    Should g:S.common_head(['neocomplcache', '']) ==# ''
+    Should g:S.common_head(['', 'neocomplcache']) ==# ''
+    Should g:S.common_head(['', '']) ==# ''
+    Should g:S.common_head(['']) ==# ''
+    End
   It returns an empty string with empty list
     Should g:S.common_head([]) ==# ''
   End


### PR DESCRIPTION
現状の実装だと、最悪ケースでリスト長分ループするので遅いです。
このため、はじめにリストをsortし、最初と最後の要素で共通部分を探すようにしました。
無駄にsortのコストがかからないようにリスト長が2個より大きい場合にだけsortするようにしてます。
