### PR TITLE
Add ConcurrentProcess module

### DIFF
--- a/autoload/vital/__latest__/ConcurrentProcess.vim
+++ b/autoload/vital/__latest__/ConcurrentProcess.vim
@@ -48,7 +48,7 @@ function! s:of(command, dir, initial_queries) abort
     try
       let vp = vimproc#popen3(a:command)
     finally
-      if len(a:dir)
+      if exists('cwd')
         execute 'lcd' cwd
       endif
     endtry
@@ -75,7 +75,7 @@ function! s:_split_at_last_newline(str) abort
   endif
 endfunction
 
-function! s:_read(label, pi, rname)
+function! s:_read(pi, rname) abort
   let pi = a:pi
 
   let [out, err] = [pi.vp.stdout.read(-1, 0), pi.vp.stderr.read(-1, 0)]
@@ -102,7 +102,9 @@ function! s:tick(label) abort
     return
   endif
 
+  " TODO return value 'is_alive' can be useful
   let is_alive = get(pi.vp.checkpid(), 0, '') ==# 'run'
+  " @vimlint(EVL102, 1, l:is_alive)
 
   let qlabel = pi.queries[0][0]
 
@@ -110,7 +112,7 @@ function! s:tick(label) abort
     let rname = pi.queries[0][1]
     let rtil = pi.queries[0][2]
 
-    call s:_read(a:label, pi, rname)
+    call s:_read(pi, rname)
 
     let pattern = "\\(^\\|\n\\)" . rtil . '$'
     " when wait ended:
@@ -128,7 +130,7 @@ function! s:tick(label) abort
     endif
   elseif qlabel ==# '*read-all*'
     let rname = pi.queries[0][1]
-    call s:_read(a:label, pi, rname)
+    call s:_read(pi, rname)
 
     " when wait ended:
     if get(s:_process_info[a:label].vp.checkpid(), 0, '') !=# 'run'

--- a/autoload/vital/__latest__/ConcurrentProcess.vim
+++ b/autoload/vital/__latest__/ConcurrentProcess.vim
@@ -232,7 +232,7 @@ endfunction
 
 " Print out log, and wipe out the log
 function! s:log_dump(label) abort
-  echomsg '-----------------------------'
+  echo '-----------------------------'
   for [stdin, stdout, stderr] in s:_process_info[a:label].logs
     echon stdin
     echon stdout

--- a/autoload/vital/__latest__/ConcurrentProcess.vim
+++ b/autoload/vital/__latest__/ConcurrentProcess.vim
@@ -142,6 +142,7 @@ function! s:tick(label) abort
     endif
   elseif qlabel ==# '*read-all*'
     let rname = pi.queries[0][1]
+    call pi.vp.stdin.close()
     call s:_read(pi, rname)
 
     " when wait ended:

