### PR TITLE
Hotfix: Vim.BufferManager: Remove critical problem

### DIFF
--- a/autoload/vital/__latest__/Vim/BufferManager.vim
+++ b/autoload/vital/__latest__/Vim/BufferManager.vim
@@ -47,7 +47,6 @@ function! s:Manager.open(bufname, ...) abort
   let new_bufnr = bufnr('%')
   let self._bufnrs[new_bufnr] = a:bufname
 
-  call self.opened(a:bufname)
   return {
   \   'loaded': loaded,
   \   'newwin': moved,


### PR DESCRIPTION
https://github.com/vim-jp/vital.vim/commit/0d24d78da6f8bde448ba7b38f96b9a679b6142d7

上記変更により BufferManager を使うと死ぬので修正