### PR TITLE
Fix file path case problem

### DIFF
--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -1,4 +1,5 @@
 let s:self_version = expand('<sfile>:t:r')
+let s:self_file = expand('<sfile>')
 
 " Note: The extra argument to globpath() was added in Patch 7.2.051.
 let s:globpath_third_arg = v:version > 702 || v:version == 702 && has('patch51')
@@ -300,5 +301,3 @@ endfunction
 function! vital#{s:self_version}#new() abort
   return s:_import('')
 endfunction
-
-let s:self_file = s:_unify_path(expand('<sfile>'))


### PR DESCRIPTION
### Problem:
  If you use Ubuntu VM(case sensitive file system) on Mac OS(case
  in-sensitive file system) and the &runtimepath is in a shared folder,
  the case handling for paths could different with different paths.
  It could cause exception, `vital: module not found:`.

ref: https://github.com/Lokaltog/vim-easymotion/issues/171

### Solution:
  Do not use tolower() (do not call s:_unify_path()) to get scripts'
  self file path.

http://lingr.com/room/vim/archives/2015/02/22#message-21320401