### PR TITLE
DateTime: Fix 'strftime()' to follow timezone of the DateTime object

### DIFF
--- a/autoload/vital/__latest__/DateTime.vim
+++ b/autoload/vital/__latest__/DateTime.vim
@@ -46,6 +46,7 @@ function! s:_vital_loaded(V) abort
   \   '_days': 0,
   \   '_seconds': 0,
   \ })
+  let s:tz_default_offset = s:timezone().offset()
 endfunction
 
 function! s:_vital_depends() abort
@@ -451,6 +452,21 @@ function! s:DateTime.format(format, ...) abort
     unlet f
   endfor
   return result
+endfunction
+" @vimlint(EVL102, 0, l:locale)
+function! s:DateTime.fastformat(format, ...) abort
+  let tz = self.timezone()
+  let ts = self.unix_time() + tz.offset() - s:tz_default_offset
+  let locale = get(a:000, 0, '')
+  let format = a:format =~ '%z'
+        \ ? substitute(a:format, '%z', tz.offset_string(), 'g')
+        \ : a:format
+  if empty(locale)
+    return strftime(format, ts)
+  else
+    let expr = printf('strftime(%s, %d)', string(format), ts)
+    return s:_with_locale(expr, locale)
+  endif
 endfunction
 " @vimlint(EVL102, 0, l:locale)
 function! s:DateTime.strftime(format, ...) abort

--- a/autoload/vital/__latest__/DateTime.vim
+++ b/autoload/vital/__latest__/DateTime.vim
@@ -458,7 +458,7 @@ function! s:DateTime.strftime(format, ...) abort
   let tz = self.timezone()
   let ts = self.unix_time() + tz.offset() - s:tz_default_offset
   let locale = get(a:000, 0, '')
-  let format = a:format =~ '%z'
+  let format = a:format =~? '%z'
         \ ? substitute(a:format, '%z', tz.offset_string(), 'g')
         \ : a:format
   if empty(locale)

--- a/autoload/vital/__latest__/DateTime.vim
+++ b/autoload/vital/__latest__/DateTime.vim
@@ -454,7 +454,7 @@ function! s:DateTime.format(format, ...) abort
   return result
 endfunction
 " @vimlint(EVL102, 0, l:locale)
-function! s:DateTime.fastformat(format, ...) abort
+function! s:DateTime.strftime(format, ...) abort
   let tz = self.timezone()
   let ts = self.unix_time() + tz.offset() - s:tz_default_offset
   let locale = get(a:000, 0, '')
@@ -467,11 +467,6 @@ function! s:DateTime.fastformat(format, ...) abort
     let expr = printf('strftime(%s, %d)', string(format), ts)
     return s:_with_locale(expr, locale)
   endif
-endfunction
-" @vimlint(EVL102, 0, l:locale)
-function! s:DateTime.strftime(format, ...) abort
-  let expr = printf('strftime(%s, %d)', string(a:format), self.unix_time())
-  return s:_with_locale(expr, a:0 ? a:1 : '')
 endfunction
 function! s:DateTime.to_string() abort
   return self.format('%c')

--- a/doc/vital-date_time.txt
+++ b/doc/vital-date_time.txt
@@ -191,6 +191,16 @@ DateTime.format({format} [, {locale}])
 	Returns the formatted string of this DateTime.
 	See |Vital.DateTime-format| about {format}.
 
+				*Vital.DateTime-DateTime.fastformat()*
+DateTime.fastformat({format} [, {locale}])
+	A faster version of |Vital.DateTime-DateTime.format()| which use
+	|strftime| internally. It substitute '%z' in {format} into the
+	value returned from |Vital.DateTime-TimeZone.offset_string()|.
+	Other accepted {format} depends on your system so it is not
+	portable.
+	See https://gist.github.com/lambdalisue/e73bd722ca8840e82bd8
+	for benchmarking.
+
 				*Vital.DateTime-DateTime.strftime()*
 DateTime.strftime({format} [, {locate}])
 	Same as "strftime({format}, dt.unix_time())".

--- a/doc/vital-date_time.txt
+++ b/doc/vital-date_time.txt
@@ -191,20 +191,16 @@ DateTime.format({format} [, {locale}])
 	Returns the formatted string of this DateTime.
 	See |Vital.DateTime-format| about {format}.
 
