### PR TITLE
add :helptags to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ before_script:
   - (cd /tmp/vimproc && make)
 script:
   - vim --cmd version --cmd quit
+  - vim --cmd "try | helptags doc/ | catch | cquit | endtry" --cmd quit
   - ./spec.sh -q -p /tmp/vimproc


### PR DESCRIPTION
.travis.ymlにtagsの重複を検出できるようにしました。
<del>#145</del> #7 で指摘を受けたようなhelpの記述の重複は、tagsが重複してる事が多いので。
