### PR TITLE
Vim.Compat: Add a compatible 'writefile' function which support 'a' frag

### DIFF
--- a/autoload/vital/__latest__/Vim/Compat.vim
+++ b/autoload/vital/__latest__/Vim/Compat.vim
@@ -10,6 +10,10 @@ set cpo&vim
 " e.g.)
 " echo s:has_version('7.3.629')
 " echo s:has_version('7.3')
+"
+" Note:
+" use has('patch-7.4.237') style instead if you need to check a version of Vim
+" equal and grater than 7.4.237
 function! s:has_version(version) abort
   let versions = split(a:version, '\.')
   if len(versions) == 2
@@ -37,6 +41,29 @@ elseif s:has_version('7.3.629')
 else
   function! s:shiftwidth() abort
     return &shiftwidth
+  endfunction
+endif
+
+" Patch 7.4.503
+if has('patch-7.4.503')
+  function! s:writefile(...) abort
+    return call('writefile', a:000)
+  endfunction
+else
+  function! s:writefile(list, fname, ...) abort
+    let flags = get(a:000, 0, '')
+    if flags !~# 'a'
+      return writefile(a:list, a:fname, flags)
+    endif
+    let f = tempname()
+    let r = writefile(a:list, f, substitute(flags, 'a', '', 'g'))
+    if has("win32") || has("win64")
+      silent! execute "!type ".shellescape(f) ">>".shellescape(a:fname)
+    else
+      silent! execute "!cat ".shellescape(f) ">>".shellescape(a:fname)
+    endif
+    call delete(f)
+    return r
   endfunction
 endif
 

--- a/test/Vim/Compat.vimspec
+++ b/test/Vim/Compat.vimspec
@@ -18,7 +18,7 @@ Describe Vim.Compat
     " TODO add other specs, refering Bram's Patch 7.3.694
   End
 
-  Describe .writefile({list}, {fname}[, {flags}])
+  Describe .writefile()
     It should write {list} into {fname}
       let list = ['hello', 'world']
       let fname = tempname()

--- a/test/Vim/Compat.vimspec
+++ b/test/Vim/Compat.vimspec
@@ -17,4 +17,23 @@ Describe Vim.Compat
     End
     " TODO add other specs, refering Bram's Patch 7.3.694
   End
+
+  Describe .writefile({list}, {fname}[, {flags}])
+    It should write {list} into {fname}
+      let list = ['hello', 'world']
+      let fname = tempname()
+      call Compat.writefile(list, fname)
+      Assert Equals(readfile(fname), list)
+      call delete(fname)
+    End
+
+    It should write {list} into {fname} in append mode with "a" flag
+      let list = ['hello', 'world']
+      let fname = tempname()
+      call Compat.writefile(list, fname, "a")
+      call Compat.writefile(list, fname, "a")
+      Assert Equals(readfile(fname), ['hello', 'world', 'hello', 'world'])
+      call delete(fname)
+    End
+  End
 End


### PR DESCRIPTION
途中で投げ出した https://github.com/vim-jp/vital.vim/pull/305 の一部。あったほうが何かと便利なので