### PR TITLE
add g:vitalizer_vital_dir variable to vitalizer

### DIFF
--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -24,8 +24,8 @@ function! s:init_vars()
   if s:vital_dir !=# ''
     return
   endif
-  if exists('g:vitalizer_vital_dir')
-    let s:vital_dir = g:vitalizer_vital_dir
+  if exists('g:vitalizer#vital_dir')
+    let s:vital_dir = g:vitalizer#vital_dir
   else
     let s:vital_dir = expand('<sfile>:h:h:p')
   endif


### PR DESCRIPTION
vitalizerの`s:vital_dir`をグローバル変数で設定できるようにしました。
なぜこの変更をするに至ったかというと、以下のような環境で問題が起きたためです。
- `C:\Users\takuya\vimfiles`に`C:\Users\takuya\Documents\Github\dotfiles\dotfiles\.vim`へのジャンクションを作成している
- 各プラグインをsubmoduleで管理している

Gitのsubmoduleの仕様上、submoduleのリポジトリの「.git」はディレクトリではなくファイルであり、中身に相対パス(gitdir: ../../../../.git/modules/dotfiles/.vim/bundle/vital.vim)が書かれていて、.gitディレクトリの実体は親リポジトリの「.git/modules/<トップレベルからの相対パス>」です。(以前は`.git`ディレクトリがsubmoduleリポジトリの中に存在していたがいつの間にか仕様変更した)

しかしこの仕様はジャンクションや、Unix系においてもシンボリックリンクの構成によっては存在しないパスを参照することがあり得ます。
(「C:/Users/takuya/vimfiles/bundle/vital.vim/../../../../.git/modules/dotfiles/.vim/bundle/vital.vim」は「C:/Users/.git/modules/dotfiles/.vim/bundle/vital.vim」となるため)

とりあえずvitalizerとしては、`s:vital_dir`をジャンクションやシンボリックリンク(Windows,Unix系含む)を含まないパスにすれば解決するため、このパスをグローバル変数で変更できるようにしました。
