### PR TITLE
モジュールの相互依存を許可する

### DIFF
--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -237,6 +237,9 @@ function! s:_build_module(sid) abort
   for func in functions
     let module[func] = function(prefix . func)
   endfor
+  if has_key(module, '_vital_export')
+    call module._vital_export(module)
+  endif
   if has_key(module, '_vital_loaded')
     let V = vital#{s:self_version}#new()
     if has_key(module, '_vital_depends')

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -240,6 +240,8 @@ function! s:_build_module(sid) abort
   if has_key(module, '_vital_export')
     call module._vital_export(module)
   endif
+  let export_module = filter(copy(module), 'v:key =~# "^\\a"')
+  let s:loaded[a:sid] = get(g:, 'vital_debug', 0) ? module : export_module
   if has_key(module, '_vital_loaded')
     let V = vital#{s:self_version}#new()
     try
@@ -248,11 +250,7 @@ function! s:_build_module(sid) abort
       " FIXME: Show an error message for debug.
     endtry
   endif
-  if !get(g:, 'vital_debug', 0)
-    call filter(module, 'v:key =~# "^\\a"')
-  endif
-  let s:loaded[a:sid] = module
-  return copy(module)
+  return copy(s:loaded[a:sid])
 endfunction
 
 if exists('+regexpengine')

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -242,13 +242,6 @@ function! s:_build_module(sid) abort
   endif
   if has_key(module, '_vital_loaded')
     let V = vital#{s:self_version}#new()
-    if has_key(module, '_vital_depends')
-      let all = {}
-      let modules =
-      \     s:_concat(map(module._vital_depends(),
-      \                   's:expand_modules(v:val, all)'))
-      call call(V.load, modules, V)
-    endif
     try
       call module._vital_loaded(V)
     catch

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -237,8 +237,8 @@ function! s:_build_module(sid) abort
   for func in functions
     let module[func] = function(prefix . func)
   endfor
-  if has_key(module, '_vital_export')
-    call module._vital_export(module)
+  if has_key(module, '_vital_created')
+    call module._vital_created(module)
   endif
   let export_module = filter(copy(module), 'v:key =~# "^\\a"')
   let s:loaded[a:sid] = get(g:, 'vital_debug', 0) ? module : export_module

--- a/autoload/vital/__latest__/Bitwise.vim
+++ b/autoload/vital/__latest__/Bitwise.vim
@@ -36,10 +36,10 @@ let s:pow2 = [
       \ ]
 
 if exists('*and')
-  function! s:_vital_loaded(V) dict abort
+  function! s:_vital_export(module) abort
     for op in ['and', 'or', 'xor', 'invert']
-      let self[op] = function(op)
-      let s:[op] = self[op]
+      let a:module[op] = function(op)
+      let s:[op] = a:module[op]
     endfor
   endfunction
   finish

--- a/autoload/vital/__latest__/Bitwise.vim
+++ b/autoload/vital/__latest__/Bitwise.vim
@@ -36,7 +36,7 @@ let s:pow2 = [
       \ ]
 
 if exists('*and')
-  function! s:_vital_export(module) abort
+  function! s:_vital_created(module) abort
     for op in ['and', 'or', 'xor', 'invert']
       let a:module[op] = function(op)
       let s:[op] = a:module[op]

--- a/autoload/vital/__latest__/System/Cache.vim
+++ b/autoload/vital/__latest__/System/Cache.vim
@@ -2,7 +2,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 let s:registry = {}
-function! s:_vital_loaded(V) dict abort
+function! s:_vital_loaded(V) abort
   let s:V = a:V
   let s:P = a:V.import('Prelude')
   call s:register('dummy',  'System.Cache.Dummy')

--- a/autoload/vital/__latest__/System/Cache/Base.vim
+++ b/autoload/vital/__latest__/System/Cache/Base.vim
@@ -1,7 +1,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! s:_vital_loaded(V) dict abort
+function! s:_vital_loaded(V) abort
   let s:Prelude = a:V.import('Prelude')
 endfunction
 function! s:_vital_depends() abort

--- a/autoload/vital/__latest__/System/Cache/Dummy.vim
+++ b/autoload/vital/__latest__/System/Cache/Dummy.vim
@@ -1,7 +1,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! s:_vital_loaded(V) dict abort
+function! s:_vital_loaded(V) abort
   let s:Base = a:V.import('System.Cache.Base')
 endfunction
 function! s:_vital_depends() abort

