### PR TITLE
Data.List: improve foldr

### DIFF
--- a/autoload/vital/__latest__/Data/List.vim
+++ b/autoload/vital/__latest__/Data/List.vim
@@ -227,15 +227,7 @@ endfunction
 
 " similar to Haskell's Prelude.foldr
 function! s:foldr(f, init, xs)
-  let memo = a:init
-  for i in reverse(range(0, len(a:xs) - 1))
-    let x = a:xs[i]
-    let expr = substitute(a:f, 'v:val', string(x), 'g')
-    let expr = substitute(expr, 'v:memo', string(memo), 'g')
-    unlet memo
-    let memo = eval(expr)
-  endfor
-  return memo
+  return s:foldl(a:f, a:init, reverse(copy(a:xs)))
 endfunction
 
 " similar to Haskell's Prelude.fold11


### PR DESCRIPTION
現行のやり方より `reverse(copy(a:xs))` を `foldl` に渡す方が速いようです。

ループ部分のベンチマーク
https://gist.github.com/ichizok/6914387#file-fold-test-vim

OS X 10.8.5 / Core i5 2.5GHz / 16GB mem

```
s:foldr_orig
----------------
[ 1]   0.006166
[ 2]   0.006257
[ 3]   0.006136
[ 4]   0.006181
[ 5]   0.006225
[ 6]   0.006158
[ 7]   0.006165
[ 8]   0.006176
[ 9]   0.006175
[10]   0.006254
----------------
total: 0.061893, avg: 0.006189
================================

s:foldr_invr
----------------
[ 1]   0.006251
[ 2]   0.006171
[ 3]   0.006182
[ 4]   0.006159
[ 5]   0.006187
[ 6]   0.006168
[ 7]   0.006162
[ 8]   0.006135
[ 9]   0.006197
[10]   0.006147
----------------
total: 0.061759, avg: 0.006176
================================

s:foldr_copy
----------------
[ 1]   0.005405
[ 2]   0.005400
[ 3]   0.005351
[ 4]   0.005382
[ 5]   0.005363
[ 6]   0.005391
[ 7]   0.005388
[ 8]   0.005383
[ 9]   0.005352
[10]   0.005391
----------------
total: 0.053806, avg: 0.005381
================================
```
