### PR TITLE
Vim.ScriptLocal: Add ScriptLocal (get script-local things)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Text.Sexp  |
 [Vim.Compat](doc/vital-vim-compat.txt)		 | Vim compatibility wrapper functions
 [Vim.Message](doc/vital-vim-message.txt)	 | Vim message functions
 [Vim.Search](doc/vital-vim-search.txt)		 | Vim's [I like function
+[Vim.ScriptLocal](doc/vital-vim-script_local.txt)		 | Get script-local things
 [Web.HTML](doc/vital-web-html.txt)		 | HTML parser written in pure Vim script
 [Web.HTTP](doc/vital-web-http.txt)		 | simple HTTP client library
 [Web.JSON](doc/vital-web-json.txt)		 | JSON parser written in pure Vim script

--- a/autoload/vital/__latest__/Vim/ScriptLocal.vim
+++ b/autoload/vital/__latest__/Vim/ScriptLocal.vim
@@ -1,0 +1,207 @@
+scriptencoding utf-8
+let s:save_cpo = &cpo
+set cpo&vim
+
+""" Helper:
+
+function! s:_throw(message) abort
+  throw printf('vital: Vim.ScriptLocal: %s', a:message)
+endfunction
+
+"" Capture command
+function! s:_capture(command) abort
+  try
+    let save_verbose = &verbose
+    let &verbose = 0
+    redir => out
+    silent execute a:command
+  finally
+    redir END
+    let &verbose = save_verbose
+  endtry
+  return out
+endfunction
+
+"" Capture command and return lines
+function! s:_capture_lines(command) abort
+  return split(s:_capture(a:command), "\n")
+endfunction
+
+"" Return funcname of script local functions with SID
+function! s:_sfuncname(sid, funcname) abort
+  return printf('<SNR>%s_%s', a:sid, a:funcname)
+endfunction
+
+function! s:_source(path) abort
+  try
+    execute ':source' a:path
+  catch /^Vim\%((\a\+)\)\=:E121/
+    " NOTE: workaround for `E121: Undefined variable: s:save_cpo`
+    execute ':source' a:path
+  endtry
+endfunction
+
+let s:_cache = { '_': {} }
+
+function! s:_cache.return(key, value) abort
+  let self._[a:key] = a:value
+  return a:value
+endfunction
+
+function! s:_cache.has(key) abort
+  return has_key(self._, a:key)
+endfunction
+
+function! s:_cache.get(key) abort
+  return self._[a:key]
+endfunction
+
+let s:cache = {
+\ 'sid': deepcopy(s:_cache),
+\ 'sid2path': deepcopy(s:_cache),
+\ 'sid2svars': deepcopy(s:_cache)
+\}
+
+""" Main:
+
+"" Improved scriptnames()
+" @return {sid1: path1, sid2: path2, ...}
+function! s:scriptnames() abort
+  let sdict = {} " { sid: path }
+  for line in s:_capture_lines(':scriptnames')
+    let [sid, path] = split(line, '\m^\s*\d\+\zs:\s\ze')
+    let sdict[str2nr(sid)] = path " str2nr(): '  1' -> 1
+  endfor
+  return sdict
+endfunction
+
+"" Return SID from the given path
+" return -1 if the given path is not found in scriptnames()
+" NOTE: it execute `:source` a given path once if the file haven't sourced yet
+function! s:sid(path) abort
+  if s:cache.sid.has(a:path)
+    return s:cache.sid.get(a:path)
+  endif
+  " Expand to full path
+  let tp = fnamemodify(a:path, ':p') " target path
+  " Relative to &runtimepath
+  if !filereadable(tp)
+    " NOTE: if there are more than one matched paths, use the first one.
+    let tp = get(split(globpath(&runtimepath, a:path, 1), "\n"), 0, '')
+  endif
+  if !filereadable(tp)
+    return s:_throw('file not found')
+  endif
+  let sid = s:_sid(tp, s:scriptnames())
+  if sid isnot -1
+    " return sid
+    return s:cache.sid.return(a:path, sid)
+  else
+    call s:_source(tp)
+    " return s:_sid(tp, s:scriptnames())
+    return s:cache.sid.return(a:path, s:_sid(tp, s:scriptnames()))
+  endif
+endfunction
+
+" Assume `a:abspath` is absolute path
+function! s:_sid(abspath, scriptnames) abort
+  " Handle symbolic link here
+  let tp = resolve(simplify(a:abspath)) " target path
+  for sid in keys(a:scriptnames)
+    " NOTE: is simplify() necessary?
+    if tp is# simplify(fnamemodify(a:scriptnames[sid], ':p'))
+      return str2nr(sid)
+    endif
+  endfor
+  return -1
+endfunction
+
+"" Return path from SID
+function! s:sid2path(sid) abort
+  if s:cache.sid2path.has(a:sid)
+    return s:cache.sid2path.get(a:sid)
+  endif
+  let sn = s:scriptnames()
+  if has_key(sn, a:sid)
+    " return sn[a:sid]
+    return s:cache.sid2path.return(a:sid, sn[a:sid])
+  else
+    return s:_throw('sid not found')
+  endif
+endfunction
+
+"" Return a dict which contains script-local functions from given path
+" `path` should be absolute path or relative to &runtimepath
+" @return {funcname: funcref, funcname2: funcref2, ...}
+" USAGE:
+" :echo s:sfuncs('~/.vim/bundle/plugname/autoload/plugname.vim')
+" " => { 'fname1': funcref1, 'fname2': funcref2, ...}
+" :echo s:sfuncs('autoload/plugname.vim')
+" " => { 'fname1': funcref1, 'fname2': funcref2, ...}
+function! s:sfuncs(path) abort
+  return s:sid2sfuncs(s:sid(a:path))
+endfunction
+
+"" Return a dict which contains script-local functions from SID
+" USAGE:
+" :echo s:sid2sfuncs(1)
+" " => { 'fname1': funcref1, 'fname2': funcref2, ...}
+" " The file whose SID is 1 may be your vimrc
+" NOTE: old regexpengine has a bug which returns 0 with
+" :echo "\<SNR>" =~# "\\%#=1\x80\xfdR"     | " => 0
+" But it matches correctly with :h /collection
+" :echo "\<SNR>" =~# "\\%#=1[\x80][\xfd]R" | " => 1
+" http://lingr.com/room/vim/archives/2015/02/13#message-21261450
+let s:SNR = join(map(range(len("\<SNR>")), '"[" . "\<SNR>"[v:val] . "]"'), '')
+function! s:sid2sfuncs(sid) abort
+  ":h :function /{pattern}
+  " ->         ^________
+  "    function <SNR>14_functionname(args, ...)
+  let fs = s:_capture_lines(':function ' . printf("/^%s%s_", s:SNR, a:sid))
+  let r = {}
+  " ->         ^--------____________-
+  "    function <SNR>14_functionname(args, ...)
+  let pattern = printf('\m^function\s<SNR>%d_\zs\w\{-}\ze(', a:sid)
+  for fname in map(fs, 'matchstr(v:val, pattern)')
+    let r[fname] = function(s:_sfuncname(a:sid, fname))
+  endfor
+  return r
+endfunction
+
+let s:GETSVARSFUNCNAME = '___VITAL_VIM_SCRIPTLOCAL_GET_SVARS___'
+
+let s:_get_svars_func = [
+\   printf('function! s:%s() abort', s:GETSVARSFUNCNAME),
+\          '    return s:',
+\          'endfunction'
+\ ]
+
+"" Return script-local variable (s:var) dict form path
+function! s:svars(path) abort
+  return s:sid2svars(s:sid(a:path))
+endfunction
+
+"" Return script-local variable (s:var) dictionary form SID
+function! s:sid2svars(sid) abort
+  if s:cache.sid2svars.has(a:sid)
+    return s:cache.sid2svars.get(a:sid)
+  endif
+  let fullpath = fnamemodify(s:sid2path(a:sid), ':p')
+  let lines = readfile(fullpath)
+  try
+    call writefile(s:_get_svars_func, fullpath)
+    execute 'source' fnameescape(fullpath)
+    let sfuncname = s:_sfuncname(a:sid, s:GETSVARSFUNCNAME)
+    let svars = call(function(sfuncname), [])
+    execute 'delfunction' sfuncname
+    " return svars
+    return s:cache.sid2svars.return(a:sid, svars)
+  finally
+    call writefile(lines, fullpath)
+  endtry
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim:set et ts=2 sts=2 sw=2 tw=0:

