### PR TITLE
Add Data.Set module

### DIFF
--- a/autoload/vital/__latest__/Data/Set.vim
+++ b/autoload/vital/__latest__/Data/Set.vim
@@ -1,0 +1,269 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:TRUE = !0
+let s:FALSE = 0
+
+function! s:set(...) abort
+  return call(s:set._new, a:000, s:set)
+endfunction
+
+function! s:frozenset(...) abort
+  return call(s:frozenset._new, a:000, s:frozenset)
+endfunction
+
+function! s:_hash_func(x) abort
+  return a:x
+endfunction
+
+let s:_base_set = {
+\   '_is_set' : s:TRUE,
+\   '_data' : {},
+\   '_hash_func' : function('s:_hash_func')
+\ }
+
+function! s:_base_set._new(...) abort
+  let obj = deepcopy(self)
+  let xs = get(a:, 1, [])
+  let obj._hash_func = get(a:, 2, obj._hash_func)
+  call obj._set_data(xs)
+  return obj
+endfunction
+
+"" Return the union of two sets as a new set.
+" (I.e. all elements that are in either set.)
+function! s:_base_set.union(t) abort
+  let r = deepcopy(self)
+  call r._update(a:t)
+  return r
+endfunction
+let s:_base_set.or = s:_base_set.union
+
+"" Return the intersection of two sets as a new set.
+" (I.e. all elements that are in both sets.)
+function! s:_base_set.intersection(t) abort
+  let t = self._to_set(a:t)
+  let [little, big] = self.len() <= t.len() ? [self, t] : [t, self]
+  return self._new(filter(copy(big.to_list()), 'little.in(v:val)'))
+endfunction
+let s:_base_set.and = s:_base_set.intersection
+
+"" Return the symmetric difference of two sets as a new set.
+" (I.e. all elements that are in exactly one of the sets.)
+function! s:_base_set.symmetric_difference(t) abort
+  let t = self._to_set(a:t)
+  return self._new(filter(copy(self.to_list()), '!t.in(v:val)')
+  \              + filter(copy(t.to_list()), '!self.in(v:val)'))
+endfunction
+let s:_base_set.xor = s:_base_set.symmetric_difference
+
+"" Return the difference of two sets as a new Set.
+function! s:_base_set.difference(t) abort
+  let t = self._to_set(a:t)
+  return self._new(filter(copy(self.to_list()), '!t.in(v:val)'))
+endfunction
+let s:_base_set.sub = s:_base_set.difference
+
+"" Report whether another set contains this set.
+function! s:_base_set.issubset(t) abort
+  let t = self._to_set(a:t)
+  return self.len() > t.len() ? s:FALSE
+  \   : empty(filter(copy(self.to_list()), '!t.in(v:val)'))
+endfunction
+
+"" Report whether this set contains another set.
+function! s:_base_set.issuperset(t) abort
+  let t = self._to_set(a:t)
+  return self.len() < t.len() ? s:FALSE
+  \   : empty(filter(copy(t.to_list()), '!self.in(v:val)'))
+endfunction
+
+" less than equal & greater than equal
+let s:_base_set.le = s:_base_set.issubset
+let s:_base_set.ge = s:_base_set.issuperset
+
+" less than
+function! s:_base_set.lt(t) abort
+  let t = self._to_set(a:t)
+  return self.len() < t.len() && self.issubset(t)
+endfunction
+
+" greater than
+function! s:_base_set.gt(t) abort
+  let t = self._to_set(a:t)
+  return self.len() > t.len() && self.issuperset(t)
+endfunction
+
+function! s:_base_set.len() abort
+  return len(self._data)
+endfunction
+
+function! s:_base_set.to_list() abort
+  return values(self._data)
+endfunction
+
+function! s:_base_set._update(xs) abort
+  for X in (s:_is_set(a:xs) ? a:xs.to_list() : a:xs)
+    call self._add(X)
+    unlet X
+  endfor
+endfunction
+
+function! s:_base_set._add(x) abort
+  let key = self._hash(a:x)
+  if !has_key(self._data, key)
+    let self._data[key] = a:x
+  endif
+endfunction
+
+" Report whether an element is a member of a set.
+function! s:_base_set.in(x) abort
+  return has_key(self._data, self._hash(a:x))
+endfunction
+
+function! s:_base_set._to_set(x) abort
+  return s:_is_set(a:x) ? a:x : self._new(a:x)
+endfunction
+
+function! s:_base_set._clear() abort
+  let self._data = {}
+endfunction
+
+function! s:_base_set._set_data(xs) abort
+  call self._clear()
+  call self._update(a:xs)
+endfunction
+
+function! s:_base_set._hash(x) abort
+  return string(self._hash_func(a:x))
+endfunction
+
+" frozenset: Immutable set class.
+
+let s:frozenset = deepcopy(s:_base_set)
+
+" Set: Mutable set class.
+
+let s:set = deepcopy(s:_base_set)
+
+" Update a set with the union of itself and another.
+function! s:set.update(iterable) abort
+  call self._update(a:iterable)
+endfunction
+
+" Update a set with the union of itself and another.
+function! s:set.ior(t) abort
+  call self.update(a:t)
+  return self
+endfunction
+
+" Update a set with the intersection of itself and another.
+function! s:set.intersection_update(t) abort
+  let r = self.and(a:t).to_list()
+  call self.clear()
+  call self.update(r)
+endfunction
+
+" Update a set with the intersection of itself and another.
+function! s:set.iand(t) abort
+  call self.intersection_update(a:t)
+  return self
+endfunction
+
+" Update a set with the symmetric difference of itself and another.
+function! s:set.symmetric_difference_update(t) abort
+  let t = self._to_set(a:t)
+  if self is t
+    call self.clear()
+    return
+  endif
+  for X in t.to_list()
+    if self.in(X)
+      call self.remove(X)
+    else
+      call self._add(X)
+    endif
+    unlet X
+  endfor
+endfunction
+
+" Update a set with the symmetric difference of itself and another.
+function! s:set.ixor(t) abort
+  call self.symmetric_difference_update(a:t)
+  return self
+endfunction
+
+" Remove all elements of another set from this set.
+function! s:set.difference_update(t) abort
+  let t = self._to_set(a:t)
+  if self is t
+    call self.clear()
+    return
+  endif
+  for X in filter(t.to_list(), 'self.in(v:val)')
+    call self.remove(X)
+    unlet X
+  endfor
+endfunction
+
+" Remove all elements of another set from this set.
+function! s:set.isub(t) abort
+  call self.difference_update(a:t)
+  return self
+endfunction
+
+" Remove all elements from this set.
+function! s:set.clear() abort
+  call self._clear()
+endfunction
+
+"" Add an element to a set.
+" This has no effect if the element is already present.
+function! s:set.add(x) abort
+  return self._add(a:x)
+endfunction
+
+"" Remove an element from a set; it must be a member.
+" If the element is not a member, throw Exception.
+function! s:set.remove(e) abort
+  try
+    unlet self._data[self._hash(a:e)]
+  catch /^Vim\%((\a\+)\)\?:E716/
+    call s:_throw('the element is not a member')
+  endtry
+endfunction
+
+"" Remove an element from a set if it is a member.
+" If the element is not a member, do nothing.
+function! s:set.discard(e) abort
+  try
+    call self.remove(a:e)
+  catch /vital: Data.Set: the element is not a member/
+    " Do nothing
+  endtry
+endfunction
+
+" Remove and return an arbitrary set element.
+function! s:set.pop() abort
+  try
+    let k = keys(self._data)[0]
+  catch /^Vim\%((\a\+)\)\?:E684/
+    call s:_throw('set is empty')
+  endtry
+  let v = self._data[k]
+  unlet self._data[k]
+  return v
+endfunction
+
+" Helper:
+
+function! s:_is_set(x) abort
+  return type(a:x) is type({}) && get(a:x, '_is_set', s:FALSE)
+endfunction
+
+function! s:_throw(message) abort
+  throw 'vital: Data.Set: ' . a:message
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/doc/vital-data-set.txt
+++ b/doc/vital-data-set.txt
@@ -1,0 +1,178 @@
+*vital-data-set.txt*	set library.
+
+Maintainer: haya14busa <hayabusa1419@gmail.com>
+
+==============================================================================
+CONTENTS					    *Vital.Data.Set-contents*
+
+INTRODUCTION		|Vital.Data.Set-introduction|
+INTERFACE		|Vital.Data.Set-interface|
+  FUNCTIONS		  |Vital.Data.Set-functions|
+  Set Object		  |Vital.Data.Set-Set|
+
+
+
+==============================================================================
+INTRODUCTION					*Vital.Data.Set-introduction*
+
+*Vital.Data.Set* is Collection Utilities Library.
+It provides set and frozenset data structure ported from python.
+  https://docs.python.org/3.4/library/stdtypes.html#set-types-set-frozenset
+
+>
+	let s:V = vital#of("vital")
+	let s:Set = s:V.import("Data.Set")
+
+	let set = s:Set.set([1,1,2,3,4,4,5])
+	echo set.to_list()              | " => [1,2,3,4,5]
+	call set.add(4)
+	echo set.to_list()              | " => [1,2,3,4,5]
+	call set.add(6)
+	echo set.to_list()              | " => [1,2,3,4,5,6]
+	echo set.sub([1,2,3]).to_list() | " => [4,5,6]
+
+	let frozenset = s:Set.frozenset([1,1,2,3,4,4,5])
+	echo frozenset.to_list() | " => [1,2,3,4,5]
+	" frozenset does not have mutable methods
+	call frozenset.add(6)
+	" => E716: Key not present in Dictionary: add
+<
+
+==============================================================================
+INTERFACE					*Vital.Data.Set-interface*
+------------------------------------------------------------------------------
+FUNCTIONS					*Vital.Data.Set-functions*
+
+set([{list}], [{hashfunc}])			*Vital.Data.Set.set()*
+	Returns a new 'Set' object.
+
+frozenset([{list}], [{hashfunc}])		*Vital.Data.Set.frozen()*
+	Returns a new 'Frozen' object which has not mutable methods
+	(|Vital.Data.Set-Set-mutable|).
+
+	{hashfunc} is used to hash the value for identifying each elements.
+
+	Example: >
+	  function! s:my_hash_func(x) abort
+	    return tolower(a:x)
+	  endfunction
+
+	  echo s:Set.set(['a', 'ab', 'A']).to_list()
+	  " => ['A', 'ab', 'a']
+	  echo s:Set.set(['a', 'ab', 'A'], function('s:my_hash_func')).to_list()
+	  " => ['ab', 'a']
+<
+
+------------------------------------------------------------------------------
+Set Object					*Vital.Data.Set-Set*
+
+Set.to_list()				*Vital.Data.Set-Set.to_list()*
+	Converts to |List|.
+
+Set.in({elem})			        *Vital.Data.Set-Set.in()*
+	Checks if there is {elem} in the set.  This returns boolean value.
+
+Set.union({other})			*Vital.Data.Set-Set.union()*
+Set.or({other})				*Vital.Data.Set-Set.or()*
+	Return a new set with elements from the set and {other}.
+
+Set.intersection({other})		*Vital.Data.Set-Set.intersection()*
+Set.and({other})			*Vital.Data.Set-Set.and()*
+	Return a new set with elements common to the set and {other}.
+
+Set.symmetric_difference({other}) *Vital.Data.Set-Set.symmetric_difference()*
+Set.xor({other})			*Vital.Data.Set-Set.xor()*
+	Return a new set with elements in either the set or {other} but not
+	both.
+
+Set.difference({other})			*Vital.Data.Set-Set.difference()*
+Set.sub({other})			*Vital.Data.Set-Set.sub()*
+	Return a new set with elements in the set that are not in {other}.
+
+Set.issubset({other})			*Vital.Data.Set-Set.issubset()*
+Set.le({other})				*Vital.Data.Set-Set.le()*
+	Test whether every element in the set is in {other}.
+
+Set.lt({other})				*Vital.Data.Set-Set.lt()*
+	Test whether the set is a proper subset of {other}, that is, >
+	    set.le(other) && set != other
+
+Set.issuperset({other})			*Vital.Data.Set-Set.issuperset()*
+Set.ge({other})				*Vital.Data.Set-Set.ge()*
+	Test whether every element in {other} is in the set.
+
+Set.gt({other})				*Vital.Data.Set-Set.gt()*
+	Test whether the set is a proper superset of {other}, that is, >
+	    set.ge(other) && set != other
+
+Set.len()				*Vital.Data.Set-Set.len()*
+	Return the length of Set.
+
+------------------------------------------------------------------------------
+Mutable Set Object				 *Vital.Data.Set-Set-mutable*
+
+	The following methods for set do not apply to immutable instances of
+	|Vital.Data.Set.frozen()|
+
+Set.update({other})			*Vital.Data.Set-Set.update()*
+Set.ior({other})			*Vital.Data.Set-Set.ior()*
+	Update the set, adding elements from {other}.
+
+Set.intersection_update({other})  *Vital.Data.Set-Set.intersection_update()*
+Set.iand({other})		  *Vital.Data.Set-Set.iand()*
+	Update the set, keeping only elements found in it and {other}.
+
+Set.difference_update({other})	  *Vital.Data.Set-Set.difference_update()*
+Set.isub({other})		  *Vital.Data.Set-Set.isub()*
+	Update the set, removing elements found in {other}.
+
+Set.symmetric_difference_update({other})
+			    *Vital.Data.Set-Set.symmetric_difference_update()*
+Set.ixor({other})	    *Vital.Data.Set-Set.ixor()*
+	Update the set, keeping only elements found in either set, but not in
+	both.
+
+Set.add({elem})					*Vital.Data.Set-Set.add()*
+	Add {elem} to the set.
+
+Set.remove({elem})				*Vital.Data.Set-Set.remove()*
+	Remove {elem} from the set. Throw >
+	  vital: Data.Set: the element is not a member
+<	if {elem} is not contained in the set.
+
+
+Set.discard({elem})				*Vital.Data.Set-Set.discard()*
+	Remove {elem} from the set if it is present.
+
+Set.pop()					*Vital.Data.Set-Set.pop()*
+	Remove and return an arbitrary element from the set. Throw >
+	  vital: Data.Set: set is empty
+<	if the set is empty.
+
+Set.clear()					*Vital.Data.Set-Set.clear()*
+	Remove all elements from the set.
+
+	Note: {other} will accept 'Set' object or |List| as an argument.
+	ior(), iand(), isub(), ixor() return Set object. 'i' is short for
+	"in-place", they are mutable version of or(), and(), sub(), xor()
+	respectively.
+
+	Note: If return value is 'Set' object, the type of returned 'Set'
+	object is same as type of the instance. Example:
+>
+	  let set = s:Set.set(['a', 'ab', 'A'], function('s:my_hash_func'))
+	  echo set.to_list() | " => ['ab', 'a']
+	  " {comparefunc} will be same as `set`
+	  let set2 = set.or(['aB', 'c'])
+	  echo set2.to_list() | " => ['ab', 'a', 'c']
+
+	  let frozenset = s:Set.frozenset([1,2,3])
+	  " returned 'Set' object is frozenset
+	  let frozenset2 = frozenset.and(s:Set.set([2,3,4]))
+	  echo frozenset2.to_list() | " => [2,3]
+	  call frozenset.add(6)
+	  " => E716: Key not present in Dictionary: add
+<
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/Data/Set.vim
+++ b/test/Data/Set.vim
@@ -1,0 +1,260 @@
+let s:suite = themis#suite('Data.Set')
+let s:assert = themis#helper('assert')
+
+function! s:suite.before()
+  let s:S = vital#of('vital').import('Data.Set')
+  let s:xs = s:S.set([1,2,3,4,5])
+  let s:ys = s:S.set([3,4,5,6,7])
+  call themis#func_alias({'set': s:S.set()})
+  call themis#func_alias({'frozenset': s:S.frozenset()})
+endfunction
+
+function! s:suite.after()
+  unlet! s:S
+  unlet! s:xs
+  unlet! s:ys
+  delfunction MyHashFunc
+endfunction
+
+function! s:equal_set(set, expect, ...) abort
+  call s:assert.equals(sort(a:set.to_list()), sort(a:expect), get(a:, 1, ''))
+endfunction
+
+function! MyHashFunc(x) abort
+  return tolower(a:x)
+endfunction
+
+function! s:suite.set() abort
+  call s:equal_set(s:S.set([1,2,3,3]), [1,2,3])
+  call s:equal_set(s:S.set(
+  \ ['a', 'ab', 'a', 'c', 'ab', function('tr'), function('tr')]),
+  \ ['a', 'ab', 'c', function('tr')])
+endfunction
+
+function! s:suite.frozenset() abort
+  call s:equal_set(s:S.frozenset([1,2,3,3]), [1,2,3])
+  call s:equal_set(s:S.frozenset(['a', 'ab', 'a', 'c', 'ab']), ['a', 'ab', 'c'])
+endfunction
+
+function! s:suite.pass_hash_func_to_set() abort
+  let s = s:S.set(['a', 'ab', 'A', 'c', 'aB'], function('MyHashFunc'))
+  call s:equal_set(s, ['a', 'ab', 'c'])
+  let x = s
+  for i in ['', 'i']
+    for method in ['or', 'and', 'xor', 'sub']
+      let x = x[i . method](s:S.set([]))
+    endfor
+  endfor
+  call s:assert.equals(x._hash_func, function('MyHashFunc'),
+  \ 'return set with same hash func')
+endfunction
+
+function! s:suite.pass_hash_func_to_frozenset() abort
+  let s = s:S.set(['a', 'ab', 'A', 'c', 'aB'], function('MyHashFunc'))
+  call s:equal_set(s, ['a', 'ab', 'c'])
+  let x = s
+  for method in ['or', 'and', 'xor', 'sub']
+    let x = x[method]([])
+  endfor
+  call s:assert.equals(x._hash_func, function('MyHashFunc'),
+  \ 'return set with same hash func')
+endfunction
+
+function! s:suite.frozenset_has_not_mutable_methods() abort
+  let methods = s:S.set(keys(s:S.set())).sub(keys(s:S.frozenset())).to_list()
+  call s:assert.compare(len(methods), '>', 0)
+  call s:assert.has_key(methods, 'update')
+  call s:assert.has_key(methods, 'add')
+  call s:assert.has_key(methods, 'symmetric_difference_update')
+endfunction
+
+function! s:suite.in() abort
+  call s:assert.true(s:xs.in(1))
+  call s:assert.false(s:xs.in(0))
+endfunction
+
+function! s:suite.union() abort
+  call s:equal_set(s:xs.union(s:ys), [1,2,3,4,5,6,7])
+  call s:equal_set(s:xs.union([6,7,8]), [1,2,3,4,5,6,7,8])
+endfunction
+
+function! s:suite.or_is_alias_for_union() abort
+  call s:assert.equals(s:xs.or, s:xs.union)
+endfunction
+
+function! s:suite.intersection() abort
+  call s:equal_set(s:xs.intersection(s:ys), [3,4,5])
+  call s:equal_set(s:xs.intersection([6,7,8]), [])
+endfunction
+
+function! s:suite.and_is_alias_for_intersection() abort
+  call s:assert.equals(s:xs.and, s:xs.intersection)
+endfunction
+
+function! s:suite.symmetric_difference() abort
+  call s:equal_set(s:xs.symmetric_difference(s:ys), [1,2,6,7])
+  call s:equal_set(s:xs.symmetric_difference([6,7,8]), [1,2,3,4,5,6,7,8])
+endfunction
+
+function! s:suite.xor_is_alias_for_symmetric_difference() abort
+  call s:assert.equals(s:xs.xor, s:xs.symmetric_difference)
+endfunction
+
+function! s:suite.difference() abort
+  call s:equal_set(s:xs.difference(s:ys), [1,2])
+  call s:equal_set(s:xs.difference([6,7,8]), [1,2,3,4,5])
+endfunction
+
+function! s:suite.sub_is_alias_for_difference() abort
+  call s:assert.equals(s:xs.sub, s:xs.difference)
+endfunction
+
+function! s:suite.issubset() abort
+  call s:assert.false(s:xs.issubset(s:ys))
+  call s:assert.false(s:xs.issubset([]))
+  call s:assert.true(s:xs.issubset(s:S.set([1,2,3,4,5])))
+  call s:assert.true(s:xs.issubset([1,2,3,4,5,6]))
+endfunction
+
+function! s:suite.issuperset() abort
+  call s:assert.false(s:xs.issuperset(s:ys))
+  call s:assert.true(s:xs.issuperset([]))
+  call s:assert.true(s:xs.issuperset(s:S.set([1,2,3,4,5])))
+  call s:assert.false(s:xs.issuperset([1,2,3,4,5,6]))
+endfunction
+
+function! s:suite.le_is_alias_for_issubset() abort
+  call s:assert.equals(s:xs.le, s:xs.issubset)
+endfunction
+
+function! s:suite.ge_is_alias_for_issuperset() abort
+  call s:assert.equals(s:xs.ge, s:xs.issuperset)
+endfunction
+
+function! s:suite.lt() abort
+  call s:assert.false(s:xs.lt(s:ys))
+  call s:assert.false(s:xs.lt([]))
+  call s:assert.false(s:xs.lt(s:S.set([1,2,3,4,5])))
+  call s:assert.true(s:xs.lt([1,2,3,4,5,6]))
+endfunction
+
+function! s:suite.gt() abort
+  call s:assert.false(s:xs.gt(s:ys))
+  call s:assert.true(s:xs.gt([]))
+  call s:assert.false(s:xs.gt(s:S.set([1,2,3,4,5])))
+  call s:assert.false(s:xs.gt([1,2,3,4,5,6]))
+endfunction
+
+function! s:suite.len() abort
+  call s:assert.equals(s:xs.len(), 5)
+  call s:assert.equals(s:ys.len(), 5)
+endfunction
+
+function! s:suite.to_list() abort
+  call s:assert.equals(s:S.set([1,2,3,3,2]).to_list(), [1,2,3])
+  call s:assert.equals(s:S.frozenset([1,2,3,3,2]).to_list(), [1,2,3])
+endfunction
+
+function! s:suite.ior() abort
+  let xs = deepcopy(s:xs)
+  let ys = deepcopy(s:ys)
+  let r = xs.ior(ys)
+  call s:equal_set(xs, [1,2,3,4,5,6,7])
+  call s:assert.equals(r, xs)
+  call s:assert.is_dict(xs.ior([]), 'returns set object')
+endfunction
+
+function! s:suite.update() abort
+  let [xs, ys] = [deepcopy(s:xs), deepcopy(s:ys)]
+  let r = xs.update(ys)
+  call s:equal_set(xs, [1,2,3,4,5,6,7])
+  call s:assert.equals(r, 0, 'update returns notiong')
+endfunction
+
+function! s:suite.iand() abort
+  let [xs, ys] = [deepcopy(s:xs), deepcopy(s:ys)]
+  let r = xs.iand(ys)
+  call s:equal_set(xs, [3,4,5])
+  call s:assert.equals(r, xs)
+  call s:assert.is_dict(xs.iand([]), 'returns set object')
+endfunction
+
+function! s:suite.intersection_update() abort
+  let [xs, ys] = [deepcopy(s:xs), deepcopy(s:ys)]
+  let r = xs.intersection_update(ys)
+  call s:equal_set(xs, [3,4,5])
+  call s:assert.equals(r, 0, 'intersection_update returns notiong')
+endfunction
+
+function! s:suite.ixor() abort
+  let [xs, ys] = [deepcopy(s:xs), deepcopy(s:ys)]
+  let r = xs.ixor(ys)
+  call s:equal_set(xs, [1,2,6,7])
+  call s:assert.equals(r, xs)
+  call s:assert.is_dict(xs.ixor([]), 'returns set object')
+endfunction
+
+function! s:suite.symmetric_difference_update() abort
+  let [xs, ys] = [deepcopy(s:xs), deepcopy(s:ys)]
+  let r = xs.symmetric_difference_update(ys)
+  call s:equal_set(xs, [1,2,6,7])
+  call s:assert.equals(r, 0, 'symmetric_difference_update returns notiong')
+endfunction
+
+function! s:suite.isub() abort
+  let [xs, ys] = [deepcopy(s:xs), deepcopy(s:ys)]
+  let r = xs.isub(ys)
+  call s:equal_set(xs, [1,2])
+  call s:assert.equals(r, xs)
+  call s:assert.is_dict(xs.isub([]), 'returns set object')
+endfunction
+
+function! s:suite.difference_update() abort
+  let [xs, ys] = [deepcopy(s:xs), deepcopy(s:ys)]
+  let r = xs.difference_update(ys)
+  call s:equal_set(xs, [1,2])
+  call s:assert.equals(r, 0, 'difference_update returns notiong')
+endfunction
+
+function! s:suite.clear() abort
+  let xs = deepcopy(s:xs)
+  let r = xs.clear()
+  call s:equal_set(xs, [])
+  call s:assert.equals(r, 0, 'clear returns notiong')
+endfunction
+
+function! s:suite.add() abort
+  let xs = deepcopy(s:xs)
+  let r = xs.add(1)
+  call s:equal_set(xs, [1,2,3,4,5])
+  let r2 = xs.add(6)
+  call s:equal_set(xs, [1,2,3,4,5,6])
+  call s:assert.equals(r, 0, 'add returns notiong')
+endfunction
+
+function! s:suite.remove() abort
+  let xs = deepcopy(s:xs)
+  let r = xs.remove(1)
+  call s:equal_set(xs, [2,3,4,5])
+  call s:assert.equals(r, 0, 'remove returns notiong')
+  Throws /vital: Data.Set: the element is not a member/ xs.remove(6)
+endfunction
+
+function! s:suite.discard() abort
+  let xs = deepcopy(s:xs)
+  let r = xs.discard(1)
+  let r2 = xs.discard(6)
+  call s:equal_set(xs, [2,3,4,5])
+  call s:assert.equals(r, 0, 'discard returns notiong')
+endfunction
+
+function! s:suite.pop() abort
+  let xs = s:S.set([1,2])
+  let r = xs.pop()
+  call s:equal_set(xs, [2])
+  let r2 = xs.pop()
+  call s:equal_set(xs, [])
+  call s:assert.equals(r, 1)
+  call s:assert.equals(r2, 2)
+  Throws /vital: Data.Set: set is empty/ xs.pop()
+endfunction


### PR DESCRIPTION
python の 2.7 のset ライブラリと 3.4 の仕様(と少しソースコード)を参考に vitalに移植してみました

- ref: https://docs.python.org/3.4/library/stdtypes.html#set-types-set-frozenset

#### TODO
- [ ] https://github.com/vim-jp/vital.vim/pull/239#discussion_r21423877 (複数の引数に対応する場合)(可変長引数かメソッド以外の方法で提供するかそもそも対応しないかで選択肢があり、どうするか思案中。保留もあり?)
- [x] https://github.com/vim-jp/vital.vim/pull/239#discussion-diff-21424330 (一意性をどうやって確保するか)
- [x] rebase (okそうであれば最後にやる)