### PR TITLE
Tune Web.JSON for speed.

### DIFF
--- a/autoload/vital/__latest__/Web/JSON.vim
+++ b/autoload/vital/__latest__/Web/JSON.vim
@@ -51,7 +51,7 @@ function! s:decode(json, ...)
         \ 'use_token': 0,
         \}, get(a:000, 0, {}))
   let json = iconv(a:json, "utf-8", &encoding)
-  let json = substitute(json, '\n', '', 'g')
+  let json = join(split(json, "\n"), '')
   let json = substitute(json, '\\u34;', '\\"', 'g')
   let json = substitute(json, '\\u\(\x\x\x\x\)', '\=s:string.nr2enc_char("0x".submatch(1))', 'g')
   if settings.use_token


### PR DESCRIPTION
https://gist.github.com/40a6465420ca29968be5

上のような巨大なjsonをdecode()する際、パフォーマンスが非常に悪かったため、速度の向上を行いました。

修正前 7.71sec
修正後 0.19sec
