### PR TITLE
Web.XML: パフォーマンス改善

### DIFF
--- a/autoload/vital/__latest__/Web/XML.vim
+++ b/autoload/vital/__latest__/Web/XML.vim
@@ -204,6 +204,7 @@ function! s:__parse_tree(ctx, top) abort
   while len(a:ctx['xml']) > 0
     let m = matchlist(a:ctx.xml, tag_mx)
     if empty(m) | break | endif
+    let a:ctx.xml = m[9]
     let is_end_tag = m[2] == '/' && m[5] == ''
     let is_start_and_end_tag = m[2] == '' && m[5] == '/'
     let tag_name = m[3]
@@ -220,20 +221,17 @@ function! s:__parse_tree(ctx, top) abort
       if len(stack) " TODO: checking whether opened tag is exist. 
         call remove(stack, -1)
       endif
-      let a:ctx['xml'] = m[9]
       continue
     endif
 
     " comment tag
     if m[8] != ''
-        let a:ctx.xml = m[9]
         continue
     endif
 
     " if element is a CDATA
     if m[6] != ''
         let content .= m[7]
-        let a:ctx.xml = m[9]
         continue
     endif
 
@@ -263,7 +261,6 @@ function! s:__parse_tree(ctx, top) abort
       " opening tag, continue parsing its contents
       call add(stack, node)
     endif
-    let a:ctx['xml'] = m[9]
   endwhile
 endfunction
 " @vimlint(EVL102, 0, l:content)

--- a/autoload/vital/__latest__/Web/XML.vim
+++ b/autoload/vital/__latest__/Web/XML.vim
@@ -189,13 +189,15 @@ function! s:__parse_tree(ctx, top) abort
   " this regex matches
   " 1) the remaining until the next tag begins
   "    2) maybe closing "/" of tag name
-  "    3)  tagname
+  "    3) tagname
   "    4) the attributes of the text (optional)
   "    5) maybe closing "/" (end of tag name)
   " or
   "    6) CDATA or ''
   "    7) text content of CDATA
-  " 8) the remaining text after the tag (rest)
+  " or
+  "    8) comment
+  " 9) the remaining text after the tag (rest)
   " (These numbers correspond to the indexes in matched list m)
   let tag_mx = '^\(\_.\{-}\)\%(\%(<\(/\?\)\([^!/>[:space:]]\+\)\(\%([[:space:]]*[^/>=[:space:]]\+[[:space:]]*=[[:space:]]*\%([^"'' >\t]\+\|"[^"]*"\|''[^'']*''\)\|[[:space:]]\+[^/>=[:space:]]\+[[:space:]]*\)*\)[[:space:]]*\(/\?\)>\)\|\%(<!\[\(CDATA\)\[\(.\{-}\)\]\]>\)\|\(<!--.\{-}-->\)\)\(.*\)'
 

--- a/autoload/vital/__latest__/Web/XML.vim
+++ b/autoload/vital/__latest__/Web/XML.vim
@@ -225,13 +225,13 @@ function! s:__parse_tree(ctx, top) abort
 
     " comment tag
     if m[8] != ''
-        continue
+      continue
     endif
 
     " if element is a CDATA
     if m[6] != ''
-        let content .= m[7]
-        continue
+      let content .= m[7]
+      continue
     endif
 
     let node = deepcopy(s:__template)

--- a/autoload/vital/__latest__/Web/XML.vim
+++ b/autoload/vital/__latest__/Web/XML.vim
@@ -197,14 +197,13 @@ function! s:__parse_tree(ctx, top) abort
   "    7) text content of CDATA
   " or
   "    8) comment
-  " 9) the remaining text after the tag (rest)
   " (These numbers correspond to the indexes in matched list m)
