### PR TITLE
System.Cache: Add a hook method 'on_changed'

### DIFF
--- a/autoload/vital/__latest__/System/Cache/Base.vim
+++ b/autoload/vital/__latest__/System/Cache/Base.vim
@@ -36,6 +36,9 @@ endfunction
 function! s:cache.clear() abort
   throw "vital: System.Cache.Base: clear() is not implemented"
 endfunction
+function! s:cache.on_changed() abort
+  " A user defined hook function
+endfunction
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/vital/__latest__/System/Cache/File.vim
+++ b/autoload/vital/__latest__/System/Cache/File.vim
@@ -77,15 +77,18 @@ function! s:cache.set(name, value) abort
   let filename = self.get_cache_filename(a:name)
   let value = [string(a:value)]
   call writefile(value, filename)
+  call self.on_changed()
 endfunction
 function! s:cache.remove(name) abort
   let filename = self.get_cache_filename(a:name)
   if filereadable(filename)
     call delete(filename)
+    call self.on_changed()
   endif
 endfunction
 function! s:cache.clear() abort
   call s:File.rmdir(self.cache_dir, 'r')
+  call self.on_changed()
 endfunction
 function! s:cache.keys() abort
   let keys = split(glob(s:Path.join(self.cache_dir, '*'), 0), '\n')

--- a/autoload/vital/__latest__/System/Cache/Memory.vim
+++ b/autoload/vital/__latest__/System/Cache/Memory.vim
@@ -35,11 +35,13 @@ endfunction
 function! s:cache.set(name, value) abort
   let cache_key = self.cache_key(a:name)
   let self._cached[cache_key] = a:value
+  call self.on_changed()
 endfunction
 function! s:cache.remove(name) abort
   let cache_key = self.cache_key(a:name)
   if has_key(self._cached, cache_key)
     unlet self._cached[cache_key]
+    call self.on_changed()
   endif
 endfunction
 function! s:cache.keys() abort
@@ -47,6 +49,7 @@ function! s:cache.keys() abort
 endfunction
 function! s:cache.clear() abort
   let self._cached = {}
+  call self.on_changed()
 endfunction
 
 let &cpo = s:save_cpo

--- a/doc/vital-system-cache-base.txt
+++ b/doc/vital-system-cache-base.txt
@@ -226,5 +226,12 @@ clear()				*Vital.System.Cache.Base.clear()*
 
 	VARIANTS MUST OVERRIDE THIS METHOD
 
+on_changed()			*Vital.System.Cache.Base.on_changed()*
+
+	A user defined hook method. This method is called when the content of
+	the cache is changed, namely after |Vital.System.Cache.Base.set()|,
+	|Vital.System.Cache.Base.remove()|, or |Vital.System.Cache.Base.clear()|
+	methods.
+
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache-dummy.txt
+++ b/doc/vital-system-cache-dummy.txt
@@ -102,5 +102,10 @@ clear()				*Vital.System.Cache.Dummy.clear()*
 
 	Do nothing.
 
+on_changed()			*Vital.System.Cache.Dummy.on_changed()*
+
+	Never called.
+
+
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache-file.txt
+++ b/doc/vital-system-cache-file.txt
@@ -122,6 +122,12 @@ clear()				*Vital.System.Cache.File.clear()*
 	It remove all files in the directory. Make sure the correct cache
 	directory is specified in the instance.
 
+on_changed()			*Vital.System.Cache.File.on_changed()*
+
+	A user defined hook method. This method is called when the content of
+	the cache is changed, namely after |Vital.System.Cache.File.set()|,
+	|Vital.System.Cache.File.remove()|, or |Vital.System.Cache.File.clear()|
+	methods.
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache-memory.txt
+++ b/doc/vital-system-cache-memory.txt
@@ -120,6 +120,13 @@ clear()				*Vital.System.Cache.Memory.clear()*
 
 	Clear a cache dictionary.
 
+on_changed()			*Vital.System.Cache.Memory.on_changed()*
+
+	A user defined hook method. This method is called when the content of
+	the cache is changed, namely after |Vital.System.Cache.Memory.set()|,
+	|Vital.System.Cache.Memory.remove()|, or
+	|Vital.System.Cache.Memory.clear()| methods.
+
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl


### PR DESCRIPTION
`System.Cache.File` に `System.Cache.Memory` の内容 (`_cached`) を保持するなどの融合型を作りたかったのですが、`System.Cache.Memory.set()` などが呼び出された場合に自動的に `System.Cache.File.set()` も呼び出したかったので Hook を追加しました