-				*Vital.DateTime-DateTime.fastformat()*
-DateTime.fastformat({format} [, {locale}])
-	A faster version of |Vital.DateTime-DateTime.format()| which use
-	|strftime| internally. It substitute '%z' in {format} into the
-	value returned from |Vital.DateTime-TimeZone.offset_string()|.
+				*Vital.DateTime-DateTime.strftime()*
+DateTime.strftime({format} [, {locale}])
+	An alternative version of |Vital.DateTime-DateTime.format()| which
+	use |strftime| internally.
+	It substitute '%z' in {format} into the value returned from
+	|Vital.DateTime-TimeZone.offset_string()|.
 	Other accepted {format} depends on your system so it is not
 	portable.
 	See https://gist.github.com/lambdalisue/e73bd722ca8840e82bd8
 	for benchmarking.
-
-				*Vital.DateTime-DateTime.strftime()*
-DateTime.strftime({format} [, {locate}])
-	Same as "strftime({format}, dt.unix_time())".
-	Note that timezone is always converted to current timezone.
 
 DateTime.to_string()		*Vital.DateTime-DateTime.to_string()*
 	Same as "format('%c')".

--- a/doc/vital-date_time.txt
+++ b/doc/vital-date_time.txt
@@ -194,14 +194,14 @@ DateTime.format({format} [, {locale}])
 				*Vital.DateTime-DateTime.strftime()*
 DateTime.strftime({format} [, {locale}])
 	An alternative version of |Vital.DateTime-DateTime.format()| which
-	use |strftime| internally. While |Vital.DateTime-DateTime.format()|
-	parse {format}, it is really slow compared to using |strftime|.
+	use |strftime()| internally. While |Vital.DateTime-DateTime.format()|
+	parse {format}, it is really slow compared to using |strftime()|.
 	However |Vital.DateTime-DateTime.format()| is required while accepted
-	{format} and a return value of |strftime| depends on the system.
+	{format} and a return value of |strftime()| depends on the system.
 	That's why this function exists for user who need performance but the
 	accuracy.
-	It substitute '%z' in {format} into the value returned from
-	|Vital.DateTime-TimeZone.offset_string()| while |strftime| always
+	It substitutes '%z' in {format} into the value returned from
+	|Vital.DateTime-TimeZone.offset_string()| while |strftime()| always
 	return the system default timezone offset string.
 	See https://gist.github.com/lambdalisue/e73bd722ca8840e82bd8
 	for benchmarking.

--- a/doc/vital-date_time.txt
+++ b/doc/vital-date_time.txt
@@ -194,11 +194,15 @@ DateTime.format({format} [, {locale}])
 				*Vital.DateTime-DateTime.strftime()*
 DateTime.strftime({format} [, {locale}])
 	An alternative version of |Vital.DateTime-DateTime.format()| which
-	use |strftime| internally.
+	use |strftime| internally. While |Vital.DateTime-DateTime.format()|
+	parse {format}, it is really slow compared to using |strftime|.
+	However |Vital.DateTime-DateTime.format()| is required while accepted
+	{format} and a return value of |strftime| depends on the system.
+	That's why this function exists for user who need performance but the
+	accuracy.
 	It substitute '%z' in {format} into the value returned from
-	|Vital.DateTime-TimeZone.offset_string()|.
-	Other accepted {format} depends on your system so it is not
-	portable.
+	|Vital.DateTime-TimeZone.offset_string()| while |strftime| always
+	return the system default timezone offset string.
 	See https://gist.github.com/lambdalisue/e73bd722ca8840e82bd8
 	for benchmarking.
 

--- a/doc/vital-process_manager.txt
+++ b/doc/vital-process_manager.txt
@@ -17,6 +17,9 @@ CONFIG				|Vital.ProcessManager-config|
 ==============================================================================
 INTRODUCTION			*Vital.ProcessManager-introduction*
 
+Note this module is going to bedeprecated. Use |Vital.ConcurrentProcess|
+instead.
+
 *Vital.ProcessManager* is a Vim's process manager library, powered by
 |vimproc|.  This manager stores external processes ran by this library, and
 provide higher layer synchronous non-blocking read/write interface.

