### PR TITLE
OptionParser: Add two extra options

### DIFF
--- a/autoload/vital/__latest__/OptionParser.vim
+++ b/autoload/vital/__latest__/OptionParser.vim
@@ -36,7 +36,7 @@ function! s:_make_option_description_for_help(opt) abort
     let extra .= 'PATTERN: ' . string(a:opt.pattern_option) . ', '
   endif
   let extra = substitute(extra, ', $', '', '')
-  if !empty(extra)
+  if extra !=# ''
     let extra = ' (' . extra . ')'
   endif
   return a:opt.description . extra

--- a/autoload/vital/__latest__/OptionParser.vim
+++ b/autoload/vital/__latest__/OptionParser.vim
@@ -105,7 +105,7 @@ function! s:_check_extra_option(parsed_args, options) abort
       throw 'vital: OptionParser: parameter is required: ' . name
     endif
     if has_key(option, 'pattern_option') && has_key(a:parsed_args, name) && a:parsed_args[name] !~# option.pattern_option
-      throw 'vital: OptionParser: parameter doesn''t match pattern: ' . name . ' ' . options.pattern_option
+      throw 'vital: OptionParser: parameter doesn''t match pattern: ' . name . ' ' . option.pattern_option
     endif
   endfor
 endfunction

--- a/autoload/vital/__latest__/OptionParser.vim
+++ b/autoload/vital/__latest__/OptionParser.vim
@@ -115,7 +115,7 @@ endfunction
 
 function! s:_check_pattern_option(parsed_args, options) abort
   for [name, pattern_option] in map(items(filter(copy(a:options), 'has_key(v:val, "pattern_option")')), '[v:val[0], v:val[1].pattern_option]')
-    if has_key(a:parsed_args, name) && a:parsed_args[name] !~ pattern_option
+    if has_key(a:parsed_args, name) && a:parsed_args[name] !~# pattern_option
       throw 'vital: OptionParser: parameter doesn''t match pattern: ' . name . ' ' . pattern_option
     endif
   endfor

--- a/doc/vital-option_parser.txt
+++ b/doc/vital-option_parser.txt
@@ -155,7 +155,7 @@ Parser.on({name}, {description} [, {extra}])
 
 	- {extra} (optional)
 	  If {extra} is |Dictionary| value, it can contain below keys; "short",
-	  "default" or "completion" or "required" or "pattern".
+	  "default", "completion", "required" or "pattern".
 	  Otherwise, {extra} is dealt with a default value of the option.
 
 	  - "short"

--- a/doc/vital-option_parser.txt
+++ b/doc/vital-option_parser.txt
@@ -155,7 +155,7 @@ Parser.on({name}, {description} [, {extra}])
 
 	- {extra} (optional)
 	  If {extra} is |Dictionary| value, it can contain below keys; "short",
-	  "default" or "completion".
+	  "default" or "completion" or "required".
 	  Otherwise, {extra} is dealt with a default value of the option.
 
 	  - "short"
@@ -180,6 +180,12 @@ Parser.on({name}, {description} [, {extra}])
 	  called when a user inputs "--hoge=".  When the user inputs "--hoge=h",
 	  "h" will be passed to {optlead}.  {optlead} is NOT ArgLead of
 	  |:command-completion-custom|.
+
+	  - "required"
+	    Value of "required" key must be 1 or 0. If 1, it means this option
+	    must be specified. If it isn't specified, Vital throw exception.
+	    And if 0, it means this option is optional.
+	    If "default" key is specified, "required" value ignored.
 
 					*Vital.OptionParser-Parser.parse()*
 Parser.parse({q-args} [, {cmd-attributes}...])

--- a/doc/vital-option_parser.txt
+++ b/doc/vital-option_parser.txt
@@ -155,7 +155,7 @@ Parser.on({name}, {description} [, {extra}])
 
 	- {extra} (optional)
 	  If {extra} is |Dictionary| value, it can contain below keys; "short",
-	  "default" or "completion" or "required".
+	  "default" or "completion" or "required" or "pattern".
 	  Otherwise, {extra} is dealt with a default value of the option.
 
 	  - "short"
@@ -186,6 +186,11 @@ Parser.on({name}, {description} [, {extra}])
 	    must be specified. If it isn't specified, Vital throw exception.
 	    And if 0, it means this option is optional.
 	    If "default" key is specified, "required" value ignored.
+
+	  - "pattern"
+	    If {extra} has "pattern" key, its value should be |String| and means
+	    this option must match "pattern" value.
+	    If it doesn't match "pattern" value, Vital throw exception.
 
 					*Vital.OptionParser-Parser.parse()*
 Parser.parse({q-args} [, {cmd-attributes}...])

