### PR TITLE
.travis.yml: Set language to generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+language: generic
 env:
   - PPA=yes
   - PPA=no


### PR DESCRIPTION
> travis、common とか sh 的な言語の指定ないの。Ruby のバージョンとか関係ないからいちいち表示して欲しくないのだけど。  @thinca
> https://twitter.com/thinca/status/546565120608829441