--- a/test/DateTime.vimspec
+++ b/test/DateTime.vimspec
@@ -677,17 +677,13 @@ Describe DateTime
         let dt = DT.from_date(2012, 1, 2, 3, 4, 5, tz)
       End
 
-      Context symbol "%z" with a timezone
-        It is same as "format('%z')"
-          Assert Equals(dt.strftime('%z'), dt.format('%z'))
-        End
+      It is same as "format('%z')"
+        Assert Equals(dt.strftime('%z'), dt.format('%z'))
       End
 
-      Context with a timezone
-        It is same as "format('%Y-%m-%d %H:%M:%S')"
-          let ft = '%Y-%m-%d %H:%M:%S'
-          Assert Equals(dt.strftime(ft), dt.format(ft))
-        End
+      It is same as "format('%Y-%m-%d %H:%M:%S')"
+        let ft = '%Y-%m-%d %H:%M:%S'
+        Assert Equals(dt.strftime(ft), dt.format(ft))
       End
     End
 

--- a/test/DateTime.vimspec
+++ b/test/DateTime.vimspec
@@ -670,6 +670,36 @@ Describe DateTime
 
     End
 
+    Describe .fastformat()
+      Before
+        " Use non default timezone
+        let tz = DT.timezone().offset_string() ==# '+0300' ? '+0500' : '+0300'
+        let dt = DT.from_date(2012, 1, 2, 3, 4, 5, tz)
+      End
+
+      Context symbol "%z" with a timezone
+        It is same as "format('%z')"
+          Assert Equals(dt.fastformat('%z'), dt.format('%z'))
+        End
+
+        It is differrent from "strftime('%z')"
+          Assert NotEquals(dt.fastformat('%z'), dt.strftime('%z'))
+        End
+      End
+
+      Context with a timezone
+        It is same as "format('%Y-%m-%d %H:%M:%S')"
+          let ft = '%Y-%m-%d %H:%M:%S'
+          Assert Equals(dt.fastformat(ft), dt.format(ft))
+        End
+
+        It is differrent from "strftime('%z')"
+          let ft = '%Y-%m-%d %H:%M:%S'
+          Assert NotEquals(dt.fastformat(ft), dt.strftime(ft))
+        End
+      End
+    End
+
     Describe .strftime()
       It is same as "strftime({format}, dt.unix_time())"
         Assert Equals(dt.strftime('%c'), strftime('%c', dt.unix_time()))

--- a/test/DateTime.vimspec
+++ b/test/DateTime.vimspec
@@ -670,7 +670,7 @@ Describe DateTime
 
     End
 
-    Describe .fastformat()
+    Describe .strftime()
       Before
         " Use non default timezone
         let tz = DT.timezone().offset_string() ==# '+0300' ? '+0500' : '+0300'
@@ -679,30 +679,15 @@ Describe DateTime
 
       Context symbol "%z" with a timezone
         It is same as "format('%z')"
-          Assert Equals(dt.fastformat('%z'), dt.format('%z'))
-        End
-
-        It is differrent from "strftime('%z')"
-          Assert NotEquals(dt.fastformat('%z'), dt.strftime('%z'))
+          Assert Equals(dt.strftime('%z'), dt.format('%z'))
         End
       End
 
       Context with a timezone
         It is same as "format('%Y-%m-%d %H:%M:%S')"
           let ft = '%Y-%m-%d %H:%M:%S'
-          Assert Equals(dt.fastformat(ft), dt.format(ft))
+          Assert Equals(dt.strftime(ft), dt.format(ft))
         End
-
-        It is differrent from "strftime('%z')"
-          let ft = '%Y-%m-%d %H:%M:%S'
-          Assert NotEquals(dt.fastformat(ft), dt.strftime(ft))
-        End
-      End
-    End
-
-    Describe .strftime()
-      It is same as "strftime({format}, dt.unix_time())"
-        Assert Equals(dt.strftime('%c'), strftime('%c', dt.unix_time()))
       End
     End
 


### PR DESCRIPTION
'%c' などハンドルできないものが多かったので別メソッドとして追加しました。
ちなみにベンチマークは https://gist.github.com/lambdalisue/e73bd722ca8840e82bd8

追記

`stftime` にマージしました。