### PR TITLE
Web.URI: Add encode() and decode()

### DIFF
--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -18,7 +18,7 @@ endfunction
 
 let s:NONE = []
 
-function! s:_uri_new_sandbox(args, retall, NothrowValue) abort "{{{
+function! s:_uri_new_sandbox(args, retall, NothrowValue) abort
   try
     let results = call('s:_uri_new', a:args)
     return a:retall ? results : results[0]
@@ -29,19 +29,19 @@ function! s:_uri_new_sandbox(args, retall, NothrowValue) abort "{{{
       throw substitute(v:exception, '^Vim([^()]\+):', '', '')
     endif
   endtry
-endfunction "}}}
+endfunction
 
-function! s:_is_own_exception(str) abort "{{{
+function! s:_is_own_exception(str) abort
   return a:str =~# '^uri parse error:'
-endfunction "}}}
+endfunction
 
-function! s:new(uri, ...) abort "{{{
+function! s:new(uri, ...) abort
   let NothrowValue = a:0 ? a:1 : s:NONE
   return s:_uri_new_sandbox(
   \   [a:uri], 0, NothrowValue)
-endfunction "}}}
+endfunction
 
-function! s:new_from_uri_like_string(str, ...) abort "{{{
+function! s:new_from_uri_like_string(str, ...) abort
   let str = a:str
   if str !~# s:RX_SCHEME    " no scheme.
     let str = 'http://' . str
@@ -50,29 +50,29 @@ function! s:new_from_uri_like_string(str, ...) abort "{{{
   let NothrowValue = a:0 ? a:1 : s:NONE
   return s:_uri_new_sandbox(
   \   [str], 0, NothrowValue)
-endfunction "}}}
+endfunction
 
-function! s:new_from_seq_string(uri, ...) abort "{{{
+function! s:new_from_seq_string(uri, ...) abort
   let NothrowValue = a:0 ? a:1 : s:NONE
   return s:_uri_new_sandbox(
   \   [a:uri, 1], 1, NothrowValue)
-endfunction "}}}
+endfunction
 
-function! s:is_uri(str) abort "{{{
+function! s:is_uri(str) abort
   let ERROR = []
   return s:new(a:str, ERROR) isnot ERROR
-endfunction "}}}
+endfunction
 
-function! s:like_uri(str) abort "{{{
+function! s:like_uri(str) abort
   let ERROR = []
   return s:new_from_uri_like_string(a:str, ERROR) isnot ERROR
-endfunction "}}}
+endfunction
 
 " }}}
 
 " URI Object {{{
 
-function! s:_uri_new(str, ...) abort "{{{
+function! s:_uri_new(str, ...) abort
   let ignore_rest = (a:0 ? a:1 : 0)
   let [result, rest] = s:_parse_uri(a:str, ignore_rest)
   " TODO: Support punycode
@@ -86,30 +86,30 @@ function! s:_uri_new(str, ...) abort "{{{
 
   let original_url = a:str[: len(a:str)-len(rest)-1]
   return [obj, original_url, rest]
-endfunction "}}}
+endfunction
 
-function! s:_uri_scheme(...) dict abort "{{{
+function! s:_uri_scheme(...) dict abort
   if a:0 && s:_is_scheme(a:1)
     let self.__scheme = a:1
   endif
   return self.__scheme
-endfunction "}}}
+endfunction
 
-function! s:_uri_host(...) dict abort "{{{
+function! s:_uri_host(...) dict abort
   if a:0 && s:_is_host(a:1)
     let self.__host = a:1
   endif
   return self.__host
-endfunction "}}}
+endfunction
 
-function! s:_uri_port(...) dict abort "{{{
+function! s:_uri_port(...) dict abort
   if a:0 && s:_is_port(a:1)
     let self.__port = a:1
   endif
   return self.__port
-endfunction "}}}
+endfunction
 
-function! s:_uri_path(...) dict abort "{{{
+function! s:_uri_path(...) dict abort
   if a:0
     " NOTE: self.__path must not have "/" as prefix.
     let path = substitute(a:1, '^/\+', '', '')
@@ -118,9 +118,9 @@ function! s:_uri_path(...) dict abort "{{{
     endif
   endif
   return "/" . self.__path
-endfunction "}}}
+endfunction
 
-function! s:_uri_opaque(...) dict abort "{{{
+function! s:_uri_opaque(...) dict abort
   if a:0
     " TODO
     throw 'vital: Web.URI: uri.opaque(value) does not support yet.'
@@ -129,9 +129,9 @@ function! s:_uri_opaque(...) dict abort "{{{
   \           self.__host,
   \           (self.__port !=# '' ? ':' . self.__port : ''),
   \           self.__path)
-endfunction "}}}
+endfunction
 
-function! s:_uri_fragment(...) dict abort "{{{
+function! s:_uri_fragment(...) dict abort
   if a:0
     " NOTE: self.__fragment must not have "#" as prefix.
     let fragment = substitute(a:1, '^#', '', '')
@@ -140,9 +140,9 @@ function! s:_uri_fragment(...) dict abort "{{{
     endif
   endif
   return self.__fragment
