### PR TITLE
Data.String: fix spec: don't change a option value

### DIFF
--- a/spec/data/string.vim
+++ b/spec/data/string.vim
@@ -8,9 +8,7 @@ Context Data.String.wrap()
     Should ['a', 'hello, world!'] ==# g:S.wrap("a\nhello, world!")
     Should ['a', 'hello, world!'] ==# g:S.wrap("a\r\nhello, world!")
     Should ['a', 'hello, world!'] ==# g:S.wrap("a\rhello, world!")
-    let [&columns, columns] = [12, &columns]
-    Should ['a', 'hello, worl', 'd!'] ==# g:S.wrap("a\nhello, world!")
-    let &columns = columns
+    Should ['a', 'hello, worl', 'd!'] ==# g:S.wrap("a\nhello, world!", 12)
   End
 End
 


### PR DESCRIPTION
To: @ujihisa 
Cc: ALL (@vim-jp/vital-vim)
#183 から派生。

spec中で`'columns'`オプションとか変えると（Vimの内部的に）無駄な処理が走りそうです。
その影響でバグも踏むかも…
とかあんまり具体的な理由ではないので全然リジェクトしちゃって大丈夫です。
むしろ「これを期にspecでは出来るだけオプション値変えない方向にするというのはどうか？」という問題提起的なPRです。
