### PR TITLE
Vim.ScriptLocal: handle special characters in paths

### DIFF
--- a/autoload/vital/__latest__/Vim/ScriptLocal.vim
+++ b/autoload/vital/__latest__/Vim/ScriptLocal.vim
@@ -34,10 +34,10 @@ endfunction
 
 function! s:_source(path) abort
   try
-    execute ':source' a:path
+    execute ':source' fnameescape(a:path)
   catch /^Vim\%((\a\+)\)\=:E121/
     " NOTE: workaround for `E121: Undefined variable: s:save_cpo`
-    execute ':source' a:path
+    execute ':source' fnameescape(a:path)
   endtry
 endfunction
 
@@ -190,7 +190,7 @@ function! s:sid2svars(sid) abort
   let lines = readfile(fullpath)
   try
     call writefile(s:_get_svars_func, fullpath)
-    execute 'source' fnameescape(fullpath)
+    call s:_source(fullpath)
     let sfuncname = s:_sfuncname(a:sid, s:GETSVARSFUNCNAME)
     let svars = call(function(sfuncname), [])
     execute 'delfunction' sfuncname

--- a/test/Vim/ScriptLocal.vimspec
+++ b/test/Vim/ScriptLocal.vimspec
@@ -55,6 +55,12 @@ Describe Vim.ScriptLocal
       Assert NotEquals(sid, -1)
       Assert Exists(printf("*\<SNR>%s_double", sid))
     End
+    It handles paths containing special characters
+      let sid = S.sid(g:root . '/test/_testdata/Vim/ScriptLocal/escape%.vim')
+      Assert IsNumber(sid)
+      Assert NotEquals(sid, -1)
+      Assert Equals(sid, g:vital_test_Vim_ScriptLocal_escape_SID)
+    End
     It handles the case &regexpengine == 1
       if !exists('+regexpengine')
         Skip 'regexpengine option doesn''t exist'

--- a/test/_testdata/Vim/ScriptLocal/escape%.vim
+++ b/test/_testdata/Vim/ScriptLocal/escape%.vim
@@ -1,0 +1,6 @@
+function s:SID() abort
+  return matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze_SID$')
+endfun
+
+let g:vital_test_Vim_ScriptLocal_escape_SID = s:SID()
+


### PR DESCRIPTION
#258 で `fnameescape()` をしっかりしきれてないことにﾏｯｼﾞされてから気づきました....ｽｲﾏｾﾝ :sweat_drops: 