### PR TITLE
Specify authorization method in Web.HTTP.curl

### DIFF
--- a/doc/vital-web-http.txt
+++ b/doc/vital-web-http.txt
@@ -97,9 +97,14 @@ request({method}, {url} [, {settings}])
 		  "wget": "/usr/local/bin/wget",
 		}
 
-        "gzipDecompress" Default: 0
-                Attempt to decompress response data as if it was gzipped
-                  
+	"authMethod"	Default: (None)
+		(This is only valid for "curl" interface.)
+		Specify the authorization method.
+		The value must be in ['basic', 'digest', 'ntlm', 'negotiate']
+		The default value is None, and then use "anyauth".
+
+	"gzipDecompress"	Default: 0
+		Attempt to decompress response data as if it was gzipped
 
 parseHeader({headers})			*Vital.Web.HTTP.parseHeader()*
 	Parse {headers} list to a dictionary.


### PR DESCRIPTION
問題
------
Web.HTTPのcurlバックエンドの認証方式がanyauthに決めうちなので、
他の認証方式を明示的に指定するためのオプションが欲しい。

変更点
-------
- Web.HTTP.requestに`authMethod`オプションを追加
  - curlでのみ有効（python,wgetでは無視）
- vital-web-http.txtにドキュメントを追加