### PR TITLE
不要なブランチの整理

### DIFF
--- a/autoload/vital/__latest__/Vim/Message.vim
+++ b/autoload/vital/__latest__/Vim/Message.vim
@@ -22,6 +22,16 @@ function! s:warn(msg)
   call s:echomsg('WarningMsg', a:msg)
 endfunction
 
+function! s:capture(command)
+  try
+    redir => out
+    silent execute a:command
+  finally
+    redir END
+  endtry
+  return out
+endfunction
+
 
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
https://github.com/vim-jp/vital.vim/branches

この中で要らなそうなブランチリストアップしてみました(全部自分のブランチなんですが)。
これ全部消しちゃっていいですかね。
- simple-result
  - specの出力をシンプルにするやつ。もういらない。
- module/buffer
  - バッファ操作系ユーティリティ。いらないような…
- module/message
  - メッセージ系ユーティリティ。もうすでにVim.Messageがある。
- vim-compat-capture (#50)
  - capture()関数が追加されそうだったので早まってvitalにも追加したら結果vim_devで追加されなかった悲しいブランチ。
- functor-squash
  - Functorモジュールにsquash()関数を追加。(何これ)
- show-msg-on-success
  - さっきマージされた（した）
