### PR TITLE
Data.List: Improve performance of .with_index()

### DIFF
--- a/autoload/vital/__latest__/Data/List.vim
+++ b/autoload/vital/__latest__/Data/List.vim
@@ -264,7 +264,7 @@ endfunction
 " Inspired by Ruby's with_index method.
 function! s:with_index(list, ...) abort
   let base = a:0 > 0 ? a:1 : 0
-  return s:zip(a:list, range(base, len(a:list)+base-1))
+  return map(copy(a:list), '[v:val, v:key + base]')
 endfunction
 
 " similar to Ruby's detect or Haskell's find.


### PR DESCRIPTION
### やったこと
Pythonのenumerateが欲しかったので実装していたんですが，すでにenumerateに相当する`.with_index()`が実装されていたようです．
しかしその実装がLingrでthincaさんに教えてもらったコードよりパフォーマンスが悪かったのでせっかくなのでPRしてみました．

(あとPython勢としては `enumerate()` のaliasが欲しいとも思ったけど，ライブラリ管理するという意味では無駄っぽいので難しそう．ドキュメントに書けば検索で引っかかるのでそれがよいかもしれないけどやってない)

Lingrログ: http://lingr.com/room/vim/archives/2015/06/29#message-22095170

### 注意点
Vim 7.1 か 7.2 のどこかで リストの `map()` で `v:key` が使えるようになったようなのでVimのバージョンにたいする互換性が壊れてる．
そういう意味では無視して頂いてもよいかもしれないです．

#### 比較

`with_index2()`がPRで変更した新しいほうです．

```vim
" similar to python's zip()
function! s:zip(...) abort
  return map(range(min(map(copy(a:000), 'len(v:val)'))), "map(copy(a:000), 'v:val['.v:val.']')")
endfunction

" Inspired by Ruby's with_index method.
function! s:with_index(list, ...) abort
  let base = a:0 > 0 ? a:1 : 0
  return s:zip(a:list, range(base, len(a:list)+base-1))
endfunction

function! s:with_index2(list, ...) abort
  let start = get(a:, 1, 0)
  return map(copy(a:list), '[v:val, v:key + start]')
endfunction

let i = 1000
let xs = range(i)

command! -bar TimerStart let start_time = reltime()
command! -bar TimerEnd echo reltimestr(reltime(start_time)) | unlet start_time

TimerStart
for _ in range(i)
  call s:with_index(xs)
endfor
TimerEnd

TimerStart
for _ in range(i)
  call s:with_index2(xs)
endfor
TimerEnd
```

#### 結果

```
5.530231
1.985088
```

コードと計測結果: http://melpon.org/wandbox/permlink/tTPel8Rt0wSlQb6a
