### PR TITLE
ProcessManager: s:stop() throws SIGTERM

### DIFF
--- a/autoload/vital/__latest__/ProcessManager.vim
+++ b/autoload/vital/__latest__/ProcessManager.vim
@@ -34,9 +34,9 @@ function! s:new(cmd)
   return s:_auto_label
 endfunction
 
-function! s:stop(i)
+function! s:stop(i, ...)
   let p = s:_processes[a:i]
-  call p.kill(9)
+  call p.kill(get(a:000, 0, 0) ? g:vimproc#SIGKILL : g:vimproc#SIGTERM)
   " call p.waitpid()
   unlet s:_processes[a:i]
 endfunction


### PR DESCRIPTION
プロセスが終了処理を行うこともあるので、`s:stop()` で投げるシグナルは `SIGTERM` が良いのでは。
オプションとして第二引数を force フラグ (`SIGKILL`) にしています。