-endfunction "}}}
+endfunction
 
-function! s:_uri_query(...) dict abort "{{{
+function! s:_uri_query(...) dict abort
   if a:0
     " NOTE: self.__query must not have "?" as prefix.
     let query = substitute(a:1, '^?', '', '')
@@ -151,9 +151,9 @@ function! s:_uri_query(...) dict abort "{{{
     endif
   endif
   return self.__query
-endfunction "}}}
+endfunction
 
-function! s:_uri_to_iri() dict abort "{{{
+function! s:_uri_to_iri() dict abort
   " Same as uri.to_string(), but do unescape for self.__path.
   return printf(
   \   '%s://%s%s/%s%s%s',
@@ -164,9 +164,9 @@ function! s:_uri_to_iri() dict abort "{{{
   \   (self.__query != '' ? '?' . self.__query : ''),
   \   (self.__fragment != '' ? '#' . self.__fragment : ''),
   \)
-endfunction "}}}
+endfunction
 
-function! s:_uri_to_string() dict abort "{{{
+function! s:_uri_to_string() dict abort
   return printf(
   \   '%s://%s%s/%s%s%s',
   \   self.__scheme,
@@ -176,14 +176,14 @@ function! s:_uri_to_string() dict abort "{{{
   \   (self.__query != '' ? '?' . self.__query : ''),
   \   (self.__fragment != '' ? '#' . self.__fragment : ''),
   \)
-endfunction "}}}
+endfunction
 
 
 
-function! s:_local_func(name) abort "{{{
+function! s:_local_func(name) abort
   let sid = matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__local_func$')
   return function('<SNR>' . sid . '_' . a:name)
-endfunction "}}}
+endfunction
 
 let s:uri = {
 \ '__scheme': '',
@@ -207,7 +207,7 @@ let s:uri = {
 
 " Parsing Functions {{{
 
-function! s:_parse_uri(str, ignore_rest) abort "{{{
+function! s:_parse_uri(str, ignore_rest) abort
   let rest = a:str
 
   " Ignore leading/trailing whitespaces.
@@ -267,8 +267,8 @@ function! s:_parse_uri(str, ignore_rest) abort "{{{
   \ 'query': query,
   \ 'fragment': fragment,
   \}, rest]
-endfunction "}}}
-function! s:_eat_em(str, pat) abort "{{{
+endfunction
+function! s:_eat_em(str, pat) abort
   let pat = a:pat.'\C'
   let m = matchlist(a:str, pat)
   if empty(m)
@@ -278,7 +278,7 @@ function! s:_eat_em(str, pat) abort "{{{
   let [match, want] = m[0:1]
   let rest = strpart(a:str, strlen(match))
   return [want, rest]
-endfunction "}}}
+endfunction
 
 
 " Patterns for URI syntax {{{

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -68,6 +68,36 @@ function! s:like_uri(str) abort
   return s:new_from_uri_like_string(a:str, ERROR) isnot ERROR
 endfunction
 
+function! s:encode(str, ...) abort
+  let encoding = a:0 ? a:1 : 'utf-8'
+  if encoding ==# ''
+    let str = a:str
+  else
+    let str = iconv(a:str, &encoding, encoding)
+  endif
+
+  let result = ''
+  for i in range(len(str))
+    if str[i] =~# '^[a-zA-Z0-9_.~-]$'
+      let result .= str[i]
+    else
+      let result .= printf('%%%02X', char2nr(str[i]))
+    endif
+  endfor
+  return result
+endfunction
+
+function! s:decode(str, ...) abort
+  let result = substitute(a:str, '%\(\x\x\)',
+  \   '\=printf("%c", str2nr(submatch(1), 16))', 'g')
+
+  let encoding = a:0 ? a:1 : 'utf-8'
+  if encoding ==# ''
+    return result
+  endif
+  return iconv(result, encoding, &encoding)
+endfunction
+
 " }}}
 
 " URI Object {{{

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -51,6 +51,17 @@ like_uri({str})				*Vital.Web.URI.like_uri()*
 	(This uses |Vital.Web.URI.new_from_uri_like_string()|
 	 instead of |Vital.Web.URI.new()|)
 
+encode({str} [, {char-enc}])		*Vital.Web.URI.encode()*
+	Encodes {str} to Percent-encoding string.
+	Converts {str} to {char-enc}(or "utf-8" when omitted) before encode.
+	When {char-enc} is an empty string, {str} is not converted.
+
+decode({str} [, {char-enc}])		*Vital.Web.URI.decode()*
+	Decodes {str} that is encoded by Percent-encoding.
+	Converts result from {char-enc}(or "utf-8" when omitted) to 'encoding'
+	after decode.
+	When {char-enc} is an empty string, result is not converted.
+
 ------------------------------------------------------------------------------
 URI OBJECT				*Vital.Web.URI-object*
 

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -1,3 +1,5 @@
+scriptencoding utf-8
+
 Describe Web.URI
   Before all
     let URI = vital#of('vital').import('Web.URI')
@@ -75,6 +77,125 @@ Describe Web.URI
     It checks invalid URI
       Assert False(URI.is_uri('foo'))
       Assert False(URI.is_uri('/bar'))
