### PR TITLE
Database.SQLite: fix query_rawdata() did not work

### DIFF
--- a/autoload/vital/__latest__/Database/SQLite.vim
+++ b/autoload/vital/__latest__/Database/SQLite.vim
@@ -8,7 +8,7 @@ function! s:_vital_loaded(V)
 endfunction
 
 function! s:_vital_depends()
-  return ['Process']
+  return ['Process', 'Data.String']
 endfunction
 
 let s:_debug_mode = 0


### PR DESCRIPTION
はじめまして。こんにちは。

`Database.SQLite.query()`で、下のようなSQL操作ができなかったので、変更しました。

調べてみたのですが、`query_rawdata(db, q, ...)`の最後で`return s:P.system(cmd, built)`しているところの`built`に格納されているSQL文が、`Process.system(str, ...)`で実行する`sqlite3 -batch -line`コマンドの後に渡ってきていませんでした。
`Process.system()`の引数に、cmdにbuiltを足した文字列だけをわたすようにしてみました。

あと、シングルクォートとダブルクォーテーションが入った文字列がINSERTできるように
`s:_quote_escape(x)`を変更いたしました。

```
let s:V       = vital#of('vital')
let s:DB      = s:V.import('Database.SQLite')

call s:DB.query('/path/to/mydb', 'insert into mytable values(?);', ['あいう'])
call s:DB.query('/path/to/mydb', 'insert into mytable values(?);', ["a'b"])
call s:DB.query('/path/to/mydb', 'insert into mytable values(?);', ['c"d'])
call s:DB.query('/path/to/mydb', 'insert into mytable values(?);', ['e\f'])
```

私の見当違いで使い方が間違っていたりしたらすみません。
よろしくおねがいいたします。