--- a/autoload/vital/__latest__/ConcurrentProcess.vim
+++ b/autoload/vital/__latest__/ConcurrentProcess.vim
@@ -1,0 +1,230 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+" * queries: [(QueueLabel, QueueBody)]
+" * logs: [(String, String, String)] stdin, stdout, stderr
+" * vp: vimproc dict
+" * buffer_out, buffer_err: String
+"     * current buffered vp output/error
+" * vars: dict
+let s:_process_info = {}
+
+function! s:_vital_loaded(V) abort
+  let s:L = a:V.import('Data.List')
+  let s:S = a:V.import('Data.String')
+  let s:P = a:V.import('Process')
+endfunction
+
+function! s:_vital_depends() abort
+  return ['Data.List', 'Data.String', 'Process']
+endfunction
+
+function! s:is_available() abort
+  return s:P.has_vimproc()
+endfunction
+
+" supervisor strategy
+" * Failed to spawn the process: exception
+" * The process has been dead: start from scratch silently
+function! s:of(command, dir, initial_queries) abort
+  let label = s:S.hash(printf(
+        \ '%s--%s--%s',
+        \ type(a:command) == type('') ? a:command : join(a:command, ' '),
+        \ a:dir,
+        \ join(a:initial_queries, ';')))
+
+  " Reset if the process is dead
+  if has_key(s:_process_info, label)
+    if get(s:_process_info[label].vp.checkpid(), 0, '') !=# 'run'
+      call remove(s:_process_info, label)
+    endif
+  endif
+
+  if !has_key(s:_process_info, label)
+    if len(a:dir)
+      let cwd = getcwd()
+      execute 'lcd' a:dir
+    endif
+    try
+      let vp = vimproc#popen3(a:command)
+    finally
+      if len(a:dir)
+        execute 'lcd' cwd
+      endif
+    endtry
+
+    let s:_process_info[label] = {
+          \ 'logs': [], 'queries': a:initial_queries, 'vp': vp,
+          \ 'buffer_out': '', 'buffer_err': '', 'vars': {}}
+  endif
+
+  call s:tick(label)
+  return label
+endfunction
+
+function! s:_split_at_last_newline(str) abort
+  if len(a:str) == 0
+    return ['', '']
+  endif
+
+  let xs = split(a:str, ".*\n\\zs", 1)
+  if len(xs) >= 2
+    return [xs[0], xs[1]]
+  else
+    return ['', a:str]
+  endif
+endfunction
+
+function! s:_read(label, pi, rname)
+  let pi = a:pi
+
+  let [out, err] = [pi.vp.stdout.read(-1, 0), pi.vp.stderr.read(-1, 0)]
+  call add(pi.logs, ['', out, err])
+
+  " stdout: store into vars and buffer_out
+  if !has_key(pi.vars, a:rname)
+    let pi.vars[a:rname] = ['', '']
+  endif
+  let [left, right] = s:_split_at_last_newline(pi.buffer_out . out)
+  if a:rname !=# '_'
+    let pi.vars[a:rname][0] .= left
+  endif
+  let pi.buffer_out = right
+
+  " stderr: directly store into buffer_err
+  let pi.buffer_err .= err
+endfunction
+
+function! s:tick(label) abort
+  let pi = s:_process_info[a:label]
+
+  if len(pi.queries) == 0
+    return
+  endif
+
+  let is_alive = get(pi.vp.checkpid(), 0, '') ==# 'run'
+
+  let qlabel = pi.queries[0][0]
+
+  if qlabel ==# '*read*'
+    let rname = pi.queries[0][1]
+    let rtil = pi.queries[0][2]
+
+    call s:_read(a:label, pi, rname)
+
+    let pattern = "\\(^\\|\n\\)" . rtil . '$'
+    " when wait ended:
+    if pi.buffer_out =~ pattern
+      if rname !=# '_'
+        let pi.vars[rname][0] .= s:S.substitute_last(pi.buffer_out, pattern, '')
+        let pi.vars[rname][1] = pi.buffer_err
+      endif
+
+      call remove(pi.queries, 0)
+      let pi.buffer_out = ''
+      let pi.buffer_err = ''
+
+      call s:tick(a:label)
+    endif
+  elseif qlabel ==# '*read-all*'
+    let rname = pi.queries[0][1]
+    call s:_read(a:label, pi, rname)
+
+    " when wait ended:
+    if get(s:_process_info[a:label].vp.checkpid(), 0, '') !=# 'run'
+      if rname !=# '_'
+        let pi.vars[rname][0] .= pi.buffer_out
+        let pi.vars[rname][1] = pi.buffer_err
+      endif
+
+      call remove(pi.queries, 0)
+      let pi.buffer_out = ''
+      let pi.buffer_err = ''
+    endif
+
+  elseif qlabel ==# '*writeln*'
+    let wbody = pi.queries[0][1]
+    call pi.vp.stdin.write(wbody . "\n")
+    call remove(pi.queries, 0)
+
+    call add(pi.logs, [wbody . "\n", '', ''])
+
+    call s:tick(a:label)
+  else
+    " must not happen
+    throw "ConcurrentProcess: must not happen"
+  endif
+endfunction
+
+" returns [out, err, timedout_p]
+function! s:consume_all_blocking(label, varname, timeout_sec) abort
+  let start = reltime()
+  while 1
+    if s:is_done(a:label, a:varname)
+      return s:consume(a:label, a:varname) + [0] " 0 as 'Did not timed out'
+    elseif reltime(start)[0] >= a:timeout_sec
+      return s:consume(a:label, a:varname) + [1] " 1 as 'Unfortunately it timed out'
+    endif
+  endwhile
+endfunction
+
+function! s:consume(label, varname) abort
+  call s:tick(a:label)
+  let pi = s:_process_info[a:label]
+
+  if has_key(pi.vars, a:varname)
+    let memo = pi.vars[a:varname]
+    call remove(pi.vars, a:varname)
+    return memo
+  else
+    return ['', '']
+  endif
+endfunction
+
+function! s:is_done(label, rname) abort
+  call s:tick(a:label)
+
+  return s:L.all(
+        \ printf('(v:val[0] ==# "*read*" || v:val[0] ==# "*read-all*") && v:val[1] !=# %s', string(a:rname)),
+        \ s:_process_info[a:label].queries)
+endfunction
+
+function! s:queue(label, queries) abort
+  call s:tick(a:label)
+  let s:_process_info[a:label].queries += a:queries
+endfunction
+
+function! s:is_busy(label) abort
+  call s:tick(a:label)
+
+  return len(s:_process_info[a:label].queries) > 0
+endfunction
+
+function! s:shutdown(label) abort
+  let pi = s:_process_info[a:label]
+  call pi.vp.kill(g:vimproc#SIGKILL)
+  call pi.vp.checkpid()
+  unlet s:_process_info[a:label]
+endfunction
+
+" Just to wipe out the log
+function! s:log_clear(label) abort
+  let s:_process_info[a:label].logs = []
+endfunction
+
+" Print out log, and wipe out the log
+function! s:log_dump(label) abort
+  echomsg '-----------------------------'
+  for [stdin, stdout, stderr] in s:_process_info[a:label].logs
+    echon stdin
+    echon stdout
+    if stderr
+      echon printf('!!!%s!!!', stderr)
+    endif
+  endfor
+  let s:_process_info[a:label].logs = []
+endfunction
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+" vim:set et ts=2 sts=2 sw=2 tw=0:

--- a/autoload/vital/__latest__/ConcurrentProcess.vim
+++ b/autoload/vital/__latest__/ConcurrentProcess.vim
@@ -198,9 +198,12 @@ endfunction
 function! s:is_done(label, rname) abort
   call s:tick(a:label)
 
+  let reads = filter(
+        \ copy(s:_process_info[a:label].queries),
+        \ 'v:val[0] ==# "*read*" || v:val[0] ==# "*read-all*"')
   return s:L.all(
-        \ printf('(v:val[0] ==# "*read*" || v:val[0] ==# "*read-all*") && v:val[1] !=# %s', string(a:rname)),
-        \ s:_process_info[a:label].queries)
+        \ printf('v:val[1] !=# %s', string(a:rname)),
+        \ reads)
 endfunction
 
 function! s:queue(label, queries) abort