--- a/autoload/vital/__latest__/System/Cache/File.vim
+++ b/autoload/vital/__latest__/System/Cache/File.vim
@@ -1,7 +1,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! s:_vital_loaded(V) dict abort
+function! s:_vital_loaded(V) abort
   let s:V = a:V
   let s:Prelude = a:V.import('Prelude')
   let s:String = a:V.import('Data.String')

--- a/autoload/vital/__latest__/System/Cache/Memory.vim
+++ b/autoload/vital/__latest__/System/Cache/Memory.vim
@@ -1,7 +1,7 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-function! s:_vital_loaded(V) dict abort
+function! s:_vital_loaded(V) abort
   let s:Base = a:V.import('System.Cache.Base')
 endfunction
 function! s:_vital_depends() abort

--- a/autoload/vital/__latest__/Web/JSON.vim
+++ b/autoload/vital/__latest__/Web/JSON.vim
@@ -32,7 +32,7 @@ function! s:_resolve(val, prefix) abort
 endfunction
 
 
-function! s:_vital_export(module) abort
+function! s:_vital_created(module) abort
   " define constant variables
   call extend(a:module, s:const)
 endfunction

--- a/autoload/vital/__latest__/Web/JSON.vim
+++ b/autoload/vital/__latest__/Web/JSON.vim
@@ -32,11 +32,14 @@ function! s:_resolve(val, prefix) abort
 endfunction
 
 
-function! s:_vital_loaded(V) dict abort
+function! s:_vital_export(module) abort
+  " define constant variables
+  call extend(a:module, s:const)
+endfunction
+
+function! s:_vital_loaded(V) abort
   let s:V = a:V
   let s:string = s:V.import('Data.String')
-  " define constant variables
-  call extend(self, s:const)
 endfunction
 
 function! s:_vital_depends() abort

--- a/doc/vital-system-cache-base.txt
+++ b/doc/vital-system-cache-base.txt
@@ -33,7 +33,7 @@ Tutorial				*Vital.System.Cache.Base-tutorial*
 First of all, create s:new(...) function to return an instance of your variant
 like:
 >
-	function! s:_vital_loaded(V) dict abort " {{{
+	function! s:_vital_loaded(V) abort " {{{
 	  let s:Base = a:V.import('System.Cache.Base')
 	endfunction " }}}
 	function! s:_vital_depends() abort " {{{


### PR DESCRIPTION
実は、モジュールにおいて相互に依存すると、ロード時に無限再帰が発生していました。
発生した無限再帰は #194 が原因で握りつぶされていたのですが、問題なので修正しました。これによっていくつか仕様変更があります。

#### `_vital_loaded()` は `module` にアクセスできなくなった

そもそもの無限再帰の原因ですが、`_build_module()`  → `_vital_loaded()` で別モジュールをロードする時点で、`s:loaded` に生成したモジュールが乗っておらず、めぐりめぐって再び `_build_module()` に戻ってきた時にロード済みのモジュールが使えないのが問題でした。
なぜ乗っていないかというと、一部モジュールで `_vital_loaded()` 時にモジュールを操作していて、これが完了しないと中途半端な状態のモジュールが `s:loaded` に乗ってしまうことになり、このタイミングでロードされると不完全なモジュールがロードされてしまうからです。
`_vital_loaded()` はその名の通りロード済みの時点で呼ばれるべきで、ロードされたあとにモジュールに変更を加えると問題が起きる可能性があるため、`module` にはアクセスできなくしました。

#### `_vital_export()` を追加した

先に挙げたとおり、`Bitwise` などの一部のモジュールは、`_vital_loaded()` でモジュールに対して変更を加えていました。
これは少なくとも現状の利用範囲では、関数を1つずつ定義するなどすれば回避可能でしたが、若干非効率です。
`_vital_loaded()` でモジュールに変更をできなくしたので、代わりに `_vital_export()` を追加し、こちらで変更できるようにしました。
`_vital_export()` では `_vital_loaded()` と違い vital ローダが渡されないので、別モジュールのロードはできません。


ロード時の流れをまとめると以下のようになります。

1. モジュール生成
2. `_vital_export()` 呼び出し (ここではモジュールの操作のみ可能)
3. `s:loaded` に完成したモジュールをセット
4. `_vital_loaded()` 呼び出し (ここで再帰的に `import` されても `s:loaded` があるのでそちらが使われる)

新しく追加した `_vital_export` の命名についてとかその他もろもろ意見ください。