### PR TITLE
Add spec.sh and FinUpdate command

### DIFF
--- a/spec.sh
+++ b/spec.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+if [ $# -gt 1 ]; then
+  echo "Usage: spec.sh {spec_file}" 1>&2
+  exit 1
+fi
+
+VIM=vim
+SPEC_FILE=$1
+OUTFILE=/tmp/vital_spec.result
+echo '' > $OUTFILE
+
+if [ -n "$SPEC_FILE" ]; then
+  # not required '&'(background process)
+  $VIM -u NONE -i NONE -N --cmd 'filetype indent on' -S $SPEC_FILE -c "FinUpdate $OUTFILE" >/dev/null 2>&1
+else
+  # all test
+  find spec -type f | grep vim | while read FILE
+  do
+    if [ $FILE != "spec/base.vim" ]; then
+      echo Testing... $FILE
+      # required '&'(background process)
+      $VIM -u NONE -i NONE -N --cmd 'filetype indent on' -S $FILE -c "FinUpdate $OUTFILE" >/dev/null 2>&1 </dev/null &
+      # TODO other methods
+      # it waits to complete vim.
+      # when not waiting, starting of the next vim goes wrong.
+      sleep 1
+    fi
+  done
+  # TODO other methods
+  # it waits to complete vim.
+  # when not waiting, cat becomes imperfect.
+  echo Done. please wait...
+  sleep 2
+fi
+
+cat $OUTFILE
+
+ALL_TEST_NUM=`grep "\[.\]" $OUTFILE | wc -l`
+FAILED_TEST_NUM=`grep "\[F\]" $OUTFILE | wc -l`
+
+if [ $FAILED_TEST_NUM -eq 0 ]; then
+  echo $ALL_TEST_NUM tests success
+  echo
+  exit 0
+else
+  FAILED_ASSERT_NUM=`grep " - " $OUTFILE | wc -l`
+  echo FAILURE!
+  echo $ALL_TEST_NUM tests. Failure: $FAILED_TEST_NUM tests, $FAILED_ASSERT_NUM assertions
+  echo
+  exit 1
+fi

--- a/spec/README.md
+++ b/spec/README.md
@@ -6,7 +6,16 @@ on vimshell
 
 for gui vim (example: MacVim):
 
+    $ cd {repository_root}
     $ /Applications/MacVim.app/Contents/MacOS/Vim -g -u NONE -i NONE -N --cmd 'filetype indent on' -S spec/prelude.vim -c 'Fin /tmp/prelude.result'
+
+unix
+
+    $ cd {repository_root}
+    # run all test
+    $ ./spec.sh
+    # run specify test
+    $ ./spec.sh spec/data/string.vim
 
 otherwise
 


### PR DESCRIPTION
テスト環境向上のための変更をしてみました。
- FinUpdateコマンドの追加
  - Finと異なり、ファイル上書きではなく更新します
  - テスト結果を多少整形して書き出します
- spec.shの追加
  - `$ ./spec.sh` とすれば全テストを実行します
  - `$ ./spec.sh spec/data/string.vim` のようにすれば指定したファイルだけ実行します
  - テスト成功時に0、失敗時に1を返します。(これによりtravis-ciで実行できるようになります)
  - bat版はありません

実行結果はこのようになります。

https://gist.github.com/kannokanno/322765e707bc67e7d2c6

よろしければご参考ください。
