### PR TITLE
Web.{HTML, XML}に記載されている関数名を、実際と合わせました

### DIFF
--- a/doc/vital-web-html.txt
+++ b/doc/vital-web-html.txt
@@ -26,7 +26,7 @@ parse({content})			*Vital.Web.HTML.parse()*
 parseFile({file})			*Vital.Web.HTML.parseFile()*
 	Parse html file into DOM object.
 
-parseURI({url})				*Vital.Web.HTML.parseURI()*
+parseURL({url})				*Vital.Web.HTML.parseURL()*
 	Get and parse html into DOM object.
 
 ------------------------------------------------------------------------------

--- a/doc/vital-web-xml.txt
+++ b/doc/vital-web-xml.txt
@@ -26,7 +26,7 @@ parse({content})			*Vital.Web.XML.parse()*
 parseFile({file})			*Vital.Web.XML.parseFile()*
 	Parse html file into DOM object.
 
-parseURI({url})				*Vital.Web.XML.parseURI()*
+parseURL({url})				*Vital.Web.XML.parseURL()*
 	Get and parse html into DOM object.
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
parseURL関数がドキュメント上ではparseURIと記載されていたので、実際の関数名に合わせて修正しました。