--- a/doc/vital-concurrent_process.txt
+++ b/doc/vital-concurrent_process.txt
@@ -17,7 +17,7 @@ CONFIG				|Vital.ConcurrentProcess-config|
 ==============================================================================
 INTRODUCTION			*Vital.ConcurrentProcess-introduction*
 
-*Vital.ConcurrentProcess* is to communitate with external process concurrently
+*Vital.ConcurrentProcess* is to communicate with external process concurrently
 with using |vimproc|.  This library stores external processes information
 spawned by this library, and provides higher layer concurrent synchronous
 non-blocking read/write interface. This library doesn't use thread nor fork,

--- a/doc/vital-concurrent_process.txt
+++ b/doc/vital-concurrent_process.txt
@@ -150,6 +150,16 @@ is_done({label}, {varname})		*Vital.ConcurrentProcess.is_done()*
 	if the read operation of given {varname} has completed. You are
 	particularly expected to use this function when you use consume().
 
+	e.g.
+	is_done(label, 'x') == 1 if you didn't read/read-all with 'x' yet
+	is_done(label, 'x') == 1 if you did read/read-all with 'x' and it
+	completed.
+	is_done(label, 'x') == 1 if you did read/read-all with 'x' and it
+	didn't complete, but the process crashed and after auto restart you
+	didn't read/read-all yet.
+	is_done(label, 'x') == 0 only if you did read/read-all with 'x' and it
+	didn't complete nor crash yet.
+
 	Idempotent? No -- return value depends on internal state.
 
 is_busy({label})			*Vital.ConcurrentProcess.is_busy()*

--- a/doc/vital-concurrent_process.txt
+++ b/doc/vital-concurrent_process.txt
@@ -1,4 +1,4 @@
-*vital-concurrent_process.txt*	Manages process concurrently with vimproc.
+*vital-concurrent_process.txt*	Manages processes concurrently with vimproc.
 
 Maintainer: ujihisa <ujihisa at gmail com>
 
@@ -10,18 +10,32 @@ INTRODUCTION			|Vital.ConcurrentProcess-introduction|
   PRINCIPLE			|Vital.ConcurrentProcess-principle|
 INTERFACE			|Vital.ConcurrentProcess-interface|
   FUNCTIONS			  |Vital.ConcurrentProcess-functions|
-CONFIG				|Vital.ConcurrentProcess-config|
+TERMS				|Vital.ConcurrentProcess-terms|
 
 
 
 ==============================================================================
 INTRODUCTION			*Vital.ConcurrentProcess-introduction*
 
