### PR TITLE
Deprecated functions in Prelude

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+83a2dbf
+	Modules: Prelude
+	Removed below deprecated functions:
+	- truncate_smart()
+	- set_dictionaryhelper()
 24877cc
 	Modules: Data.List
 	permutations({list}[, {r}]) behavior is changed not to support string input as {list}.

--- a/Changes
+++ b/Changes
@@ -1,3 +1,12 @@
+d4d6207
+	Modules: Prelude
+	Below functions were moved to Data.String module (#295) and they are marked as
+	deprecated in Prelude. They will be removed in the near future.
+	- truncate_skipping()
+	- truncate()
+	- strwidthpart()
+	- strwidthpart_reverse()
+	- wcswidth()
 83a2dbf
 	Modules: Prelude
 	Removed below deprecated functions:

--- a/autoload/vital/__latest__/Prelude.vim
+++ b/autoload/vital/__latest__/Prelude.vim
@@ -69,6 +69,8 @@ function! s:is_dict(Value) abort
 endfunction
 
 function! s:truncate_skipping(str, max, footer_width, separator) abort
+  call s:_warn_deprecated("truncate_skipping", "Data.String.truncate_skipping")
+
   let width = s:wcswidth(a:str)
   if width <= a:max
     let ret = a:str
@@ -84,6 +86,8 @@ endfunction
 function! s:truncate(str, width) abort
   " Original function is from mattn.
   " http://github.com/mattn/googlereader-vim/tree/master
+
+  call s:_warn_deprecated("truncate", "Data.String.truncate")
 
   if a:str =~# '^[\x00-\x7f]*$'
     return len(a:str) < a:width ?
@@ -105,6 +109,8 @@ function! s:truncate(str, width) abort
 endfunction
 
 function! s:strwidthpart(str, width) abort
+  call s:_warn_deprecated("strwidthpart", "Data.String.strwidthpart")
+
   if a:width <= 0
     return ''
   endif
@@ -119,6 +125,8 @@ function! s:strwidthpart(str, width) abort
   return ret
 endfunction
 function! s:strwidthpart_reverse(str, width) abort
+  call s:_warn_deprecated("strwidthpart_reverse", "Data.String.strwidthpart_reverse")
+
   if a:width <= 0
     return ''
   endif
@@ -136,10 +144,13 @@ endfunction
 if v:version >= 703
   " Use builtin function.
   function! s:wcswidth(str) abort
+    call s:_warn_deprecated("wcswidth", "Data.String.wcswidth")
     return strwidth(a:str)
   endfunction
 else
   function! s:wcswidth(str) abort
+    call s:_warn_deprecated("wcswidth", "Data.String.wcswidth")
+
     if a:str =~# '^[\x00-\x7f]*$'
       return strlen(a:str)
     end
@@ -204,6 +215,14 @@ function! s:is_unix() abort
   return s:is_unix
 endfunction
 
+function! s:_warn_deprecated(name, alternative) abort
+  try
+    echohl Error
+    echomsg "Prelude." . a:name . " is deprecated!  Please use " . a:alternative . " instead."
+  finally
+    echohl None
+  endtry
+endfunction
 
 function! s:smart_execute_command(action, word) abort
   execute a:action . ' ' . (a:word == '' ? '' : '`=a:word`')

--- a/autoload/vital/__latest__/Prelude.vim
+++ b/autoload/vital/__latest__/Prelude.vim
@@ -68,11 +68,6 @@ function! s:is_dict(Value) abort
   return type(a:Value) ==# s:__TYPE_DICT
 endfunction
 
-function! s:truncate_smart(str, max, footer_width, separator) abort
-  echoerr 'Prelude.truncate_smart() is obsolete. Use its truncate_skipping() instead; they are equivalent.'
-  return s:truncate_skipping(a:str, a:max, a:footer_width, a:separator)
-endfunction
-
 function! s:truncate_skipping(str, max, footer_width, separator) abort
   let width = s:wcswidth(a:str)
   if width <= a:max
@@ -209,10 +204,6 @@ function! s:is_unix() abort
   return s:is_unix
 endfunction
 
-function! s:_deprecated2(fname) abort
-  echomsg printf("Vital.Prelude.%s is deprecated!",
-        \ a:fname)
-endfunction
 
 function! s:smart_execute_command(action, word) abort
   execute a:action . ' ' . (a:word == '' ? '' : '`=a:word`')
@@ -258,16 +249,6 @@ function! s:set_default(var, val) abort
   if !exists(a:var) || type({a:var}) != type(a:val)
     let {a:var} = a:val
   endif
-endfunction
-
-function! s:set_dictionary_helper(variable, keys, pattern) abort
-  call s:_deprecated2('set_dictionary_helper')
-
-  for key in split(a:keys, '\s*,\s*')
-    if !has_key(a:variable, key)
-      let a:variable[key] = a:pattern
-    endif
-  endfor
 endfunction
 
 function! s:substitute_path_separator(path) abort

--- a/doc/vital-prelude.txt
+++ b/doc/vital-prelude.txt
@@ -85,19 +85,24 @@ is_dict({value})				*Vital.Prelude.is_dict()*
 
 					*Vital.Prelude.truncate_skipping()*
 truncate_skipping({str}, {max}, {footer-width}, {separator})
-	TODO
+	This function is deprecated. Please use
+	|Vital.Data.String.truncate_skipping()| instead.
 
 truncate({str}, {width})			*Vital.Prelude.truncate()*
-	TODO
+	This function is deprecated. Please use |Vital.Data.String.truncate()|
+	instead.
 
 strwidthpart({str}, {width})			*Vital.Prelude.strwidthpart()*
-	TODO
+	This function is deprecated. Please use
+	|Vital.Data.String.strwidthpart()| instead.
 
 strwidthpart_reverse({str}, {width})	*Vital.Prelude.strwidthpart_reverse()*
-	TODO
+	This function is deprecated. Please use
+	|Vital.Data.String.strwidthpart_reverse()| instead.
 
 wcswidth({str})					*Vital.Prelude.wcswidth()*
-	TODO
+	This function is deprecated. Please use |Vital.Data.String.wcswidth()|
+	instead.
 
 is_windows()					*Vital.Prelude.is_windows()*
 	Returns non-zero if Vim is a MS-Windows version, zero otherwise.

--- a/doc/vital-prelude.txt
+++ b/doc/vital-prelude.txt
@@ -83,11 +83,6 @@ is_list({value})				*Vital.Prelude.is_list()*
 is_dict({value})				*Vital.Prelude.is_dict()*
 	Returns non-zero if {value} is a |Dictionary|, zero otherwise.
 
-					*Vital.Prelude.truncate_smart()*
-truncate_smart({str}, {max}, {footer-width}, {separator})
-	Deprecated. Use Prelude.truncate_skipping() instead; they are
-	equivalent.
-
 					*Vital.Prelude.truncate_skipping()*
 truncate_skipping({str}, {max}, {footer-width}, {separator})
 	TODO
@@ -165,20 +160,6 @@ set_default({var}, {val})			*Vital.Prelude.set_default()*
 	let g:aaa = get(g:, 'aaa', 'bbb')
 <
 	But not exactly same when the type of aaa is not |expr-string|.
-
-				*Vital.Prelude.set_dictionary_helper()*
-set_dictionary_helper({variable}, {keys}, {pattern})
-	TODO (deprecated)
->
-	let x = {'b': 123}
-	call V.set_dictionary_helper('x', 'a, b, c', 999)
-<
-	is same to
->
-	let x = {'b': 123}
-	let x.a = 999
-	let x.c = 999
-<
 
 				*Vital.Prelude.substitute_path_separator()*
 substitute_path_separator({path})


### PR DESCRIPTION
Prelude の deprecated な関数を処理しました．

- `truncate_smart()` と `set_dictionaryhelper()` はずいぶん長い間 deprecated のまま放置されていたので削除しました
- #295 で `Data.String` に移った関数を `Prelude` では廃止扱いにしました．3ヶ月後ぐらい（適当）で削除予定です．（僕が忘れていたら誰か代わりにお願いします）

Changes も書いたので `:Vitalize` 時にメッセージが出るはずです．