### PR TITLE
ProcessManager version 2

### DIFF
--- a/autoload/vital/__latest__/ProcessManager.vim
+++ b/autoload/vital/__latest__/ProcessManager.vim
@@ -242,7 +242,7 @@ endfunction
 function! s:_go(bulk_or_part, self)
   let self = a:self
   if self.is_idle()
-    throw 'Vital.ProcessManager: go has nothing to do'
+    throw 'vital: ProcessManager: go has nothing to do'
   endif
   let [msgkey, msgvalue] = self['*mailbox*'][0]
 
@@ -253,7 +253,7 @@ function! s:_go(bulk_or_part, self)
     return result
 
   elseif state ==# 'reading' && msgkey ==# 'writeln'
-    throw 'Vital.ProcessManager: Must not happen!!!!!!!!!!!!!1'
+    throw 'vital: ProcessManager: Must not happen!!!!!!!!!!!!!1'
 
   elseif state ==# 'reading' && msgkey ==# 'wait'
     call s:read(self.label, msgvalue)

--- a/autoload/vital/__latest__/ProcessManager.vim
+++ b/autoload/vital/__latest__/ProcessManager.vim
@@ -243,7 +243,7 @@ endfunction
 
 function! s:_go(bulk_or_part, self)
   let self = a:self
-  if self._is_idle()
+  if self.is_idle()
     throw 'vital: ProcessManager: go has nothing to do'
   endif
   let [msgkey, msgvalue] = self['*mailbox*'][0]
@@ -285,7 +285,7 @@ function! s:_go(bulk_or_part, self)
       return s:_trigger(self)
     elseif msgkey ==# 'wait'
       call remove(self['*mailbox*'], 0)
-      return self._go_bulk()
+      return self.go_bulk()
     elseif msgkey ==# 'read'
       let out = self['*buffer*'][0]
       let err = self['*buffer*'][1]
@@ -300,7 +300,7 @@ function! s:_go(bulk_or_part, self)
 endfunction
 
 function! s:_tick() dict
-  if self._is_idle()
+  if self.is_idle()
     return
   endif
 

--- a/autoload/vital/__latest__/ProcessManager.vim
+++ b/autoload/vital/__latest__/ProcessManager.vim
@@ -253,7 +253,7 @@ function! s:_go(bulk_or_part, self)
     return result
 
   elseif state ==# 'reading' && msgkey ==# 'writeln'
-    throw 'Must not happen!!!!!!!!!!!!!1'
+    throw 'Vital.ProcessManager: Must not happen!!!!!!!!!!!!!1'
 
   elseif state ==# 'reading' && msgkey ==# 'wait'
     call s:read(self.label, msgvalue)

--- a/autoload/vital/__latest__/ProcessManager.vim
+++ b/autoload/vital/__latest__/ProcessManager.vim
@@ -144,43 +144,43 @@ function! s:of(label, command)
         \ 'label': a:label,
         \ '*mailbox*': ['*new*'],
         \ '*buffer*': ['', ''],
-        \ 'is_new': function('s:is_new'),
-        \ 'is_idle': function('s:is_idle'),
-        \ 'shutdown': function('s:shutdown'),
-        \ 'reserve_wait': function('s:reserve_wait'),
-        \ 'reserve_writeln': function('s:reserve_writeln'),
-        \ 'reserve_read': function('s:reserve_read'),
-        \ 'go_bulk': function('s:go_bulk'),
-        \ 'go_part': function('s:go_part'),
-        \ 'tick': function('s:tick')}
+        \ 'is_new': function('s:_is_new'),
+        \ 'is_idle': function('s:_is_idle'),
+        \ 'shutdown': function('s:_shutdown'),
+        \ 'reserve_wait': function('s:_reserve_wait'),
+        \ 'reserve_writeln': function('s:_reserve_writeln'),
+        \ 'reserve_read': function('s:_reserve_read'),
+        \ 'go_bulk': function('s:_go_bulk'),
+        \ 'go_part': function('s:_go_part'),
+        \ 'tick': function('s:_tick')}
   let s:_processes2[a:label] = p
   return p
 endfunction
 