-*Vital.ConcurrentProcess* is to communicate with external process concurrently
-with using |vimproc|.  This library stores external processes information
-spawned by this library, and provides higher layer concurrent synchronous
-non-blocking read/write interface. This library doesn't use thread nor fork,
-so by nature this library can't crash Vim by them.
+*Vital.ConcurrentProcess* (or if it's too long you can all it as concproc) is
+to communicate with external process concurrently with using |vimproc|.  This
+library stores external processes information spawned by this library, and
+provides higher layer concurrent synchronous non-blocking read/write
+interface. This library doesn't use thread nor fork, so by nature this library
+can't crash Vim by them.
+
+This module is most likely used for following types of Vim plugins:
+* Language support (code completion, execution, or inspection) with using the
+  language runtime process.
+  (e.g. neoclojure.vim provides clojure code completion and execution with
+  using leiningen as a persistent external process)
+* Networking with using external process.
+  (e.g. create a zeromq connection via external ruby process, and use it from
+  Vim concurrently)
+ConcurrentProcess is particularly powerful if the external process takes long
+time to start, comparing to do without using ConcurrentProcess, because it's
+managed by ConcurrentProcess.
+(e.g. JVM, or any scripting languages with lots of libraries)
 
 Note that this library doesn't work on Vim without vimproc; vimproc is
 required.
@@ -29,6 +43,88 @@ required.
 
 ==============================================================================
 USAGE				*Vital.ConcurrentProcess-usage*
+
+Here I will introduce 3 different usage depending on your purpose.
+
+1. like system(cmd) -- run external command and wait until the end.
+
+This is the simplest example; the following sample code runs "ls" command as
+an external process, wait for the termination of the process synchronously,
+and returns the output. This also takes care of exceptional cases such as (1)
+taking longer time than you have expected, (2) unexpected stderr output, or (3)
+failure of invoking the external command itself (as an exception thornw.)
+
+Note that this usage gives you little benefit to you comparing just to use
+system(), vimproc#system(), or Vital.Process.system(). Keep reading other
+examples before you try to use this for your own plugin ;)
+>
+	let s:CP = vital#of('vital').import('ConcurrentProcess')
+
+	function! s:list_files(path) abort
+	  let label = s:CP.of(['ls', a:path], '', [
+		\ ['*read-all*', 'x']])
+	  let [out, err, timeout_p] = s:CP.consume_all_blocking(label, 'x', 1.0)
+
+	  if timeout_p
+	    throw 'Timed out'
+	  elseif err !=# ''
+	    throw printf("[STDERR] %s", err)
+	  endif
+	  return split(out, '\r\?\n')
+	endfunction
+
+	echo s:list_files('/') " == ['bin', 'boot', 'dev', 'etc', ...]
+<
+
+Things to learn from this example:
+* |Vital.ConcurrentProcess.of()| with '*read-all*' query
+    * This creates an external process, and reserve ConcurrentProcess to read
+      all the stdout/stderr until the process terminates by itself.
+* |Vital.ConcurrentProcess.consume_all_blocking()|
+    * This starts the reserved queries above, in this case this start reading
+      stdout/stderr, and return them once process terminates.
+* The ls process will be created in the beginning of list_files(), and will be
+  terminated during the function.
+
+2. like system(cmd, input)
+
+You can give text to stdin as well.
+>
+	let s:CP = vital#of('vital').import('ConcurrentProcess')
+
+	function! s:with_linenum(text) abort
+	  let label = s:CP.of('cat -n', '', [
+		\ ['*writeln*', a:text],
+		\ ['*read-all*', 'x']])
+	  let [out, err, timeout_p] = s:CP.consume_all_blocking(label, 'x', 1.0)
+
+	  if timeout_p
+	    throw 'Timed out'
+	  elseif err !=# ''
+	    throw printf("[STDERR] %s", err)
+	  endif
+	  return out
+	endfunction
+
+	echo s:with_linenum("Hello\nWorld")
+<
+
+Note that you can separate of() with different queue() call, like this. They
+are different, but in this example they behave exactly samely.
+>
+	  " Before
+	  let label = s:CP.of('cat -n', '', [
+		\ ['*writeln*', a:text],
+		\ ['*read-all*', 'x']])
+
+	  " After
+	  let label = s:CP.of('cat -n', '', [])
+	  call s:CP.queue(label, [
+		\ ['*writeln*', a:text],
+		\ ['*read-all*', 'x']])
+<
+
+3. like system(cmd, input), but reuse the process
 
 TODO
 
@@ -50,11 +146,11 @@ PRINCIPLE			*Vital.ConcurrentProcess-principle*
 ==============================================================================
 INTERFACE			*Vital.ConcurrentProcess-interface*
 
-The following function is to start a process.
+The following function is to start a process, or to refer existing process.
 	|Vital.ConcurrentProcess.of()|
 The following function is to terminate a process.
 	|Vital.ConcurrentProcess.shutdown()|
-The following function is to change queries in queue.
+The following function is to add queries in queue.
 	|Vital.ConcurrentProcess.queue()|
 The following functions are to obtain information with side effect, based on
 queries in the queue and etc.
@@ -83,6 +179,10 @@ of({command}, {dir}, {list})			*Vital.ConcurrentProcess.of()*
 	Check |Vital.ConcurrentProcess-usage| how to use this with other
 	functions.
 
