### PR TITLE
Data.List: remove string input for permutations()

### DIFF
--- a/autoload/vital/__latest__/Data/List.vim
+++ b/autoload/vital/__latest__/Data/List.vim
@@ -386,21 +386,12 @@ function! s:permutations(list, ...)
   if r > len(a:list)
     return []
   endif
-  if type(a:list) == type('')
-    let l = s:_permutations(split(a:list, '\zs'), r)
-    return map(l, 'join(v:val, "")')
-  else
-    return s:_permutations(a:list, r)
-  endif
-endfunction
-
-function! s:_permutations(list, r)
   let n = len(a:list)
   let result = []
   let indices = range(n)
-  let cycles = range(n, n - a:r + 1, -1)
-  call add(result, a:list[: a:r - 1])
-  let desc = range(a:r - 1, 0, -1)
+  let cycles = range(n, n - r + 1, -1)
+  call add(result, a:list[: r - 1])
+  let desc = range(r - 1, 0, -1)
   while n != 0
     let cont = 0
     for i in desc
@@ -411,7 +402,7 @@ function! s:_permutations(list, r)
       else
         let j = cycles[i]
         let [indices[i], indices[-j]] = [indices[-j], indices[i]]
-        call add(result, map(indices[: a:r - 1], 'a:list[v:val]'))
+        call add(result, map(indices[: r - 1], 'a:list[v:val]'))
         let cont = 1
         break
       endif

--- a/doc/vital-data-list.txt
+++ b/doc/vital-data-list.txt
@@ -494,18 +494,16 @@ binary_search({list}, {expr}, [{func}, [{dict}]])
 	" 1
 	echo s:L.binary_search(['a', 'aa', 'aaa'], 'vivi', CompareByLength.func, CompareByLength)
 	" -1
+<
 permutations({list} [, {r}])			*Vital.Data.List.permutations*
 	Returns successive {r} length permutations of elements in the {list}.
 	If {r} is not specified, then {r} defaults to the length of the {list}
 	and all possible full-length permutations are generated.
-	If {list} is string, this function returns {r} length string permutations.
 >
 	echo L.permutations([1, 2, 3])
 	" [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
 	echo L.permutations([1, 2, 3], 2)
 	" [[1, 2] , [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]
-	echo L.permutations('ABC', 2)
-	" ['AB', 'AC', 'BA', 'BC', 'CA', 'CB']
 <
 
 ==============================================================================

--- a/spec/data/list.vim
+++ b/spec/data/list.vim
@@ -466,13 +466,12 @@ End
 Context Data.List.permutations()
   It returns permutations of elements in given list
     Should g:L.permutations([1, 2, 3]) == [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
-    Should g:L.permutations('ABC') == ['ABC', 'ACB', 'BAC', 'BCA', 'CAB', 'CBA']
+    Should g:L.permutations([]) == [[]]
   End
 
   It returns r length permutations of elements in given list if r is given
     Should g:L.permutations([1, 2, 3], 1) == [[1], [2], [3]]
     Should g:L.permutations([1, 2, 3], 2) == [[1, 2], [1, 3], [2, 1], [2, 3], [3, 1], [3, 2]]
-    Should g:L.permutations('ABC', 2) == ['AB', 'AC', 'BA', 'BC', 'CA', 'CB']
     Should g:L.permutations([1, 2, 3], 4) == []
  End
 End


### PR DESCRIPTION
permutations()の「文字列の入力も受け付ける」という仕様をdropしました。

今後permutations()と似たようなメソッドとしてproduct, combinationsをPRしようと考えています。
文字列に関する扱いについては、permutationsを含めたこれら3つを実装後に改めて検討したいという意図からこのPRを出しました。