--- a/doc/vital-vim-script_local.txt
+++ b/doc/vital-vim-script_local.txt
@@ -1,0 +1,122 @@
+*vital-vim-script_local.txt*	Get script-local things
+
+Maintainer: haya14busa <hayabusa1419@gmail.com>
+
+==============================================================================
+CONTENTS				*Vital.Vim.ScriptLocal-contents*
+
+INTRODUCTION			|Vital.Vim.ScriptLocal-introduction|
+INTERFACE			|Vital.Vim.ScriptLocal-interface|
+  Functions			  |Vital.Vim.ScriptLocal-functions|
+
+==============================================================================
+INTRODUCTION				*Vital.Vim.ScriptLocal-introduction*
+
+*Vital.Vim.ScriptLocal* provides a way to get script local things.
+>
+	let s:V = vital#of('vital')
+	let s:S = s:V.import('Vim.ScriptLocal')
+>
+	"" Get <SID> with relative path to &runtimepath
+	" e.g. starts with autoload/, plugin/, etc...
+	" (autoload/**/*.vim, plugin/**/*.vim)
+
+	echo s:S.sid('test/_testdata/Vim/ScriptLocal/test.vim')
+	" => <SID>
+
+	"" Get the dict which contains script local functions with absolute
+	" path
+	let bundle = '~/.vim/bundle/'
+	let p = 'vital.vim/test/_testdata/Vim/ScriptLocal/test.vim'
+	let absolute_path = bundle . p
+	let sf = s:S.sfuncs(absolute_path)
+	echo sf
+	" =>
+	"  {
+	"   'double': function('<SNR>439_double'),
+	"   '_square': function('<SNR>439__square')
+	"  }
+	echo sf.double(3)  | " => 6
+	echo sf._square(3) | " => 9
+
+==============================================================================
+INTERFACE				*Vital.Vim.ScriptLocal-interface*
+------------------------------------------------------------------------------
+FUNCTIONS				*Vital.Vim.ScriptLocal-functions*
+
+sid({path})				*Vital.Vim.ScriptLocal.sid()*
+	Returns <SID> with given path. {path} could be relative to
+	'runtimepath' or absolute path.
+
+					*Vital.Vim.ScriptLocal-path*
+	{path} example
+	1. /home/haya14busa/.vim/bundle/incsearch.vim/autoload/incsearch.vim
+	2. ~/.vim/bundle/incsearch.vim/autoload/incsearch.vim
+	3. autoload/incsearch.vim
+	4. plugin/incsearch.vim
+
+	You can pass paths which start with autoload/, plugin/, etc... as a
+	relative path (relative to 'runtimepath').
+	NOTE: _relative_ doesn't mean relative to current file, but relative
+	to 'runtimepath'.
+>
+	"" Get <SID> with relative path to &runtimepath
+	" e.g. starts with autoload/, plugin/, etc...
+	" (autoload/**/.vim, plugin/**/.vim)
+	echo s:S.sid('test/_testdata/Vim/ScriptLocal/test.vim')
+	" => <SID>
+
+sid2path(<SID>)				*Vital.Vim.ScriptLocal.sid2path()*
+	Returns the sourced script path which has the given <SID>. >
+	echo s:S.sid2path(1) | " => '~/.vimrc'
+
+sfuncs({path})				*Vital.Vim.ScriptLocal.sfuncs()*
+	Returns a dict which contains |script-local| functions with {path}
+	(See |Vital.Vim.ScriptLocal-path|).
+>
+	"" Get the dict which contains script local functions
+	let sf = s:S.sfuncs('test/_testdata/Vim/ScriptLocal/test.vim')
+	echo sf
+	" =>
+	"  {
+	"   'double': function('<SNR>439_double'),
+	"   '_square': function('<SNR>439__square')
+	"  }
+	echo sf.double(3)  | " => 6
+	echo sf._square(3) | " => 9
+
+sid2sfuncs(<SID>)			*Vital.Vim.ScriptLocal.sid2sfuncs()*
+	Returns a dict which contains |script-local| functions with <SID>.
+>
+	echo s:S.sid2sfuncs(1)
+	" => { 'fname1': funcref1, 'fname2': funcref2, ...}
+	" The file whose SID is 1 may be your vimrc
+
+svars({path})				*Vital.Vim.ScriptLocal.svars()*
+	Returns a dict which contains |script-variable| with {path}.
+	(See |Vital.Vim.ScriptLocal-path|). >
+
+	let s = s:S.svars('test/_testdata/Vim/ScriptLocal/test.vim')
+	echo s | " => { 'i': 1 }
+<
+	CAUTION: svars() will temporarily overwrite the target file and
+	restore the file, so please be careful if you want to use it.
+
+sid2svars(<SID>)			*Vital.Vim.ScriptLocal.sid2svars()*
+	Returns a dict which contains |script-variable| with <SID>. >
+
+	let s = s:S.sid2svars(1)
+	echo s | " => { ... } (Maybe this is s:var in your vimrc)
+<
+	CAUTION: sid2svars() will temporarily overwrite the target file and
+	restore the file, so please be careful if you want to use it.
+
+scriptnames()				*Vital.Vim.ScriptLocal.scriptnames()*
+	Returns a dict of |:scriptnames|. The keys are <SID> and the values
+	are paths. >
+	" { <SID>: path/to/the/file }
+	  {'1': path1, '2': path2, '3': path3, ... }
+
+
+==============================================================================
+vim:tw=78:ts=8:ft=help:norl:noet:fen:fdl=0:fdm=marker:

--- a/doc/vital.txt
+++ b/doc/vital.txt
@@ -179,6 +179,7 @@ LINKS					*Vital-links*
   |vital-vim-compat.txt|	  Vim compatibility wrapper functions
   |vital-vim-message.txt|	  Vim message functions
   |vital-vim-search.txt|	  Vim's [I like function
+  |vital-vim-script_local.txt|	  Get script-local things
   |vital-web-html.txt|		  HTML parser written in pure Vim script
   |vital-web-http.txt|		  simple HTTP client library
   |vital-web-json.txt|		  JSON parser written in pure Vim script

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -1,4 +1,7 @@
 call themis#option('recursive', 1)
+call themis#option('exclude', 'test/_testdata/')
 
 let g:Expect = themis#helper('expect')
 call themis#helper('command').with(themis#helper('assert')).with({'Expect': g:Expect})
+
+let g:root = fnamemodify(expand('<sfile>'), ':h:h')

--- a/test/Vim/ScriptLocal.vimspec
+++ b/test/Vim/ScriptLocal.vimspec
@@ -1,0 +1,169 @@
+Describe Vim.ScriptLocal
+
+  Before all
+    let V = vital#of('vital')
+    let P = V.import('Prelude')
+    let S = V.import('Vim.ScriptLocal')
+  End
+
+  Describe .sid()
+    It returns SID with relative path to &runtimepath
+      let sid = S.sid('test/_testdata/Vim/ScriptLocal/test.vim')
+      Assert IsNumber(sid)
+      Assert NotEquals(sid, -1)
+      Assert Exists(printf("*\<SNR>%s_double", sid))
+    End
+    It returns SID with absolute path
+      let sid = S.sid(g:root . '/test/_testdata/Vim/ScriptLocal/test.vim')
+      Assert IsNumber(sid)
+      Assert NotEquals(sid, -1)
+      Assert Exists(printf("*\<SNR>%s_double", sid))
+    End
+    It returns SID with unsourced file (absolute path)
+      let g:vital_test_Vim_ScriptLocal_absolute_is_loaded = 0
+      Assert False(g:vital_test_Vim_ScriptLocal_absolute_is_loaded)
+      let sid = S.sid(g:root . '/test/_testdata/Vim/ScriptLocal/absolute.vim')
+      Assert IsNumber(sid)
+      Assert NotEquals(sid, -1)
+      Assert True(g:vital_test_Vim_ScriptLocal_absolute_is_loaded)
+      Assert Equals(sid, g:vital_test_Vim_ScriptLocal_absolute_SID)
+    End
+    It returns SID with unsourced file (relative path)
+      let g:vital_test_Vim_ScriptLocal_relative_is_loaded = 0
+      Assert False(g:vital_test_Vim_ScriptLocal_relative_is_loaded)
+      let sid = S.sid('test/_testdata/Vim/ScriptLocal/relative.vim')
+      Assert IsNumber(sid)
+      Assert NotEquals(sid, -1)
+      Assert True(g:vital_test_Vim_ScriptLocal_relative_is_loaded)
+      Assert Equals(sid, g:vital_test_Vim_ScriptLocal_relative_SID)
+    End
+    It returns SID with symbolic link (relative)
+      if P.is_windows()
+        Skip "windows doesn't handle symlink"
+      endif
+      let sid = S.sid('test/_testdata/Vim/ScriptLocal/symlink.vim')
+      Assert IsNumber(sid)
+      Assert NotEquals(sid, -1)
+      Assert Exists(printf("*\<SNR>%s_double", sid))
+    End
+    It returns SID with symbolic link (absolute)
+      if P.is_windows()
+        Skip "windows doesn't handle symlink"
+      endif
+      let sid = S.sid(g:root . '/test/_testdata/Vim/ScriptLocal/symlink.vim')
+      Assert IsNumber(sid)
+      Assert NotEquals(sid, -1)
+      Assert Exists(printf("*\<SNR>%s_double", sid))
+    End
+    It handles the case &regexpengine == 1
+      if !exists('+regexpengine')
+        Skip 'regexpengine option doesn''t exist'
+      endif
+      let regexpengine_save = &regexpengine
+      let &regexpengine = 1
+      try
+        let sid = S.sid('test/_testdata/Vim/ScriptLocal/test.vim')
+        Assert IsNumber(sid)
+        Assert NotEquals(sid, -1)
+        Assert Exists(printf("*\<SNR>%s_double", sid))
+      finally
+        let &regexpengine = regexpengine_save
+      endtry
+    End
+    It throws with wrong absolute path
+      Throws /vital: Vim.ScriptLocal: file not found/ S.sid(g:root . '/test/_testdata/Vim/ScriptLocal/notfound.vim')
+    End
+    It throws with wrong relative path
+      Throws /vital: Vim.ScriptLocal: file not found/ S.sid('test/_testdata/Vim/ScriptLocal/notfound.vim')
+    End
+  End
+
+  Describe .sid2path()
+    It returns path from sid
+      let path = g:root . '/test/_testdata/Vim/ScriptLocal/test.vim'
+      let sid = S.sid(path)
+      Assert Equals(fnamemodify(S.sid2path(sid), ':p'), path)
+    End
+    It throws with wrong sid
+      Throws /vital: Vim.ScriptLocal: sid not found/ S.sid2path(-100)
+    End
+  End
+
+  Describe .sfuncs()
+    It returns sfuncs with relative path to &runtimepath
+      let sfuncs = S.sfuncs('test/_testdata/Vim/ScriptLocal/test.vim')
+      Assert IsDict(sfuncs)
+      Assert HasKey(sfuncs, 'double')
+      Assert Equals(sfuncs.double(3), 6)
+      Assert HasKey(sfuncs, '_square', 'it handles underscore too')
+      Assert Equals(sfuncs._square(3), 9)
+    End
+    It returns sfuncs with absolute path
+      let sfuncs = S.sfuncs(g:root . '/test/_testdata/Vim/ScriptLocal/test.vim')
+      Assert IsDict(sfuncs)
+      Assert HasKey(sfuncs, 'double')
+      Assert Equals(sfuncs.double(3), 6)
+      Assert HasKey(sfuncs, '_square', 'it handles underscore too')
+      Assert Equals(sfuncs._square(3), 9)
+    End
+  End
+
+  Describe .sid2sfuncs()
+    It returns sfuncs with relative path to &runtimepath
+      let sfuncs = S.sid2sfuncs(S.sid('test/_testdata/Vim/ScriptLocal/test.vim'))
+      Assert IsDict(sfuncs)
+      Assert HasKey(sfuncs, 'double')
+      Assert Equals(sfuncs.double(3), 6)
+      Assert HasKey(sfuncs, '_square', 'it handles underscore too')
+      Assert Equals(sfuncs._square(3), 9)
+    End
+  End
+
+  Describe .svars()
+    It clean up the temporal function
+      let p = 'test/_testdata/Vim/ScriptLocal/test.vim'
+      let sfuncs_before = S.sfuncs(p)
+      call S.svars(p)
+      let sfuncs_after = S.sfuncs(p)
+      Assert Equals(sfuncs_after, sfuncs_before)
+    End
+    It restore the original file
+      let p = 'test/_testdata/Vim/ScriptLocal/test.vim'
+      let before = readfile(p)
+      call S.svars(p)
+      let after = readfile(p)
+      Assert Equals(after, before)
+    End
+    It returns s:var with relative path to &runtimepath
+      let svars = S.svars('test/_testdata/Vim/ScriptLocal/test.vim')
+      Assert IsDict(svars)
+      Assert HasKey(svars, 'i')
+      Assert Equals(svars.i, 1)
+      " And you can increment it
+      Assert Equals(Vital_test_Vim_ScriptLocal_test_i(), 1)
+      let svars.i += 1
+      Assert Equals(Vital_test_Vim_ScriptLocal_test_i(), 2)
+    End
+  End
+
+  Describe .sid2svars()
+    It returns s:var with sid
+      let svars = S.sid2svars(S.sid('test/_testdata/Vim/ScriptLocal/test.vim'))
+      Assert IsDict(svars)
+      Assert HasKey(svars, 'i')
+    End
+  End
+
+  Describe .scriptnames()
+    It returns scriptnames dict
+      let sns = S.scriptnames()
+      Assert IsDict(sns)
+      Assert HasKey(sns, '1')
+      for k in keys(sns)
+        Assert True(k > 0)
+        Assert IsDict(S.sid2sfuncs(k))
+      endfor
+    End
+  End
+
+End

