### PR TITLE
Web.HTTP: add gzip decode to python curl requests

### DIFF
--- a/doc/vital-web-http.txt
+++ b/doc/vital-web-http.txt
@@ -97,6 +97,10 @@ request({method}, {url} [, {settings}])
 		  "wget": "/usr/local/bin/wget",
 		}
 
+        "gzipDecompress" Default: 0
+                Attempt to decompress response data as if it was gzipped
+                  
+
 parseHeader({headers})			*Vital.Web.HTTP.parseHeader()*
 	Parse {headers} list to a dictionary.
 	Duplicated fields are overwritten.


### PR DESCRIPTION
This will decode websites served with gzip. 

I came accross a website that didn't respond to accept-encoding, and all the content comes back compressed.

wget has no built in decompression, so the only option would be to pipe it into gunzip or similar. probably a bit of an edge case anyway.

here is a url for testing: http://www.nic-west.com/messages/test.txt