+	{command} can be a single string that contains both command name and
+	command line options such as "ls /tmp", or it can also be a list such
+	as ["ls", "/tmp"]
+
 	Idempotent? Yes -- but side-effect can be different.
 
 is_available()			*Vital.ConcurrentProcess.is_available()*
@@ -99,7 +199,7 @@ queue({label}, {list})			*Vital.ConcurrentProcess.queue()*
 	The query has to be either one of them.
 	['*writeln*', string]
 	['*read*', string, string]
-	['*read-all', string]
+	['*read-all*', string]
 
 >
 	call s:CP.queue(label, [
@@ -108,6 +208,12 @@ queue({label}, {list})			*Vital.ConcurrentProcess.queue()*
 	let [out, err] = s:CP.consume(label, 'x')
 	" out may contain "3"
 <
+
+	Notes:
+	* '*write*' without newline does not exist yet. Please ask me if you
+	  actually need it.
+	* '*read-all*' must be always at the very end.
+	* '*read-all*' automatically closes stdin pipe beforehand.
 
 consume({label}, {varname})		*Vital.ConcurrentProcess.consume()*
 	This is an action |Vital.ConcurrentProcess-term.action|, and returns
@@ -165,6 +271,21 @@ is_done({label}, {varname})		*Vital.ConcurrentProcess.is_done()*
 is_busy({label})			*Vital.ConcurrentProcess.is_busy()*
 	This is an action |Vital.ConcurrentProcess-term.action|, and checks
 	if the queries are currently empty.
+
+	This function is possibly used for checking if you can querying
+	something light and get the response immedicately, with using
+	consume_all_blocking(), like for code completion.
+
+>
+	if s:CP.is_busy(label, 'code-completion')
+	  return 'Busy for something else. Try later please.'
+	else
+	  call s:CP.queue([
+		\ ['*writeln*', something],
+		\ ['*read*', 'code-completion', another_something]])
+	  return s:CP.consume_all_blocking(label, 'code-completion', 0.5)
+	endif
+<
 
 	Idempotent? No -- return value depends on internal state.
 

--- a/doc/vital-concurrent_process.txt
+++ b/doc/vital-concurrent_process.txt
@@ -1,0 +1,122 @@
+*vital-concurrent_process.txt*	Manages process concurrently with vimproc.
+
+Maintainer: ujihisa <ujihisa at gmail com>
+
+==============================================================================
+CONTENTS			*Vital.ConcurrentProcess-contents*
+
+INTRODUCTION			|Vital.ConcurrentProcess-introduction|
+  USAGE				|Vital.ConcurrentProcess-usage|
+  PRINCIPLE			|Vital.ConcurrentProcess-principle|
+INTERFACE			|Vital.ConcurrentProcess-interface|
+  FUNCTIONS			  |Vital.ConcurrentProcess-functions|
+CONFIG				|Vital.ConcurrentProcess-config|
+
+
+
+==============================================================================
+INTRODUCTION			*Vital.ConcurrentProcess-introduction*
+
+*Vital.ConcurrentProcess* is to communitate with external process concurrently
+with using |vimproc|.  This library stores external processes information
+spawned by this library, and provides higher layer concurrent synchronous
+non-blocking read/write interface. This library doesn't use thread nor fork,
+so by nature this library can't crash Vim by them.
+
+Note that this library doesn't work on Vim without vimproc; vimproc is
+required.
+
+
+==============================================================================
+USAGE				*Vital.ConcurrentProcess-usage*
+
+TODO
+
+==============================================================================
+PRINCIPLE			*Vital.ConcurrentProcess-principle*
+
+* Nonblocking by default
+  * blocking APIs should have verbose name to discourage developers to use
+* Timeout is required if it's blocking
+  * Remember that: not to specify timeout is same to specify timeout as
+    forever. Having 30 year timeout explicitly is better than to specify
+    forever implicitly.
+* Synchronous (asynchronous in Vim always makes trouble)
+* Don't show lower layer too much easily, but don't hide completely. No
+  perfect abstraction exists in the world.
+* Avoid tricky specification. Function name and behaviour itself should
+  explain what it does.
+>
+==============================================================================
+INTERFACE			*Vital.ConcurrentProcess-interface*
+
+------------------------------------------------------------------------------
+FUNCTIONS			*Vital.ConcurrentProcess-functions*
+
+of({command}, {dir}, {list})			*Vital.ConcurrentProcess.of()*
+	Spawns an external process based on the arguments, and returns a
+	string which is used as |Vital.ConcurrentProcess-term.label| later.
+
+	Besides the side-effect, the return value is idempotent; if you give
+	exactly same arguments, this function always returns exactly same
+	string.
+
+	Check |Vital.ConcurrentProcess-usage| how to use this with other
+	functions.
+
+is_available()			*Vital.ConcurrentProcess.is_available()*
+	Returns 1 if the running Vim can use ConcurrentProcess, otherwise 0.
+
+tick({label})				*Vital.ConcurrentProcess.tick()*
+	This is an action |Vital.ConcurrentProcess-term.action|, and does
+	nothing besides action.
+
+queue({label}, {list})			*Vital.ConcurrentProcess.queue()*
+	TODO
+
+consume({label}, {varname})		*Vital.ConcurrentProcess.consume()*
+	TODO
+
+consume_all_blocking({label}, {varname})
+			*Vital.ConcurrentProcess.consume_all_blocking()*
+	TODO
+
+is_done({label}, {rname})		*Vital.ConcurrentProcess.is_done()*
+	TODO
+
+is_busy({label})			*Vital.ConcurrentProcess.is_busy()*
+	TODO
+
+shutdown({label})			*Vital.ConcurrentProcess.shutdown()*
+	TODO
+
+log_clear({label})			*Vital.ConcurrentProcess.log_clear()*
+	Just to wipe out accumulated logs for the process.
+
+log_dump({label})			*Vital.ConcurrentProcess.log_dump()*
+	Print out the accumulated logs for the process, and wipe out it.
+
+------------------------------------------------------------------------------
+TERMS				*Vital.ConcurrentProcess-terms*
+
+label					*Vital.ConcurrentProcess-term.label*
+	A string that represents a running/dead process managed by
+	ConcurrentProcess.
+
+action
+	The external process runs in parallel independent to Vim, but the
+	communication between Vim and the process is always done
+	synchronously. A function which is an action, such as consume(), will
+	trigger the communication; reads from stdout/stderr, or writes to stdin
+	if there's corresponding queue.
+
+	The following functions are actions.
+	* |Vital.ConcurrentProcess.tick()|
+	* |Vital.ConcurrentProcess.consume()|
+	* |Vital.ConcurrentProcess.consume_all_blocking()|
+	* |Vital.ConcurrentProcess.is_done()|
+	* |Vital.ConcurrentProcess.queue()|
+	* |Vital.ConcurrentProcess.is_busy()|
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-concurrent_process.txt
+++ b/doc/vital-concurrent_process.txt
@@ -50,6 +50,25 @@ PRINCIPLE			*Vital.ConcurrentProcess-principle*
 ==============================================================================
 INTERFACE			*Vital.ConcurrentProcess-interface*
 
+The following function is to start a process.
+	|Vital.ConcurrentProcess.of()|
+The following function is to terminate a process.
+	|Vital.ConcurrentProcess.shutdown()|
+The following function is to change queries in queue.
+	|Vital.ConcurrentProcess.queue()|
+The following functions are to obtain information with side effect, based on
+queries in the queue and etc.
+	|Vital.ConcurrentProcess.consume()|
+	|Vital.ConcurrentProcess.consume_all_blocking()|
+	|Vital.ConcurrentProcess.is_done()|
+	|Vital.ConcurrentProcess.is_busy()|
+The following functions are for debugging.
+	|Vital.ConcurrentProcess.log_clear()|
+	|Vital.ConcurrentProcess.log_dump()|
+Etc
+	|Vital.ConcurrentProcess.tick()|
+	|Vital.ConcurrentProcess.is_available()|
+
 ------------------------------------------------------------------------------
 FUNCTIONS			*Vital.ConcurrentProcess-functions*
 
@@ -64,37 +83,94 @@ of({command}, {dir}, {list})			*Vital.ConcurrentProcess.of()*
 	Check |Vital.ConcurrentProcess-usage| how to use this with other
 	functions.
 
+	Idempotent? Yes -- but side-effect can be different.
+
 is_available()			*Vital.ConcurrentProcess.is_available()*
 	Returns 1 if the running Vim can use ConcurrentProcess, otherwise 0.
+
+	Idempotent? Yes
 
 tick({label})				*Vital.ConcurrentProcess.tick()*
 	This is an action |Vital.ConcurrentProcess-term.action|, and does
 	nothing besides action.
 
 queue({label}, {list})			*Vital.ConcurrentProcess.queue()*
-	TODO
+	Pushes the given {list} of queries into the queue for the process.
+	The query has to be either one of them.
+	['*writeln*', string]
+	['*read*', string, string]
+	['*read-all', string]
+
+>
+	call s:CP.queue(label, [
+	      \ ['*writeln*', '1 + 2'],
+	      \ ['*read*', 'x', '> ']])
+	let [out, err] = s:CP.consume(label, 'x')
+	" out may contain "3"
+<
 
 consume({label}, {varname})		*Vital.ConcurrentProcess.consume()*
-	TODO
+	This is an action |Vital.ConcurrentProcess-term.action|, and returns
+	accumulated value for {varname} immediately, and remove it from
+	internal buffer.
 
-consume_all_blocking({label}, {varname})
+	similar to consume() described above, but this doesn't immediately
+	return the current output but blocks until the end of the read of the
+	given {varname}, at most {timeout-sec} seconds. This also returns a
+	0/1 value as the 3rd element of the list to tell if it has timed out
+	or not.
+
+	Idempotent? No -- this removes the internal buffer.
+
+consume_all_blocking({label}, {varname}, {timeout-sec})
 			*Vital.ConcurrentProcess.consume_all_blocking()*
-	TODO
+	This is an action |Vital.ConcurrentProcess-term.action|, and does
+	similar to consume() described above, but this doesn't immediately
+	return the current output but blocks until the end of the read of the
+	given {varname}, at most {timeout-sec} seconds. This also returns a
+	0/1 value as the 3rd element of the list to tell if it has timed out
+	or not.
+>
+	" get stdout/stderr for the var x, with blocking at worst 10 seconds.
+	let [out, err, timeout_p] =
+	      \ s:CP.consume_all_blocking(label, 'x', 10)
+	if timeout_p
+	  " omg it timed out!
+	else
+	  " yes it completed without 10 seconds. Do normal stuff here
+	endif
+<
+	For your info this function is internally using is_done() described
+	below.
 
-is_done({label}, {rname})		*Vital.ConcurrentProcess.is_done()*
-	TODO
+	Idempotent? No -- this removes the internal buffer.
+
+is_done({label}, {varname})		*Vital.ConcurrentProcess.is_done()*
+	This is an action |Vital.ConcurrentProcess-term.action|, and checks
+	if the read operation of given {varname} has completed. You are
+	particularly expected to use this function when you use consume().
+
+	Idempotent? No -- return value depends on internal state.
 
 is_busy({label})			*Vital.ConcurrentProcess.is_busy()*
-	TODO
+	This is an action |Vital.ConcurrentProcess-term.action|, and checks
+	if the queries are currently empty.
+
+	Idempotent? No -- return value depends on internal state.
 
 shutdown({label})			*Vital.ConcurrentProcess.shutdown()*
-	TODO
+	Terminates the underlying process for the given label immediately, no
+	matter how many queries are in the queue. This also removes all
+	internal buffers for the process, including queries and logs.
 
 log_clear({label})			*Vital.ConcurrentProcess.log_clear()*
 	Just to wipe out accumulated logs for the process.
 
 log_dump({label})			*Vital.ConcurrentProcess.log_dump()*
 	Print out the accumulated logs for the process, and wipe out it.
+
+	Idempotent? No -- output depends on the internal buffer and every time
+	you call this ConcurrentProcess removes buffer.
 
 ------------------------------------------------------------------------------
 TERMS				*Vital.ConcurrentProcess-terms*

--- a/test/ConcurrentProcess.vimspec
+++ b/test/ConcurrentProcess.vimspec
@@ -50,6 +50,8 @@ function! s:suite.consume()
 
   call s:CP.tick(label)
 
+  sleep
+
   let [outx, errx] = s:CP.consume(label, 'x')
   let [outy, erry] = s:CP.consume(label, 'y')
 

--- a/test/ConcurrentProcess.vimspec
+++ b/test/ConcurrentProcess.vimspec
@@ -6,7 +6,14 @@ let s:assert = themis#helper('assert')
 function! s:suite.before()
   let s:CP = vital#of('vital').import('ConcurrentProcess')
 
-  " Check if user has `cat` executable command
+  " NOTE: currently themis ignores s:assert.skip() from before.
+  " This will be fixed in the future.
+  if !s:CP.is_available()
+    call s:assert.skip('CP is not available. Do you have vimproc?')
+  endif
+  if !executable('cat') || !executable('sh')
+    call s:assert.skip('cat or sh are not available. Do you have vimproc?')
+  endif
 endfunction
 
 function! s:suite.after()

--- a/test/ConcurrentProcess.vimspec
+++ b/test/ConcurrentProcess.vimspec
@@ -1,0 +1,100 @@
+scriptencoding utf-8
+
+let s:suite = themis#suite('ConcurrentProcess')
+let s:assert = themis#helper('assert')
+
+function! s:suite.before()
+  let s:CP = vital#of('vital').import('ConcurrentProcess')
+
+  " Check if user has `cat` executable command
+endfunction
+
+function! s:suite.after()
+  unlet! s:CP
+endfunction
+
+function! s:suite.of()
+  " Well, this also has tick() and log_dump()
+  " This may depend on performance of computer as well
+  let label = s:CP.of('cat -n', '/tmp', [
+        \ ['*writeln*', 'hello'],
+        \ ['*read*', 'x', '']])
+  call s:assert.is_string(label)
+
+  call s:CP.tick(label)
+  redir => output
+    silent call s:CP.log_dump(label)
+  redir END
+  call s:assert.match(output, '1\s\+hello')
+endfunction
+
+function! s:suite.of_with_failure()
+  try
+    call s:CP.of('this-command-does-not-exist', '', [])
+    call s:assert.fail('of')
+  catch /File "this-command-does-not-exist" is not found/
+    call s:assert.true(1)
+    return
+  endtry
+  call s:assert.fail('of')
+endfunction
+
+function! s:suite.consume()
+  " Well, this also has of(), and tick()
+  " This may depend on performance of computer as well
+  let label = s:CP.of('cat -n', '/tmp', [
+        \ ['*writeln*', 'hello'],
+        \ ['*read*', 'x', ''],
+        \ ['*writeln*', 'world'],
+        \ ['*read*', 'y', '']])
+
+  call s:CP.tick(label)
+
+  let [outx, errx] = s:CP.consume(label, 'x')
+  let [outy, erry] = s:CP.consume(label, 'y')
+
+  call s:assert.match(outx, '1\s\+hello')
+  call s:assert.not_match(outx, '2\s\+world')
+
+  call s:assert.not_match(outy, '1\s\+hello')
+  call s:assert.match(outy, '2\s\+world')
+
+  call s:assert.equals(errx, '')
+  call s:assert.equals(erry, '')
+
+  " 2nd time is different.
+  let [out, err] = s:CP.consume(label, 'x')
+  call s:assert.equals(out, '')
+  call s:assert.equals(err, '')
+
+  let [out, err] = s:CP.consume(label, 'y')
+  call s:assert.equals(out, '')
+  call s:assert.equals(err, '')
+endfunction
+
+function! s:suite.consume_all_blocking()
+  let label = s:CP.of('sh -c "sleep 2; echo -n done; sleep 2"', '/tmp', [
+        \ ['*read*', 'x', 'done']])
+
+  call s:assert.false(s:CP.is_done(label, 'x'))
+
+  " with very little timeout value
+  let [out, err, timedout_p] = s:CP.consume_all_blocking(label, 'x', 1)
+  call s:assert.true(timedout_p)
+  call s:assert.false(s:CP.is_done(label, 'x'))
+
+  " with enough timeout value
+  let [out, err, timedout_p] = s:CP.consume_all_blocking(label, 'x', 10)
+  call s:assert.false(timedout_p)
+  call s:assert.true(s:CP.is_done(label, 'x'))
+endfunction
+
+function! s:suite.read_all()
+  " system() pattern -- execute something and get everything.
+  let label = s:CP.of('sh -c "sleep 1; echo done"', '', [
+        \ ['*read-all*', 'x']])
+
+  let [out, err, timedout_p] = s:CP.consume_all_blocking(label, 'x', 10)
+  call s:assert.equals(out, "done\n")
+  call s:assert.false(timedout_p)
+endfunction


### PR DESCRIPTION
ConcurrentProcessは、ProcessManagerやその後継として試作されていたPM2を置き換える別のAPIと機能を持った類似のライブラリです。

Vitalにすでに存在するProcessManager / PM2では、

* アプリケーション側にプロセスの内部状態を確認・調整する責任があり、アプリケーション開発が困難であった
* PMがプロセスに行った行為をトラックするのが難しいため、デバッグにかなり強い推理力と想像力が求められた
* 名前が意味するところが曖昧

などの問題がありました。ConcurrentProcessはこれらの問題を解決しています。

## 使用例 :rabbit:

* neoclojure.vimはすでにPM2からConcurrentProcessを用いた実装に置き換えられています。
    * https://github.com/ujihisa/neoclojure.vim

* thinca/vim-quickrunにも`runner/concurrent_process`を実装しました。`runner/process_manager`に比べ、かなり短い実装となりました。
    * https://github.com/thinca/vim-quickrun/compare/master...ujihisa:concproc?expand=1
    * 特に二番目のコミットを見るとconcprocの実際の使用例がわかりやすいのではないかと思います。

## 未来 :soon:

現在のConcurrentProcessは、以下をサポートしていませんが、今後(もしかしたら別モジュールに分離した形で)提供したいなと考えているもの:

* autocmd CursorHold/CursorHoldIを用いたイベント登録の簡略化
* Data.Closureとの連携
* `if_python`に依存し、かわりに`vimproc`に依存しない実装
* neovimのアレに依存し、neovimなら何も依存しない実装

## link :link:

RFC時点でのpull request https://github.com/vim-jp/vital.vim/pull/267