--- a/test/_testdata/Vim/ScriptLocal/absolute.vim
+++ b/test/_testdata/Vim/ScriptLocal/absolute.vim
@@ -1,0 +1,7 @@
+let g:vital_test_Vim_ScriptLocal_absolute_is_loaded = 1
+
+function s:SID() abort
+  return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze_SID$')
+endfun
+
+let g:vital_test_Vim_ScriptLocal_absolute_SID = s:SID()

--- a/test/_testdata/Vim/ScriptLocal/relative.vim
+++ b/test/_testdata/Vim/ScriptLocal/relative.vim
@@ -1,0 +1,7 @@
+let g:vital_test_Vim_ScriptLocal_relative_is_loaded = 1
+
+function s:SID() abort
+  return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze_SID$')
+endfun
+
+let g:vital_test_Vim_ScriptLocal_relative_SID = s:SID()

--- a/test/_testdata/Vim/ScriptLocal/symlink.vim
+++ b/test/_testdata/Vim/ScriptLocal/symlink.vim
@@ -1,0 +1,1 @@
+test.vim

--- a/test/_testdata/Vim/ScriptLocal/test.vim
+++ b/test/_testdata/Vim/ScriptLocal/test.vim
@@ -1,0 +1,13 @@
+function! s:double(x) abort
+    return a:x * 2
+endfunction
+
+function! s:_square(x) abort
+    return a:x * a:x
+endfunction
+
+let s:i = 1
+
+function! Vital_test_Vim_ScriptLocal_test_i() abort
+  return s:i
+endfunction