-  let tag_mx = '^\(\_.\{-}\)\%(\%(<\(/\?\)\([^!/>[:space:]]\+\)\(\%([[:space:]]*[^/>=[:space:]]\+[[:space:]]*=[[:space:]]*\%([^"'' >\t]\+\|"[^"]*"\|''[^'']*''\)\|[[:space:]]\+[^/>=[:space:]]\+[[:space:]]*\)*\)[[:space:]]*\(/\?\)>\)\|\%(<!\[\(CDATA\)\[\(.\{-}\)\]\]>\)\|\(<!--.\{-}-->\)\)\(.*\)'
+  let tag_mx = '^\(\_.\{-}\)\%(\%(<\(/\?\)\([^!/>[:space:]]\+\)\(\%([[:space:]]*[^/>=[:space:]]\+[[:space:]]*=[[:space:]]*\%([^"'' >\t]\+\|"[^"]*"\|''[^'']*''\)\|[[:space:]]\+[^/>=[:space:]]\+[[:space:]]*\)*\)[[:space:]]*\(/\?\)>\)\|\%(<!\[\(CDATA\)\[\(.\{-}\)\]\]>\)\|\(<!--.\{-}-->\)\)'
 
   while len(a:ctx['xml']) > 0
     let m = matchlist(a:ctx.xml, tag_mx)
     if empty(m) | break | endif
-    let a:ctx.xml = m[9]
+    let a:ctx.xml = a:ctx.xml[len(m[0]) :]
     let is_end_tag = m[2] == '/' && m[5] == ''
     let is_start_and_end_tag = m[2] == '' && m[5] == '/'
     let tag_name = m[3]

--- a/autoload/vital/__latest__/Web/XML.vim
+++ b/autoload/vital/__latest__/Web/XML.vim
@@ -179,7 +179,7 @@ function! s:__parse_tree(ctx, top) abort
     let matches = matchlist(match, mx)
     if len(matches)
       let encoding = matches[1]
-      if len(encoding) && len(a:ctx['encoding']) == 0
+      if encoding !=# '' && a:ctx['encoding'] ==# ''
         let a:ctx['encoding'] = encoding
         let a:ctx['xml'] = iconv(a:ctx['xml'], encoding, &encoding)
       endif
@@ -200,7 +200,7 @@ function! s:__parse_tree(ctx, top) abort
   " (These numbers correspond to the indexes in matched list m)
   let tag_mx = '^\(\_.\{-}\)\%(\%(<\(/\?\)\([^!/>[:space:]]\+\)\(\%([[:space:]]*[^/>=[:space:]]\+[[:space:]]*=[[:space:]]*\%([^"'' >\t]\+\|"[^"]*"\|''[^'']*''\)\|[[:space:]]\+[^/>=[:space:]]\+[[:space:]]*\)*\)[[:space:]]*\(/\?\)>\)\|\%(<!\[\(CDATA\)\[\(.\{-}\)\]\]>\)\|\(<!--.\{-}-->\)\)'
 
-  while len(a:ctx['xml']) > 0
+  while a:ctx.xml !=# ''
     let m = matchlist(a:ctx.xml, tag_mx)
     if empty(m) | break | endif
     let a:ctx.xml = a:ctx.xml[len(m[0]) :]
@@ -209,7 +209,7 @@ function! s:__parse_tree(ctx, top) abort
     let tag_name = m[3]
     let attrs = m[4]
 
-    if len(m[1])
+    if m[1] !=# ''
       let content .= s:decodeEntityReference(m[1])
     endif
 
@@ -237,13 +237,13 @@ function! s:__parse_tree(ctx, top) abort
     let node = deepcopy(s:__template)
     let node.name = tag_name
     let attr_mx = '\([^=[:space:]]\+\)\s*\%(=\s*''\([^'']*\)''\|=\s*"\([^"]*\)"\|=\s*\(\w\+\)\|\)'
-    while len(attrs) > 0
+    while attrs !=# ''
       let attr_match = matchlist(attrs, attr_mx)
       if len(attr_match) == 0
         break
       endif
       let name = attr_match[1]
-      let value = len(attr_match[2]) ? attr_match[2] : len(attr_match[3]) ? attr_match[3] : len(attr_match[4]) ? attr_match[4] : ""
+      let value = attr_match[2] !=# '' ? attr_match[2] : attr_match[3] !=# '' ? attr_match[3] : attr_match[4] !=# '' ? attr_match[4] : ""
       if value == ""
         let value = name
       endif


### PR DESCRIPTION
`parse()` が遅かったので、改善しました。

試しに [GitHubのとあるページ](https://github.com/vim-jp/vital.vim/blob/afa4b8d2248fd0e422ffacb4625b3bf565cf75de/autoload/vital/__latest__/Web/XML.vim) の HTML をパースしてみたところ、手元の環境で55秒かかっていたのが2.4秒ほどに短縮されました。