### PR TITLE
use Vital.Bitwise.xor instead of built-in xor() function

### DIFF
--- a/autoload/vital/__latest__/Random/Xor128.vim
+++ b/autoload/vital/__latest__/Random/Xor128.vim
@@ -25,11 +25,11 @@ function! s:srand(...)
 endfunction
 
 function! s:rand()
-  let t = xor(s:x, s:B.lshift(s:x, 11))
+  let t = s:B.xor(s:x, s:B.lshift(s:x, 11))
   let s:x = s:y
   let s:y = s:z
   let s:z = s:w
-  let s:w = xor(xor(s:w, s:B.rshift(s:w, 19)), xor(t, s:B.rshift(t, 8)))
+  let s:w = s:B.xor(s:B.xor(s:w, s:B.rshift(s:w, 19)), s:B.xor(t, s:B.rshift(t, 8)))
   return s:w
 endfunction
 


### PR DESCRIPTION
Random.Xor128 に使う排他的論理和は組み込み関数 xor() を使っていたのですが，Vim にビット演算関数が追加されたのが比較的最近（7.3.377から）だと知ったので，Vital.Bitwise.xor() を使うように変更しました．
Vital.Bitwise.xor() は組み込みのビット演算関数がある場合それらを使い，無い場合はオリジナルの実装を使うため，こちらのほうが優れています．
