### PR TITLE
Math: add round()

### DIFF
--- a/autoload/vital/__latest__/Math.vim
+++ b/autoload/vital/__latest__/Math.vim
@@ -76,6 +76,12 @@ function! s:sum(list) abort
   return sum
 endfunction
 
+function! s:round(float, ...) abort
+  let digits = get(a:, 1, 0)
+  let n = pow(10.0, digits)
+  return round(a:float*n)/n
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 

--- a/doc/vital-math.txt
+++ b/doc/vital-math.txt
@@ -84,5 +84,20 @@ sum({values})				*Vital.Math.sum()*
         sum([]) == 0
 <
 
+round({expr} [, {digits}])		*Vital.Math.round()*
+	Round off {expr} to {digits} digits after the decimal point and
+	return it as a Float.
+	If {digits} is omitted, it defaults to 0.
+	If {expr} lies halfway between two values, then use the larger
+	one (away from zero).
+	{expr} must evaluate to a Float or a Number.
+>
+	round(2.675) == 3
+	round(2.675, 2) == 2.68
+	round(-2.675, 2) == -2.68
+	round(5.127, -1) == 10.0
+	round(5.127, 20) == 5.127
+<
+
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/Math.vim
+++ b/test/Math.vim
@@ -70,4 +70,7 @@ function! s:suite.round()
   call s:assert.equals(s:M.round(5.127, 2), 5.13)
   call s:assert.equals(s:M.round(5.127, 3), 5.127)
   call s:assert.equals(s:M.round(5.127, 20), 5.127)
+  call s:assert.equals(s:M.round(123, -2), 100.0)
+  call s:assert.equals(s:M.round(123, -1), 120.0)
+  call s:assert.equals(s:M.round(123, 1), 123.0)
 endfunction

--- a/test/Math.vim
+++ b/test/Math.vim
@@ -59,3 +59,15 @@ function! s:suite.sum()
   " It returns argument is empty list
   call s:assert.equals(s:M.sum([]), 0)
 endfunction
+
+function! s:suite.round()
+  call s:assert.equals(s:M.round(2.675, 0), 3)
+  call s:assert.equals(s:M.round(2.675, 2), 2.68)
+  call s:assert.equals(s:M.round(-2.675, 2), -2.68)
+  call s:assert.equals(s:M.round(5.127, -1), 10.0)
+  call s:assert.equals(s:M.round(5.127, 0), 5.0)
+  call s:assert.equals(s:M.round(5.127, 1), 5.1)
+  call s:assert.equals(s:M.round(5.127, 2), 5.13)
+  call s:assert.equals(s:M.round(5.127, 3), 5.127)
+  call s:assert.equals(s:M.round(5.127, 20), 5.127)
+endfunction


### PR DESCRIPTION
Mathにround()を追加しました。
vimに標準で用意されているroundに桁数を指定する引数(digits)をつけて拡張したものです。

issue #296 