--- a/test/OptionParser.vimspec
+++ b/test/OptionParser.vimspec
@@ -139,6 +139,16 @@ Describe OptionParser
       Assert IsFunc(o.options.huga.completion)
     End
 
+    It occurs an error when invalid required option is specified
+      let o = O.new()
+      Throws o.on('--hoge=VALUE', '', {'required' : '-1'})
+      Throws o.on('--hoge=VALUE', '', {'required' : '2'})
+      Throws o.on('--hoge=VALUE', '', {'required' : 'a'})
+      Throws o.on('--hoge=VALUE', '', {'required' : ''})
+      Throws o.on('--hoge=VALUE', '', {'required' : 1.0})
+      Throws o.on('--hoge=VALUE', '', {'required' : 0.0})
+    End
+
   End
 
   Describe obj.parse()
@@ -218,6 +228,24 @@ Describe OptionParser
       call o.on('--huga', '', 'default value')
       Assert Equals(o.parse(''), {'__unknown_args__' : [], 'hoge' : 3.14, 'huga' : 'default value'})
       Assert Equals(o.parse('--hoge --huga --piyo'), {'__unknown_args__' : ['--piyo'], 'hoge' : 1, 'huga' : 1})
+    End
+
+    It parses required option --hoge must be specified
+      let o = O.new()
+      call o.on('--hoge', '', {'required' : 1})
+      call o.on('--huga', '')
+      Assert Equals(o.parse('--hoge --huga'), {'__unknown_args__' : [], 'hoge' : 1, 'huga' : 1})
+      Assert Equals(o.parse('--hoge'), {'__unknown_args__' : [], 'hoge' : 1})
+      Throws o.parse('--huga')
+    End
+
+    It parses required option --hoge need not be specified
+      let o = O.new()
+      call o.on('--hoge', '', {'required' : 0})
+      call o.on('--huga', '')
+      Assert Equals(o.parse('--hoge --huga'), {'__unknown_args__' : [], 'hoge' : 1, 'huga' : 1})
+      Assert Equals(o.parse('--hoge'), {'__unknown_args__' : [], 'hoge' : 1})
+      Assert Equals(o.parse('--huga'), {'__unknown_args__' : [], 'huga' : 1})
     End
 
     It doesn't parse arguments not defined with on()
@@ -312,6 +340,8 @@ Describe OptionParser
       call o.on('--[no-]bar', 'description of bar, contradictable')
       call o.on('--baz', 'description of baz, has short option', {'short' : '-b'})
       call o.on('--qux', 'description of qux, has default value', {'default' : 3.14})
+      call o.on('--quux', 'description of quux, has required option', {'required' : 1})
+      call o.on('--grault', 'description of grault, has extra options', {'default' : 3.14, 'required' : 1})
 
       Assert Equals(o.help(), join([
             \   "Options:",
@@ -320,6 +350,8 @@ Describe OptionParser
             \   "  --hoge=VALUE : description of hoge, must have value",
             \   "  --[no-]bar   : description of bar, contradictable",
             \   "  --qux        : description of qux, has default value (DEFAULT: 3.14)",
+            \   "  --quux       : description of quux, has required option (REQUIRED)",
+            \   "  --grault     : description of grault, has extra options (DEFAULT: 3.14, REQUIRED)",
             \ ], "\n"))
     End
 

--- a/test/OptionParser.vimspec
+++ b/test/OptionParser.vimspec
@@ -356,19 +356,19 @@ Describe OptionParser
       call o.on('--baz', 'description of baz, has short option', {'short' : '-b'})
       call o.on('--qux', 'description of qux, has default value', {'default' : 3.14})
       call o.on('--quux', 'description of quux, has required option', {'required' : 1})
-      call o.on('--corge', 'description of corge, has pattern option', {'pattern' : '^\d$'})
-      call o.on('--grault', 'description of grault, has extra options', {'default' : 3.14, 'required' : 1, 'pattern' : '^\d$'})
+      call o.on('--corge', 'description of corge, has pattern option', {'pattern' : '^\d\+\%(\.\d\+\)\?$'})
+      call o.on('--grault', 'description of grault, has extra options', {'default' : 3.14, 'required' : 1, 'pattern' : '^\d\+\%(\.\d\+\)\?$'})
 
       Assert Equals(o.help(), join([
             \   "Options:",
             \   "  --foo        : description of foo",
             \   "  --baz, -b    : description of baz, has short option",
-            \   "  --corge      : description of corge, has pattern option (PATTERN: '^\\d$')",
+            \   "  --corge      : description of corge, has pattern option (PATTERN: '^\\d\\+\\%(\\.\\d\\+\\)\\?$')",
             \   "  --hoge=VALUE : description of hoge, must have value",
             \   "  --[no-]bar   : description of bar, contradictable",
             \   "  --qux        : description of qux, has default value (DEFAULT: 3.14)",
             \   "  --quux       : description of quux, has required option (REQUIRED)",
-            \   "  --grault     : description of grault, has extra options (DEFAULT: 3.14, REQUIRED, PATTERN: '^\\d$')",
+            \   "  --grault     : description of grault, has extra options (DEFAULT: 3.14, REQUIRED, PATTERN: '^\\d\\+\\%(\\.\\d\\+\\)\\?$')",
             \ ], "\n"))
     End
 