### PR DESCRIPTION
### 概要

path から `<SID>` を取得したり, script-local な関数を取得したオブジェクト(`sfuncs`) を取得できるモジュールです.
外部モジュールとして実装していた vital-snoop (https://github.com/haya14busa/vital-snoop.vim) が vital 本家にもあると便利という想いによりテストやドキュメントを vital に合わせて移植しました.

実装した関数は4つで

1. `sid({path})`: {path}から`<SID>`を返す　
2. `sfuncs({path})`: {path}からそのpathのscript-local関数を持つオブジェクトを返す
3. `sid2sfucs(<SID>)`: `<SID>`からscript-local関数を持つオブジェクトを返す
4. `scriptnames()`: `<SID>`をキー, pathを値とした辞書を返す. (あとで知りましたが `:h scriptnames-dictionary`と同内容です)

{path}については絶対パスと, `&runtimepath`から見ての相対パスを渡すことができます.

要するに以下のようなことができます.

```vim
let s:V = vital#of('vital')
let s:S = s:V.import('Vim.ScriptLocal')

"" Get <SID> with relative path to &runtimepath
" e.g. starts with autoload/, plugin/, etc...
" (autoload/**/*.vim, plugin/**/*.vim)
:echo s:S.sid('autoload/vital/test/Vim/ScriptLocal/test.vim')
" => <SID>
"" Get the dict which contains script local functions with absolute
" path
:let bundle = '~/.vim/bundle/'
:let p = 'vital.vim/autoload/vital/test/Vim/ScriptLocal/test.vim'
:let absolute_path = bundle . p
:let sf = s:S.sfuncs(absolute_path)
:echo sf
" =>
"  {
"   'double': function('<SNR>439_double'),
"   '_power': function('<SNR>439__power')
"  }
:echo sf.double(3) | " => 6
:echo sf._power(3) | " => 9
```

##### vital.vim/autoload/vital/test/Vim/ScriptLocal/test.vim

```vim
function! s:double(x) abort
    return a:x * 2
endfunction

function! s:_power(x) abort
    return a:x * a:x
endfunction
```

### 名前について
外部モジュールは`Snoop`という名前にしていましたが, 本PRでは`ScriptLocal`にしました.
少し長い気もするのでより良さげな名前があれば教えて欲しいです!


### その他
a) テストでautoloadファイル以下や.themisrcを汚してる
autoloadファイルの読み込みなどをテストするため, テスト用のファイルが`autoload/`以下に置かれてます.
まずい気もしますがどうでしょう... `test/` 以下におくとテストとして実行されてしまうので別のディレクトリに置いとくとかはありかなと思いました.

b) Windows におけるシンボリックリンクのテスト

ちょっとやり方がわからないのでスキップしてます. いい感じのやり方思いつく方教えてください...
シンボリックリンク以外のテストが通ることは確認しました. https://ci.appveyor.com/project/haya14busa/vital-snoop-vim

c) script-local変数も取得したい?
https://gist.github.com/haya14busa/cb78147229dfde98a5e6
script-local 変数をpathから無理やり取得する闇の関数も実装してみたのですが, 安全じゃないことを
明示した上で, vitalに含めるという選択肢もありますかね?

テストとかで使いたいという需要が多数あればワンチャン:dog:あるかも? (基本的にはなしかなと思いますが)