-function! s:is_new() dict
+function! s:_is_new() dict
   return self['*mailbox*'] ==# ['*new*']
 endfunction
 
-function! s:is_idle() dict
+function! s:_is_idle() dict
   return empty(self['*mailbox*'])
 endfunction
 
-function! s:shutdown() dict
+function! s:_shutdown() dict
   call s:kill(self.label)
   unlet! s:_processes2[self.label]
 endfunction
 
-function! s:reserve_wait(endpatterns) dict
+function! s:_reserve_wait(endpatterns) dict
   call s:_reserve(self, 'wait', a:endpatterns)
   return self
 endfunction
 
-function! s:reserve_writeln(line) dict
+function! s:_reserve_writeln(line) dict
   call s:_reserve(self, 'writeln', a:line)
   return self
 endfunction
 
-function! s:reserve_read(endpatterns) dict
+function! s:_reserve_read(endpatterns) dict
   call s:_reserve(self, 'read', a:endpatterns)
   return self
 endfunction
@@ -233,17 +233,17 @@ function! s:_trigger2(self)
   endif
 endfunction
 
-function! s:go_bulk() dict
+function! s:_go_bulk() dict
   return s:_go('bulk', self)
 endfunction
 
-function! s:go_part() dict
+function! s:_go_part() dict
   return s:_go('part', self)
 endfunction
 
 function! s:_go(bulk_or_part, self)
   let self = a:self
-  if self.is_idle()
+  if self._is_idle()
     throw 'vital: ProcessManager: go has nothing to do'
   endif
   let [msgkey, msgvalue] = self['*mailbox*'][0]
@@ -285,7 +285,7 @@ function! s:_go(bulk_or_part, self)
       return s:_trigger(self)
     elseif msgkey ==# 'wait'
       call remove(self['*mailbox*'], 0)
-      return self.go_bulk()
+      return self._go_bulk()
     elseif msgkey ==# 'read'
       let out = self['*buffer*'][0]
       let err = self['*buffer*'][1]
@@ -299,8 +299,8 @@ function! s:_go(bulk_or_part, self)
   endif
 endfunction
 
-function! s:tick() dict
-  if self.is_idle()
+function! s:_tick() dict
+  if self._is_idle()
     return
   endif
 

--- a/autoload/vital/__latest__/ProcessManager.vim
+++ b/autoload/vital/__latest__/ProcessManager.vim
@@ -5,6 +5,7 @@ let s:_processes = {}
 
 function! s:_vital_loaded(V) abort
   let s:V = a:V
+  let s:Prelude = s:V.import('Prelude')
   let s:S = s:V.import('Data.String')
   let s:P = s:V.import('Process')
 endfunction