--- a/test/OptionParser.vimspec
+++ b/test/OptionParser.vimspec
@@ -253,14 +253,19 @@ Describe OptionParser
       Assert Equals(o.parse('--huga'), {'__unknown_args__' : [], 'huga' : 1})
     End
 
-    It parses pattern option only number
+    It parses pattern option
       let o = O.new()
       call o.on('--hoge=VALUE', '', {'pattern' : '^\d\+$'})
+      call o.on('--huga=VALUE', '', {'pattern' : '^[a-m]\+$'})
       Assert Equals(o.parse('--hoge=0'), {'__unknown_args__' : [], 'hoge' : '0'})
       Assert Equals(o.parse('--hoge=99999'), {'__unknown_args__' : [], 'hoge' : '99999'})
+      Assert Equals(o.parse('--huga=a'), {'__unknown_args__' : [], 'huga' : 'a'})
+      Assert Equals(o.parse('--huga=cde'), {'__unknown_args__' : [], 'huga' : 'cde'})
       Throws o.parse('--hoge=-1')
       Throws o.parse('--hoge=99999.')
       Throws o.parse('--hoge=aaa')
+      Throws o.parse('--huga=xyz')
+      Throws o.parse('--huga=hoge')
     End
 
     It doesn't parse arguments not defined with on()

--- a/test/OptionParser.vimspec
+++ b/test/OptionParser.vimspec
@@ -149,6 +149,11 @@ Describe OptionParser
       Throws o.on('--hoge=VALUE', '', {'required' : 0.0})
     End
 
+    It occurs an error when invalid pattern option is specified
+      let o = O.new()
+      Throws o.on('--hoge=VALUE', '', {'pattern' : '\('})
+    End
+
   End
 
   Describe obj.parse()
@@ -248,6 +253,16 @@ Describe OptionParser
       Assert Equals(o.parse('--huga'), {'__unknown_args__' : [], 'huga' : 1})
     End
 
+    It parses pattern option only number
+      let o = O.new()
+      call o.on('--hoge=VALUE', '', {'pattern' : '^\d\+$'})
+      Assert Equals(o.parse('--hoge=0'), {'__unknown_args__' : [], 'hoge' : '0'})
+      Assert Equals(o.parse('--hoge=99999'), {'__unknown_args__' : [], 'hoge' : '99999'})
+      Throws o.parse('--hoge=-1')
+      Throws o.parse('--hoge=99999.')
+      Throws o.parse('--hoge=aaa')
+    End
+
     It doesn't parse arguments not defined with on()
       let o = O.new()
       call o.on('--foo', 'huga')
@@ -341,17 +356,19 @@ Describe OptionParser
       call o.on('--baz', 'description of baz, has short option', {'short' : '-b'})
       call o.on('--qux', 'description of qux, has default value', {'default' : 3.14})
       call o.on('--quux', 'description of quux, has required option', {'required' : 1})
-      call o.on('--grault', 'description of grault, has extra options', {'default' : 3.14, 'required' : 1})
+      call o.on('--corge', 'description of corge, has pattern option', {'pattern' : '^\d$'})
+      call o.on('--grault', 'description of grault, has extra options', {'default' : 3.14, 'required' : 1, 'pattern' : '^\d$'})
 
       Assert Equals(o.help(), join([
             \   "Options:",
             \   "  --foo        : description of foo",
             \   "  --baz, -b    : description of baz, has short option",
+            \   "  --corge      : description of corge, has pattern option (PATTERN: '^\\d$')",
             \   "  --hoge=VALUE : description of hoge, must have value",
             \   "  --[no-]bar   : description of bar, contradictable",
             \   "  --qux        : description of qux, has default value (DEFAULT: 3.14)",
             \   "  --quux       : description of quux, has required option (REQUIRED)",
-            \   "  --grault     : description of grault, has extra options (DEFAULT: 3.14, REQUIRED)",
+            \   "  --grault     : description of grault, has extra options (DEFAULT: 3.14, REQUIRED, PATTERN: '^\\d$')",
             \ ], "\n"))
     End
 


### PR DESCRIPTION
OptionParserに以下の2つのextra optionを追加しました。

- 'required': オプションの指定を必須にします。指定されていなければ例外を投げます。
- 'pattern': 'pattern'で指定したパターンにマッチするかどうかチェックします。マッチしなければ例外を投げます。

docとかちょっとアレですがご査収ください。