### PR TITLE
Data.Closure

### DIFF
--- a/doc/vital-data-closure.txt
+++ b/doc/vital-data-closure.txt
@@ -54,10 +54,13 @@ TERM					*Vital.Data.Closure-term*
 	{binding} is a |Dictionary|.  You can access to this Dictionary from
 	{expr} or {command} as local variables.
 	Note that the key for |Funcref| must start with a capital.
-	If local variable is changed, {binding} will change similarly.
+
 	When {binding} is a |List| of |Dictionary|, a new |Dictionary| will be
 	created as new {binding}, and all dictionaries are extended to the new
 	dictionary.
+
+	If local variable is changed, {binding} will change similarly.  This
+	feature is available in Vim 7.3.560 or later.
 
 
 
@@ -146,6 +149,10 @@ sweep_functions()			*Vital.Data.Closure.sweep_functions()*
 	As a result, the function remains as garbage.
 	This function sweeps it.
 	This is automatically called by |Vital.Data.Closure.build()|.
+
+is_binding_supported()		*Vital.Data.Closure.is_binding_supported()*
+	Returns true when the {binding} feature supports local changing.
+	See also |Vital.Data.Closure-term-binding|.
 
 
 

--- a/test/Data/Closure.vimspec
+++ b/test/Data/Closure.vimspec
@@ -135,6 +135,9 @@ Describe Data.Closure
       End
 
       It can change the variables of binding
+        if !g:C.is_binding_supported()
+          Skip {binding} is not supported in this Vim
+        endif
         let foo = 10
         let closure = g:C.from_command('let foo = a:1', l:)
         Assert Equals(foo, 10)


### PR DESCRIPTION
Closure オブジェクトです。今のところ叩き台で、今後 `push -f` で容赦なく変更する可能性があります。
以下残タスク。
- [x] doc
- [x] spec
- [x] binding のキャプチャ問題(下記参照)
- [ ] from_command などでの with_context() 問題(下記参照)
- [x] Data.List 依存は微妙なので外したい
### binding のキャプチャ問題

``` vim
let i = 0
let f = Closure.from_command(':let i += 1', l:)
for _ in range(10)
  call f.call()
endfor
echo i  " => 10
```

みたいなことがしたい。要は、from_command で、ローカル変数を変更した場合、binding も更新したい。
ただし、`from_command(cmd, l:, s:)` のように、binding は複数渡したい場合もあるので、その場合どうするか。
### from_command などでの with_context() 問題

`from_command` などで作成した Closure オブジェクトは、独自の構成を持っているので、`with_context()` などを使うとその構成が破壊されてしまう。仕様とするか、何かしらのケアをした方がいいか。