@@ -31,6 +32,7 @@ function! s:_stop(i, ...) abort
   let p = s:_processes[a:i]
   call p.kill(get(a:000, 0, 0) ? g:vimproc#SIGKILL : g:vimproc#SIGTERM)
   " call p.waitpid()
+  call p.checkpid()
   unlet s:_processes[a:i]
   if has_key(s:state, a:i)
     unlet s:state[a:i]
@@ -60,14 +62,14 @@ function! s:read_wait(i, wait, endpatterns) abort
 
   if s:status(a:i) ==# 'inactive'
     let s:state[a:i] = 'inactive'
-    return [p.stdout.read(), p.stderr.read(), 'inactive']
+    return [p.stdout.read(-1, 0), p.stderr.read(-1, 0), 'inactive']
   endif
 
   let out_memo = ''
   let err_memo = ''
   let lastchanged = reltime()
   while 1
-    let [x, y] = [p.stdout.read(), p.stderr.read()]
+    let [x, y] = [p.stdout.read(-1, 0), p.stderr.read(-1, 0)]
     if x ==# '' && y ==# ''
       if str2float(reltimestr(reltime(lastchanged))) > a:wait
         let s:state[a:i] = 'reading'
@@ -125,6 +127,190 @@ endfunction
 
 function! s:debug_processes() abort
   return s:_processes
+endfunction
+
+" ------------ Experimental version 2 ------------
+let s:_processes2 = {}
+
+function! s:of(label, command)
+  let p = get(s:_processes2, a:label)
+  if s:Prelude.is_dict(p)
+    return p
+  endif
+
+  unlet! p
+  call s:touch(a:label, a:command)
+  let p = {
+        \ 'label': a:label,
+        \ '*mailbox*': ['*new*'],
+        \ '*buffer*': ['', ''],
+        \ 'is_new': function('s:is_new'),
+        \ 'is_idle': function('s:is_idle'),
+        \ 'shutdown': function('s:shutdown'),
+        \ 'reserve_wait': function('s:reserve_wait'),
+        \ 'reserve_writeln': function('s:reserve_writeln'),
+        \ 'reserve_read': function('s:reserve_read'),
+        \ 'go_bulk': function('s:go_bulk'),
+        \ 'go_part': function('s:go_part'),
+        \ 'tick': function('s:tick')}
+  let s:_processes2[a:label] = p
+  return p
+endfunction
+
+function! s:is_new() dict
+  return self['*mailbox*'] ==# ['*new*']
+endfunction
+
+function! s:is_idle() dict
+  return empty(self['*mailbox*'])
+endfunction
+
+function! s:shutdown() dict
+  call s:kill(self.label)
+  unlet! s:_processes2[self.label]
+endfunction
+
+function! s:reserve_wait(endpatterns) dict
+  call s:_reserve(self, 'wait', a:endpatterns)
+  return self
+endfunction
+
+function! s:reserve_writeln(line) dict
+  call s:_reserve(self, 'writeln', a:line)
+  return self
+endfunction
+
+function! s:reserve_read(endpatterns) dict
+  call s:_reserve(self, 'read', a:endpatterns)
+  return self
+endfunction
+
+function! s:_reserve(self, key, value)
+  if a:self['*mailbox*'] ==# ['*new*']
+    let a:self['*mailbox*'] = [[a:key, a:value]]
+  else
+    call add(a:self['*mailbox*'], [a:key, a:value])
+  endif
+endfunction
+
+function! s:_trigger(self)
+  let trigger2 = s:_trigger2(a:self)
+  if !has_key(trigger2, 'ready to read')
+    return trigger2
+  endif
+
+  let [msgkey, msgvalue] = a:self['*mailbox*'][0]
+
+  let [out, err, t] = s:read(a:self.label, msgvalue)
+  if t ==# 'matched'
+    call remove(a:self['*mailbox*'], 0)
+    let out = a:self['*buffer*'][0] . out
+    let err = a:self['*buffer*'][1] . err
+    return {'done': 1, 'fail': 0, 'out': out, 'err': err}
+  else
+    let a:self['*buffer*'][0] .= out
+    let a:self['*buffer*'][1] .= err
+    return {'done': 0, 'fail': 0}
+  endif
+endfunction
+
+function! s:_trigger2(self)
+  let [msgkey, msgvalue] = a:self['*mailbox*'][0]
+  if msgkey ==# 'writeln'
+    call s:writeln(a:self.label, msgvalue)
+    call remove(a:self['*mailbox*'], 0)
+    return s:_trigger2(a:self)
+  elseif msgkey ==# 'wait'
+    let [_, _, t] = s:read(a:self.label, msgvalue)
+    if t ==# 'matched'
+      call remove(a:self['*mailbox*'], 0)
+    endif
+    return {'done': 0, 'fail': 0}
+  elseif msgkey ==# 'read'
+    return {'ready to read': 'civ5'}
+  endif
+endfunction
+
+function! s:go_bulk() dict
+  return s:_go('bulk', self)
+endfunction
+
+function! s:go_part() dict
+  return s:_go('part', self)
+endfunction
+
+function! s:_go(bulk_or_part, self)
+  let self = a:self
+  if self.is_idle()
+    throw 'Vital.ProcessManager: go has nothing to do'
+  endif
+  let [msgkey, msgvalue] = self['*mailbox*'][0]
+
+  let state = s:state(self.label)
+  " echomsg string(['state', state, 'msg', msgkey, msgvalue, 'mailbox', self['*mailbox*']])
+  if state ==# 'inactive'
+    let result = {'done': 0, 'fail': 1}
+    return result
+
+  elseif state ==# 'reading' && msgkey ==# 'writeln'
+    throw 'Must not happen!!!!!!!!!!!!!1'
+
+  elseif state ==# 'reading' && msgkey ==# 'wait'
+    call s:read(self.label, msgvalue)
+    let result = {'done': 0, 'fail': 0}
+    return result
+
+  elseif state ==# 'reading' && msgkey ==# 'read'
+    let [out, err, _] = s:read(self.label, msgvalue)
+    if a:bulk_or_part == 'bulk'
+      let self['*buffer*'][0] .= out
+      let self['*buffer*'][1] .= err
+      let result = {'done': 0, 'fail': 0}
+    else " 'part'
+      let out = self['*buffer*'][0] . out
+      let err = self['*buffer*'][1] . err
+      let self['*buffer*'] = ['', '']
+      let result = {'done': 0, 'fail': 0, 'part': {'out': out, 'err': err}}
+    endif
+    return result
+
+  elseif state ==# 'undefined'
+    return s:_trigger2(self)
+
+  elseif state ==# 'idle'
+    " idle == current message processing is done. finish it.
+    if msgkey ==# 'writeln'
+      return s:_trigger(self)
+    elseif msgkey ==# 'wait'
+      let result = {'done': 0, 'fail': 0}
+      call remove(self['*mailbox*'], 0)
+      return self.go_bulk()
+    elseif msgkey ==# 'read'
+      let out = self['*buffer*'][0]
+      let err = self['*buffer*'][1]
+      let self['*buffer*'] = ['', '']
+      call remove(self['*mailbox*'], 0)
+      let result = {'done': 1, 'fail': 0, 'out': out, 'err': err}
+      return result
+    endif
+  else
+    throw printf('Vital.ProcessManager: Must not happen: %s', state)
+  endif
+endfunction
+
+function! s:tick() dict
+  if self.is_idle()
+    return
+  endif
+
+  let [msgkey, msgvalue] = self['*mailbox*'][0]
+  let state = s:state(self.label)
+
+  if state ==# 'reading' && msgkey ==# 'wait'
+    call s:read(self.label, msgvalue)
+  elseif state ==# 'undefined'
+    return s:_trigger2(self)
+  endif
 endfunction
 
 let &cpo = s:save_cpo

--- a/autoload/vital/__latest__/ProcessManager.vim
+++ b/autoload/vital/__latest__/ProcessManager.vim
@@ -199,7 +199,9 @@ function! s:_trigger(self)
     return trigger2
   endif
 
-  let [msgkey, msgvalue] = a:self['*mailbox*'][0]
+  " @vimlint(EVL102, 0, l:_)
+  let [_, msgvalue] = a:self['*mailbox*'][0]
+  " @vimlint(EVL102, 1, l:_)
 
   let [out, err, t] = s:read(a:self.label, msgvalue)
   if t ==# 'matched'
@@ -282,7 +284,6 @@ function! s:_go(bulk_or_part, self)
     if msgkey ==# 'writeln'
       return s:_trigger(self)
     elseif msgkey ==# 'wait'
-      let result = {'done': 0, 'fail': 0}
       call remove(self['*mailbox*'], 0)
       return self.go_bulk()
     elseif msgkey ==# 'read'

--- a/doc/vital-process_manager.txt
+++ b/doc/vital-process_manager.txt
@@ -10,8 +10,7 @@ INTRODUCTION			|Vital.ProcessManager-introduction|
   PRINCIPLE			|Vital.ProcessManager-principle|
 INTERFACE			|Vital.ProcessManager-interface|
   FUNCTIONS			  |Vital.ProcessManager-functions|
-CONFIG				|Vital.ProcessManager-config|
-
+VERSION UP MIGRATION		|Vital.ProcessManager-migration-1to2|
 
 
 ==============================================================================
@@ -26,7 +25,51 @@ required.
 
 
 ==============================================================================
-USAGE				*Vital.ProcessManager-usage*
+USAGE					*Vital.ProcessManager-usage*
+A code example that keeps /usr/bin/bash process and uses it without stopping.
+>
+	let s:P = g:V.import('ProcessManager')
+
+	function! s:benri()
+	  if !s:P.is_available() " please always check if it's available.
+	    throw 'omg'
+	  endif
+
+	  " Create/refer the ProcessManager object represents the process.
+	  " Add --norc and -i options to force it behaves interactively.
+	  let p = s:P.of('pm-doc-sample-bash', 'bash --norc -i')
+
+	  " The p may be already created by somebody. That way this p just referes the
+	  " existing one. The below if block will be executed only when this p is
+	  " really new.
+	  if p.is_new()
+	    " The default prompt is probably like 'ujihisa@host ~ $ ' but it's too
+	    " fragile. Let's change the prompt.
+	    call p.reserve_wait(['.*\$ $'])
+		  \.reserve_writeln('export PS1="\nPM-DOC-SAMPLE-BASH$ "')
+		  \.reserve_wait(['PM-DOC-SAMPLE-BASH\$ '])
+	  endif
+
+	  " Ok so what should I do? Let's just check current time.
+	  call p.reserve_writeln('date')
+		\.reserve_read(['PM-DOC-SAMPLE-BASH\$ '])
+
+	  " Let's block Vim to get complete result.
+	  while 1
+	    let result = p.go_bulk()
+	    if result.done
+	      echomsg string([result])
+	      break
+	    endif
+	  endwhile
+	endfunction
+
+	call s:benri()
+<
+
+USAGE-OLD				*Vital.ProcessManager-usage-old*
+
+SOFT DEPRECATED. See |Vital.ProcessManager-migration-1to2|.
 >
 	let P = V.import('ProcessManager')
 	if !P.is_available() " please always check if it's available.
@@ -71,10 +114,6 @@ USAGE				*Vital.ProcessManager-usage*
 	echo s:f('2 + 3') "=> '5' and fast!
 <
 
-MEMO
-* touch is almost idempotent
-* read's out split needs \r as well for windows
-
 ==============================================================================
 PRINCIPLE			*Vital.ProcessManager-principle*
 
@@ -93,11 +132,20 @@ INTERFACE			*Vital.ProcessManager-interface*
 FUNCTIONS			*Vital.ProcessManager-functions*
 
 touch({label}, {cmd})		*Vital.ProcessManager.touch()*
+	SOFT DEPRECATED. See |Vital.ProcessManager-migration-1to2|.
+
 	Returns a string which is either "existing" or "new".
-	TODO
 
 state({label})			*Vital.ProcessManager.state()*
 	Returns either "undefined", "inactive", "reading", or "idle".
+
+==============================================================================
+VERSION UP MIGRATION		*Vital.ProcessManager-migration-1to2*
+
+ProcessManager had changed its API in August 2014. Avoid using all functions
+which are marked as SOFT DEPRECATED. SOFT DEPRECATED functions will be marked
+as DEPRECATED, and then removed in the future.
+
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-process_manager.txt
+++ b/doc/vital-process_manager.txt
@@ -142,9 +142,9 @@ state({label})			*Vital.ProcessManager.state()*
 ==============================================================================
 VERSION UP MIGRATION		*Vital.ProcessManager-migration-1to2*
 
-ProcessManager had changed its API in August 2014. Avoid using all functions
-which are marked as SOFT DEPRECATED. SOFT DEPRECATED functions will be marked
-as DEPRECATED, and then removed in the future.
+ProcessManager had changed its API in Novemeber 2014. Avoid using all
+functions which are marked as SOFT DEPRECATED. SOFT DEPRECATED functions will
+be marked as DEPRECATED, and then removed in the future.
 
 
 ==============================================================================

--- a/doc/vital-process_manager.txt
+++ b/doc/vital-process_manager.txt
@@ -10,6 +10,7 @@ INTRODUCTION			|Vital.ProcessManager-introduction|
   PRINCIPLE			|Vital.ProcessManager-principle|
 INTERFACE			|Vital.ProcessManager-interface|
   FUNCTIONS			  |Vital.ProcessManager-functions|
+  OBJECTS			  |Vital.ProcessManager-objects|
 VERSION UP MIGRATION		|Vital.ProcessManager-migration-1to2|
 
 
@@ -143,25 +144,41 @@ state({label})			*Vital.ProcessManager.state()*
 
 of()				*Vital.ProcessManager.of()*
 	TODO
-is_new()			*Vital.ProcessManager.is_new()*
+
+==============================================================================
+OBJECTS				*Vital.ProcessManager-objects*
+
+------------------------------------------------------------------------------
+ProcessManager Object			*Vital.ProcessManager-PM*
+
+is_new()			*Vital.ProcessManager-PM.is_new()*
 	TODO
-is_idle()			*Vital.ProcessManager.is_idle()*
+
+is_idle()			*Vital.ProcessManager-PM.is_idle()*
 	TODO
-shutdown()			*Vital.ProcessManager.shutdown()*
+
+shutdown()			*Vital.ProcessManager-PM.shutdown()*
 	TODO
-				*Vital.ProcessManager.reserve_wait({endpatterns})*
+
+			*Vital.ProcessManager-PM.reserve_wait({endpatterns})*
 reserve_wait({endpatterns})
 	TODO
-				*Vital.ProcessManager.reserve_writeln({line})*
+
+			*Vital.ProcessManager-PM.reserve_writeln({line})*
 reserve_writeln({line})
 	TODO
-reserve_read({endpatterns})	*Vital.ProcessManager.reserve_read({endpatterns})*
+
+			*Vital.ProcessManager-PM.reserve_read({endpatterns})*
+reserve_read({endpatterns})
 	TODO
-go_bulk()			*Vital.ProcessManager.go_bulk()*
+
+go_bulk()			*Vital.ProcessManager-PM.go_bulk()*
 	TODO
-go_part()			*Vital.ProcessManager.go_part()*
+
+go_part()			*Vital.ProcessManager-PM.go_part()*
 	TODO
-tick()				*Vital.ProcessManager.tick()*
+
+tick()				*Vital.ProcessManager-PM.tick()*
 	TODO
 
 ==============================================================================

--- a/doc/vital-process_manager.txt
+++ b/doc/vital-process_manager.txt
@@ -137,7 +137,32 @@ touch({label}, {cmd})		*Vital.ProcessManager.touch()*
 	Returns a string which is either "existing" or "new".
 
 state({label})			*Vital.ProcessManager.state()*
+	SOFT DEPRECATED. See |Vital.ProcessManager-migration-1to2|.
+
 	Returns either "undefined", "inactive", "reading", or "idle".
+
+of()				*Vital.ProcessManager.of()*
+	TODO
+is_new()			*Vital.ProcessManager.is_new()*
+	TODO
+is_idle()			*Vital.ProcessManager.is_idle()*
+	TODO
+shutdown()			*Vital.ProcessManager.shutdown()*
+	TODO
+				*Vital.ProcessManager.reserve_wait({endpatterns})*
+reserve_wait({endpatterns})
+	TODO
+				*Vital.ProcessManager.reserve_writeln({line})*
+reserve_writeln({line})
+	TODO
+reserve_read({endpatterns})	*Vital.ProcessManager.reserve_read({endpatterns})*
+	TODO
+go_bulk()			*Vital.ProcessManager.go_bulk()*
+	TODO
+go_part()			*Vital.ProcessManager.go_part()*
+	TODO
+tick()				*Vital.ProcessManager.tick()*
+	TODO
 
 ==============================================================================
 VERSION UP MIGRATION		*Vital.ProcessManager-migration-1to2*


### PR DESCRIPTION
introducing is_new(), is_idle(), shutdown(), reserve_wait(endpatterns), reserve_writeln(line), reserve_read(endpatterns), go_bulk(), go_part(), and tick()

This pullreq is to introduce ProcessManager version 2 (PM2) without removing current version of ProcessManager (PM1). PM2 is already used in some experimental projects such as neoclojure. PM1 functions aren't removed or marked as DEPRECATED yet, but I'm planning to mark them as DEPRECATED eventually once PM2 gets stable.

References
* PM1を使ったコードの改善、そしてPM2への移植 <https://gist.github.com/ujihisa/53429203cec28d9396c6>
* PM2 <https://gist.github.com/ujihisa/06953aae66eff9aa8d29>
* VimConf2014 slides "PM2" http://vimconf.vim-jp.org/2014/reports/
