### PR TITLE
Processmanager: read_wait() always returns result

### DIFF
--- a/autoload/vital/__latest__/ProcessManager.vim
+++ b/autoload/vital/__latest__/ProcessManager.vim
@@ -49,11 +49,13 @@ function! s:read_wait(i, wait, endpatterns)
   if !has_key(s:_processes, a:i)
     throw printf("ProcessManager doesn't know about %s", a:i)
   endif
-  if s:status(a:i) ==# 'inactive'
-    return ['', '', 'inactive']
-  endif
 
   let p = s:_processes[a:i]
+
+  if s:status(a:i) ==# 'inactive'
+    return [p.stdout.read(), p.stderr.read(), 'inactive']
+  endif
+
   let out_memo = ''
   let err_memo = ''
   let lastchanged = reltime()
@@ -101,7 +103,7 @@ function! s:status(i)
   let p = s:_processes[a:i]
   " vimproc.kill isn't to stop but to ask for the current state.
   " return p.kill(0) ? 'inactive' : 'active'
-  " ... checkpid() checks if the process is running AND does waitpid() in C, 
+  " ... checkpid() checks if the process is running AND does waitpid() in C,
   " so it solves zombie processes.
   return get(p.checkpid(), 0, '') ==# 'run' ?
         \ 'active' : 'inactive'


### PR DESCRIPTION
Currently read_wait() does not return stdout and stderror when process is inactive. However, I think that it should always return result.

[SampleCode](https://gist.github.com/anonymous/7200242/raw/d47589036039b6bbafe2ad5582b35445243a545f/test.vim)
