### PR TITLE
System.File: Escape # and % in Windows

### DIFF
--- a/autoload/vital/__latest__/System/File.vim
+++ b/autoload/vital/__latest__/System/File.vim
@@ -24,7 +24,12 @@ function! s:open(filename) abort "{{{
     if s:need_trans
       let filename = iconv(filename, &encoding, 'char')
     endif
-    silent execute '!start rundll32 url.dll,FileProtocolHandler' filename
+    " Note:
+    "   # and % required to be escaped (:help cmdline-special)
+    silent execute printf(
+          \ '!start rundll32 url.dll,FileProtocolHandler %s',
+          \ escape(filename, '#%'),
+          \)
   elseif s:is_cygwin
     " Cygwin.
     call system(printf('%s %s', 'cygstart',


### PR DESCRIPTION
With `System.File.open()`, I faced the following exception in Windows

```
E194: No alternate file name to substitute for '#': !start rundll32 url.dll,FileProtocolHandler https://github.com/lambdalisue/vim-gita/blob/hotfix/noshellslash_in_windows/autoload/gita.vim#L2
```

It seems that '#' and '%' required to be escaped due to the [`cmdline-special`](http://vimdoc.sourceforge.net/htmldoc/cmdline.html#cmdline-special), so I escape the two character before passing to command line.