+    End
+  End
+
+  Describe .encode()
+    It encodes string to Percent-encoding string
+      Assert Equals(URI.encode('abc12390'), 'abc12390')
+      Assert Equals(URI.encode("abc\x01\x0a\x0d AB-"), 'abc%01%0A%0D%20AB-')
+      Assert Equals(URI.encode("\xA4\xC1\xA4\xE3"), '%A4%C1%A4%E3')
+      Assert Equals(URI.encode("\xA4\xC1\xA4\xE5"), '%A4%C1%A4%E5')
+      Assert Equals(URI.encode("\xA4\xC1\xA4\xE7"), '%A4%C1%A4%E7')
+    End
+
+    It encodes the reserved characters in RFC3986
+      Assert Equals(URI.encode(':/?#[]@'), '%3A%2F%3F%23%5B%5D%40')
+      Assert Equals(URI.encode("!$&'()*+,;="), '%21%24%26%27%28%29%2A%2B%2C%3B%3D')
+      Assert Equals(URI.encode('%'), '%25')
+    End
+
+    It does not change the unreserved characters in RFC3986
+      for s in ['1234567890',
+      \  'abcdefghijklmnopqrstuvwxyz',
+      \  'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      \  '._-~',
+      \  'abc1.2345_ABCD-EZY']
+        Assert Equals(URI.encode(s), s)
+      endfor
+    End
+
+    Context with {char-enc}
+      Context is omitted
+        It is treated as "utf-8"
+          Assert Equals(URI.encode('あいうえお'), '%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A')
+        End
+      End
+
+      Context is cp932
+        It converts {str} to cp932
+          Assert Equals(URI.encode('あいうえお', 'cp932'), '%82%A0%82%A2%82%A4%82%A6%82%A8')
+        End
+      End
+
+      Context is empty
+        Before
+          let cp932 = iconv('あいうえお', 'utf-8', 'cp932')
+          let encoding = &encoding
+          set encoding=cp932
+        End
+        After
+          let &encoding = encoding
+        End
+
+        It never converts character encoding
+          Assert Equals(URI.encode(cp932), '%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A')
+          Assert Equals(URI.encode(cp932, ''), '%82%A0%82%A2%82%A4%82%A6%82%A8')
+        End
+      End
+    End
+  End
+
+  Describe .decode()
+    It decodes string that is encoded by Percent-encoding
+      Assert Equals(URI.decode('1234567890'), '1234567890')
+      Assert Equals(URI.decode('abc12390'), 'abc12390')
+      Assert Equals(URI.decode('%A4%C1%A4%E3'), "\xA4\xC1\xA4\xE3")
+      Assert Equals(URI.decode('%A4%C1%A4%E5'), "\xA4\xC1\xA4\xE5")
+      Assert Equals(URI.decode('%A4%C1%A4%E7'), "\xA4\xC1\xA4\xE7")
+    End
+
+    It does not change the unreserved characters
+      for s in ['1234567890',
+      \  'abcdefghijklmnopqrstuvwxyz',
+      \  'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      \  'abc12345ABCDEZY',
+      \  '._-~',
+      \  'abc1.2345_ABCD-EZY']
+        Assert Equals(URI.decode(s), s)
+      endfor
+    End
+
+    It encodes and decodes string
+      for s in ['1234567890',
+      \  'abcdefghijklmnopqrstuvwxyz',
+      \  'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+      \  'abc12345ABCDEZY',
+      \  '%123ABC!"#$%&''()~=-~^|\\[]@:;+<>/\',
+      \  'あいうえお',
+      \  'ちゃちゅちょ']
+        Assert Equals(URI.decode(URI.encode(s)), s)
+      endfor
+    End
+
+    Context with {char-enc}
+      Context is omitted
+        It is treated as "utf-8"
+          Assert Equals(URI.decode('%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A'), 'あいうえお')
+        End
+      End
+
+      Context is cp932
+        It converts {str} to cp932
+          Assert Equals(URI.decode('%82%A0%82%A2%82%A4%82%A6%82%A8', 'cp932'), 'あいうえお')
+        End
+      End
+
+      Context is empty
+        Before
+          let cp932 = iconv('あいうえお', 'utf-8', 'cp932')
+          let encoding = &encoding
+          set encoding=cp932
+        End
+        After
+          let &encoding = encoding
+        End
+
+        It never converts character encoding
+          Assert Equals(URI.decode('%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A'), cp932)
+          Assert Equals(URI.decode('%82%A0%82%A2%82%A4%82%A6%82%A8', ''), cp932)
+        End
+      End
     End
   End
 End


### PR DESCRIPTION
Web.URI に[パーセントエンコーディング](https://en.wikipedia.org/wiki/Percent-encoding)を行う関数を追加しました。
Web.HTTP にある `encodeURI()` と `decodeURI()` に近いものです。(ただしあちらは `application/x-www-form-urlencoded` なので若干違う)
Web.HTTP 側のは、最終的には消すなり別の機能に特化するなりして住み分けたいなと思ってます(しかし詳細はあまり考えてない)。

関連: #108 (無変換は空文字列としました)