### PR TITLE
Add a single file based cache module

### DIFF
--- a/autoload/vital/__latest__/System/Cache.vim
+++ b/autoload/vital/__latest__/System/Cache.vim
@@ -5,9 +5,10 @@ let s:registry = {}
 function! s:_vital_loaded(V) abort
   let s:V = a:V
   let s:P = a:V.import('Prelude')
-  call s:register('dummy',  'System.Cache.Dummy')
-  call s:register('memory', 'System.Cache.Memory')
-  call s:register('file',   'System.Cache.File')
+  call s:register('dummy',      'System.Cache.Dummy')
+  call s:register('memory',     'System.Cache.Memory')
+  call s:register('file',       'System.Cache.File')
+  call s:register('singlefile', 'System.Cache.SingleFile')
 endfunction
 function! s:_vital_depends() abort
   return [
@@ -15,6 +16,7 @@ function! s:_vital_depends() abort
         \ 'System.Cache.Dummy',
         \ 'System.Cache.Memory',
         \ 'System.Cache.File',
+        \ 'System.Cache.SingleFile',
         \]
 endfunction
 

--- a/autoload/vital/__latest__/System/Cache/SingleFile.vim
+++ b/autoload/vital/__latest__/System/Cache/SingleFile.vim
@@ -16,6 +16,7 @@ let s:cache = {
 function! s:new(...) abort
   let options = extend({
         \ 'cache_file': '',
+        \ 'autodump': 1,
         \}, get(a:000, 0, {})
         \)
   if empty(options.cache_file)
@@ -34,7 +35,9 @@ function! s:new(...) abort
   let cache._memory = s:Memory.new()
   let cache._memory.__parent__ = cache
   function! cache._memory.on_changed() abort
-    call self.__parent__.dump()
+    if self.__parent__.autodump
+      call self.__parent__.dump()
+    endif
   endfunction
   " Load cache
   call cache.load()

--- a/autoload/vital/__latest__/System/Cache/SingleFile.vim
+++ b/autoload/vital/__latest__/System/Cache/SingleFile.vim
@@ -1,0 +1,84 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! s:_vital_loaded(V) abort
+  let s:Base = a:V.import('System.Cache.Base')
+  let s:File = a:V.import('System.Cache.File')
+  let s:Memory = a:V.import('System.Cache.Memory')
+endfunction
+function! s:_vital_depends() abort
+  return ['System.Cache.Base', 'System.Cache.File', 'System.Cache.Memory']
+endfunction
+
+let s:cache = {
+      \ '__name__': 'singlefile',
+      \}
+function! s:new(...) abort
+  let options = extend({
+        \ 'cache_file': '',
+        \}, get(a:000, 0, {})
+        \)
+  if empty(options.cache_file)
+    throw 'vital: System.Cache.SingleFile: "cache_file" option is empty.'
+  endif
+  " create a cache directory if it does not exist
+  let cache_dir = fnamemodify(options.cache_file, ':p:h')
+  if !isdirectory(cache_dir)
+    call mkdir(cache_dir, 'p')
+  endif
+  let cache = extend(
+        \ call(s:Base.new, a:000, s:Base),
+        \ extend(options, deepcopy(s:cache))
+        \)
+  " Add internal cache system
+  let cache._memory = s:Memory.new()
+  let cache._memory.__parent__ = cache
+  function! cache._memory.on_changed() abort
+    call self.__parent__.dump()
+  endfunction
+  " Load cache
+  call cache.load()
+  return cache
+endfunction
+
+function! s:cache.load() abort
+  if filereadable(self.cache_file)
+    let obj = s:File.load(self.cache_file, {})
+    if type(obj) == type({})
+      let self._memory._cached = obj
+      call self.on_changed()
+    endif
+  endif
+endfunction
+function! s:cache.dump() abort
+  call s:File.dump(self.cache_file, self._memory._cached)
+endfunction
+
+function! s:cache.has(name) abort
+  return self._memory.has(a:name)
+endfunction
+function! s:cache.get(name, ...) abort
+  let default = get(a:000, 0, '')
+  return self._memory.get(a:name, default)
+endfunction
+function! s:cache.set(name, value) abort
+  call self._memory.set(a:name, a:value)
+  call self.on_changed()
+endfunction
+function! s:cache.remove(name) abort
+  if self._memory.has(a:name)
+    call self._memory.remove(a:name)
+    call self.on_changed()
+  endif
+endfunction
+function! s:cache.keys() abort
+  return self._memory.keys()
+endfunction
+function! s:cache.clear() abort
+  call self._memory.clear()
+  call self.on_changed()
+endfunction
+
+let &cpo = s:save_cpo
+unlet! s:save_cpo
+" vim:set et ts=2 sts=2 sw=2 tw=0 fdm=marker:

--- a/doc/vital-system-cache-base.txt
+++ b/doc/vital-system-cache-base.txt
@@ -19,9 +19,10 @@ INTRODUCTIONS				*Vital.System.Cache.Base-intro*
 *Vital.System.Cache.Base* is an abstract class of unified cache system.
 The following variants are currently available.
 
-- |Vital.System.Cache.Dummy|  : A dummy cache system
-- |Vital.System.Cache.Memory| : A dictionary instance based cache system
-- |Vital.System.Cache.File|   : A file based cache system
+- |Vital.System.Cache.Dummy|      : A dummy cache system
+- |Vital.System.Cache.Memory|     : A dictionary instance based cache system
+- |Vital.System.Cache.File|       : A file based cache system
+- |Vital.System.Cache.SingleFile| : A single file based cache system
 
 This document is for creating your own variants. See |Vital.System.Cache| for
 the cache system usage.
@@ -119,7 +120,7 @@ new([{options}])			*Vital.System.Cache.Base.new()*
 -------------------------------------------------------------------------------
 METHODS					*Vital.System.Cache.Base-methods*
 
-cache_key({obj})		*Vital.System.Cache.Base.cache_key()*
+cache_key({obj})	*Vital.System.Cache.Base-instance.cache_key()*
 
 	Return a |String| which will be used as a cache key.
 	Variants can override this method to create a cache key from {obj}.
@@ -127,7 +128,7 @@ cache_key({obj})		*Vital.System.Cache.Base.cache_key()*
 	return a string representation (See |string()| for details) of the
 	{obj}.
 
-has({name})			*Vital.System.Cache.Base.has()*
+has({name})		*Vital.System.Cache.Base-instance.has()*
 
 	Whether the cache instance has a {name} cache or not.
 	
@@ -135,7 +136,7 @@ has({name})			*Vital.System.Cache.Base.has()*
 
 	{name} (required)
 	A name of the cache. An actual cache key SHOULD be created via
-	|Vital.System.Cache.Base.cache_key()| method thus {name} is not
+	|Vital.System.Cache.Base-instance.cache_key()| method thus {name} is not
 	required to be |String|.
 
 	See the following example:
@@ -145,7 +146,8 @@ has({name})			*Vital.System.Cache.Base.has()*
 	    return has_key(self._cached, cache_key)
 	endfunction
 <
-get({name}, [, {default}])	*Vital.System.Cache.Base.get()*
+			*Vital.System.Cache.Base-instance.get()* 
+get({name}[, {default}])
 
 	Return a {name} cache. It no {name} cache is found, it return
 	{default} or an empty |String|.
@@ -154,7 +156,7 @@ get({name}, [, {default}])	*Vital.System.Cache.Base.get()*
 
 	{name} (required)
 	A name of the cache. An actual cache key SHOULD be created via
-	|Vital.System.Cache.Base.cache_key()| method thus {name} is not
+	|Vital.System.Cache.Base-instance.cache_key()| method thus {name} is not
 	required to be |String|.
 
 	{default} (optional)
@@ -172,7 +174,7 @@ get({name}, [, {default}])	*Vital.System.Cache.Base.get()*
 	    return default
 	endfunction
 <
-set({name}, {value})		*Vital.System.Cache.Base.set()*
+set({name}, {value})	*Vital.System.Cache.Base-instance.set()*
 
 	Save {value} as a {name} cache.
 
@@ -180,7 +182,7 @@ set({name}, {value})		*Vital.System.Cache.Base.set()*
 
 	{name} (required)
 	A name of the cache. An actual cache key SHOULD be created via
-	|Vital.System.Cache.Base.cache_key()| method thus {name} is not
+	|Vital.System.Cache.Base-instance.cache_key()| method thus {name} is not
 	required to be |String|.
 
 	{value} (required)
@@ -193,13 +195,13 @@ set({name}, {value})		*Vital.System.Cache.Base.set()*
 	  let self._cached[cache_key] = a:value
 	endfunction
 <
-keys()				*Vital.System.Cache.Base.keys()*
+keys()			*Vital.System.Cache.Base-instance.keys()*
 
 	Return a list of cache keys
 
 	VARIANTS MUST OVERRIDE THIS METHOD
 
-remove({name})			*Vital.System.Cache.Base.remove()*
+remove({name})		*Vital.System.Cache.Base-instance.remove()*
 
 	Remove a {name} cache. If no {name} cache is found, it should do
 	nothing.
@@ -208,7 +210,7 @@ remove({name})			*Vital.System.Cache.Base.remove()*
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.Base.cache_key()| method thus {name} is not
+	|Vital.System.Cache.Base-instance.cache_key()| method thus {name} is not
 	required to be |String|.
 
 	See the following example:
@@ -220,18 +222,19 @@ remove({name})			*Vital.System.Cache.Base.remove()*
 	  endif
 	endfunction
 <
-clear()				*Vital.System.Cache.Base.clear()*
+clear()			*Vital.System.Cache.Base-instance.clear()*
 
 	Clear all caches
 
 	VARIANTS MUST OVERRIDE THIS METHOD
 
-on_changed()			*Vital.System.Cache.Base.on_changed()*
+on_changed()		*Vital.System.Cache.Base-instance.on_changed()*
 
 	A user defined hook method. This method is called when the content of
-	the cache is changed, namely after |Vital.System.Cache.Base.set()|,
-	|Vital.System.Cache.Base.remove()|, or |Vital.System.Cache.Base.clear()|
-	methods.
+	the cache is changed, namely after the follwing methods:
+	- |Vital.System.Cache.Base-instance.set()|
+	- |Vital.System.Cache.Base-instance.remove()|
+	- |Vital.System.Cache.Base-instance.clear()|
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache-dummy.txt
+++ b/doc/vital-system-cache-dummy.txt
@@ -55,18 +55,19 @@ new([{options}])			*Vital.System.Cache.Dummy.new()*
 ==============================================================================
 METHODS					*Vital.System.Cache.Dummy-methods*
 
-cache_key({obj})		*Vital.System.Cache.Dummy.cache_key()*
+cache_key({obj})	*Vital.System.Cache.Dummy-instance.cache_key()*
 
-	See |Vital.System.Cache.Base.cache_key()|.
+	See |Vital.System.Cache.Base-instance.cache_key()|.
 
-has({name})			*Vital.System.Cache.Dummy.has()*
+has({name})		*Vital.System.Cache.Dummy-instance.has()*
 
 	Always return 0.
 	
 	{name} (required)
 	Dummy.
 
-get({name}, [, {default}])	*Vital.System.Cache.Dummy.get()*
+                        *Vital.System.Cache.Dummy-instance.get()*
+get({name}[, {default}])
 
 	Always return a value of {default}. If no {default} is specified, an
 	empty string will be returned.
@@ -77,7 +78,7 @@ get({name}, [, {default}])	*Vital.System.Cache.Dummy.get()*
 	{default} (optional)
 	A return value.
 
-set({name}, {value})		*Vital.System.Cache.Dummy.set()*
+set({name}, {value})	*Vital.System.Cache.Dummy-instance.set()*
 
 	Do nothing.
 
@@ -87,22 +88,22 @@ set({name}, {value})		*Vital.System.Cache.Dummy.set()*
 	{value} (required)
 	Dummy
 
-keys()				*Vital.System.Cache.Dummy.keys()*
+keys()			*Vital.System.Cache.Dummy-instance.keys()*
 
 	Always return an empty list.
 
-remove({name})			*Vital.System.Cache.Dummy.remove()*
+remove({name})		*Vital.System.Cache.Dummy-instance.remove()*
 
 	Do nothing.
 
 	{name} (required)
 	Dummy
 
-clear()				*Vital.System.Cache.Dummy.clear()*
+clear()			*Vital.System.Cache.Dummy-instance.clear()*
 
 	Do nothing.
 
-on_changed()			*Vital.System.Cache.Dummy.on_changed()*
+on_changed()		*Vital.System.Cache.Dummy-instance.on_changed()*
 
 	Never called.
 

--- a/doc/vital-system-cache-file.txt
+++ b/doc/vital-system-cache-file.txt
@@ -10,6 +10,7 @@ Introductions		|Vital.System.Cache.File-intro|
 Usage			|Vital.System.Cache.File-usage|
 Functions		|Vital.System.Cache.File-functions|
 Methods			|Vital.System.Cache.File-methods|
+Properties		|Vital.System.Cache.File-properties|
 
 
 ==============================================================================
@@ -20,7 +21,6 @@ It stores a value into a file in a cache directory, mean that individual files
 have one particular Vim object.
 If you prefer to store keys and values into a single file, use
 |Vital.System.Cache.SingleFile| instead.
-
 
 
 ==============================================================================
@@ -77,61 +77,62 @@ dump({filename}, {obj})			*Vital.System.Cache.File.dump()*
 ==============================================================================
 METHODS					*Vital.System.Cache.File-methods*
 
-cache_key({obj})		*Vital.System.Cache.File.cache_key()*
+cache_key({obj})	*Vital.System.Cache.File-instance.cache_key()*
 
-	See |Vital.System.Cache.Base.cache_key()|
+	See |Vital.System.Cache.Base-instance.cache_key()|
 
-has({name})			*Vital.System.Cache.File.has()*
+has({name})		*Vital.System.Cache.File-instance.has()*
 
 	Return 1 if the cache instance has {name} in its cache directory.
 	Otherwise 0.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.File.cache_key()| method thus {name} is not
+	|Vital.System.Cache.File-instance.cache_key()| method thus {name} is not
 	required to be |String|.
 
-get({name}[, {default}])	*Vital.System.Cache.File.get()*
+			*Vital.System.Cache.File-instance.get()*
+get({name}[, {default}])
 
 	Return a cached value of {name} in a cache directory. It return
 	{default} if no value is found.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.File.cache_key()| method thus {name} is not
+	|Vital.System.Cache.File-instance.cache_key()| method thus {name} is not
 	required to be |String|.
 
 	{default} (optional)
 	A default value. It will be returned when no value is found in the
 	cache dictionary.
 
-set({name}, {value})		*Vital.System.Cache.File.set()*
+set({name}, {value})	*Vital.System.Cache.File-instance.set()*
 
 	Save {value} into a cache directory as {name}.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.File.cache_key()| method thus {name} is not
+	|Vital.System.Cache.File-instance.cache_key()| method thus {name} is not
 	required to be |String|.
 
 	{value} (required)
 	A value of the cache.
 
-keys()				*Vital.System.Cache.File.keys()*
+keys()			*Vital.System.Cache.File-instance.keys()*
 
 	Return a list of cache keys
 
-remove({name})			*Vital.System.Cache.File.remove()*
+remove({name})		*Vital.System.Cache.File-instance.remove()*
 
 	Remove {name} from a cache directory. It does nothing when the
 	specified {name} is not found in the cache.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.File.cache_key()| method thus {name} is not
+	|Vital.System.Cache.File-instance.cache_key()| method thus {name} is not
 	required to be |String|.
 
-clear()				*Vital.System.Cache.File.clear()*
+clear()			*Vital.System.Cache.File-instance.clear()*
 
 	Clear all files in the cache directory without prompts.
 
@@ -139,12 +140,23 @@ clear()				*Vital.System.Cache.File.clear()*
 	It remove all files in the directory. Make sure the correct cache
 	directory is specified in the instance.
 
-on_changed()			*Vital.System.Cache.File.on_changed()*
+on_changed()		*Vital.System.Cache.File-instance.on_changed()*
 
 	A user defined hook method. This method is called when the content of
-	the cache is changed, namely after |Vital.System.Cache.File.set()|,
-	|Vital.System.Cache.File.remove()|, or |Vital.System.Cache.File.clear()|
-	methods.
+	the cache is changed, namely after the following methods:
+	- |Vital.System.Cache.File-instance.set()|
+	- |Vital.System.Cache.File-instance.remove()|
+	- |Vital.System.Cache.File-instance.clear()|
+
 
 ==============================================================================
+PROPERTIES				*Vital.System.Cache.File-properties*
+
+cache_dir		*Vital.System.Cache.File-instance.cache_dir*
+
+	A directory path where cache files (keys) are saved.
+	The directory need to be exists if users re-define this property after
+	the |Vital.System.Cache.File-new()| function call.
+
+
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache-file.txt
+++ b/doc/vital-system-cache-file.txt
@@ -56,6 +56,18 @@ new([{options}])			*Vital.System.Cache.File.new()*
 	specified, it will throw an exception.
 	The 'cache_dir' will automatically be created if missing.
 
+load({filename}[, {default}])		*Vital.System.Cache.File.load()*
+
+	Load a vim object from a {filename}. It use |sandbox| and |eval| internally
+	to build a vim object dumped by |Vital.System.Cache.File.dump()|.
+	If the {filename} is unreadable or the content of {filename} is empty,
+	an empty dictionary or {default} (when specified) will be returned.
+
+dump({filename}, {obj})			*Vital.System.Cache.File.dump()*
+
+	Dump a vim object ({obj}) into a {filename}.
+	Use |Vital.System.Cache.File.load()| to restore the dumped vim object.
+
 
 ==============================================================================
 METHODS					*Vital.System.Cache.File-methods*

--- a/doc/vital-system-cache-file.txt
+++ b/doc/vital-system-cache-file.txt
@@ -156,7 +156,7 @@ cache_dir		*Vital.System.Cache.File-instance.cache_dir*
 
 	A directory path where cache files (keys) are saved.
 	The directory need to be exists if users re-define this property after
-	the |Vital.System.Cache.File-new()| function call.
+	the |Vital.System.Cache.File.new()| function call.
 
 
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache-file.txt
+++ b/doc/vital-system-cache-file.txt
@@ -16,6 +16,11 @@ Methods			|Vital.System.Cache.File-methods|
 INTRODUCTIONS				*Vital.System.Cache.File-intro*
 
 *Vital.System.Cache.File* is a file based unified cache system.
+It store a value into a file in a cache directory, mean that individual files
+have one particular Vim object.
+If you prefer to store keys and values into a single file, use
+|Vital.System.Cache.SingleFile| instead.
+
 
 
 ==============================================================================
@@ -52,7 +57,7 @@ FUNCTIONS				*Vital.System.Cache.File-functions*
 new([{options}])			*Vital.System.Cache.File.new()*
 
 	Create a new instance of System.Cache.File.
-	It require 'cache_dir' option in {options}. If no 'cache_dir' is
+	It requires 'cache_dir' option in {options}. If no 'cache_dir' is
 	specified, it will throw an exception.
 	The 'cache_dir' will automatically be created if missing.
 

--- a/doc/vital-system-cache-file.txt
+++ b/doc/vital-system-cache-file.txt
@@ -16,7 +16,7 @@ Methods			|Vital.System.Cache.File-methods|
 INTRODUCTIONS				*Vital.System.Cache.File-intro*
 
 *Vital.System.Cache.File* is a file based unified cache system.
-It store a value into a file in a cache directory, mean that individual files
+It stores a value into a file in a cache directory, mean that individual files
 have one particular Vim object.
 If you prefer to store keys and values into a single file, use
 |Vital.System.Cache.SingleFile| instead.
@@ -63,7 +63,7 @@ new([{options}])			*Vital.System.Cache.File.new()*
 
 load({filename}[, {default}])		*Vital.System.Cache.File.load()*
 
-	Load a vim object from a {filename}. It use |sandbox| and |eval| internally
+	Load a vim object from a {filename}. It uses |sandbox| and |eval| internally
 	to build a vim object dumped by |Vital.System.Cache.File.dump()|.
 	If the {filename} is unreadable or the content of {filename} is empty,
 	an empty dictionary or {default} (when specified) will be returned.

--- a/doc/vital-system-cache-file.txt
+++ b/doc/vital-system-cache-file.txt
@@ -29,7 +29,7 @@ calculated values.
 	let s:V = vital#of('vital')
 	let s:C = s:V.import('System.Cache.File')
 
-	let s:factorial_cache = s:C.new('.cache')
+	let s:factorial_cache = s:C.new({'cache_dir': '.cache'})
 
 	function! s:factorial(n)
 	  if a:n == 0

--- a/doc/vital-system-cache-memory.txt
+++ b/doc/vital-system-cache-memory.txt
@@ -58,70 +58,72 @@ new([{options}])			*Vital.System.Cache.Memory.new()*
 ==============================================================================
 METHODS					*Vital.System.Cache.Memory-methods*
 
-cache_key({obj})		*Vital.System.Cache.Memory.cache_key()*
+cache_key({obj})	*Vital.System.Cache.Memory-instance.cache_key()*
 
-	See |Vital.System.Cache.Base.cache_key()|
+	See |Vital.System.Cache.Base-instance.cache_key()|
 
-has({name})			*Vital.System.Cache.Memory.has()*
+has({name})		*Vital.System.Cache.Memory-instance.has()*
 
 	Return 1 if the cache instance has {name} in its cache dictionary.
 	Otherwise 0.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.Memory.cache_key()| method thus {name} is not
-	required to be |String|.
+	|Vital.System.Cache.Memory-instance.cache_key()| method thus {name} is
+	not required to be |String|.
 
-get({name}, [, {default}])	*Vital.System.Cache.Memory.get()*
+                        *Vital.System.Cache.Memory-instance.get()*
+get({name}[, {default}])
 
 	Return a cached value of {name} in a cache dictionary. It return
 	{default} if no value is found.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.Memory.cache_key()| method thus {name} is not
-	required to be |String|.
+	|Vital.System.Cache.Memory-instance.cache_key()| method thus {name} is
+	not required to be |String|.
 
 	{default} (optional)
 	A default value. It will be returned when no value is found in the
 	cache dictionary.
 
-set({name}, {value})		*Vital.System.Cache.Memory.set()*
+set({name}, {value})	*Vital.System.Cache.Memory-instance.set()*
 
 	Save {value} into a cache dictionary as {name}.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.Memory.cache_key()| method thus {name} is not
-	required to be |String|.
+	|Vital.System.Cache.Memory-instance.cache_key()| method thus {name} is
+	not required to be |String|.
 
 	{value} (required)
 	A value of the cache.
 
-keys()				*Vital.System.Cache.Memory.keys()*
+keys()			*Vital.System.Cache.Memory-instance.keys()*
 
 	Return a list of cache keys
 
-remove({name})			*Vital.System.Cache.Memory.remove()*
+remove({name})		*Vital.System.Cache.Memory-instance.remove()*
 
 	Remove {name} from a cache dictionary. It does nothing when the
 	specified {name} is not found in the cache.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.Memory.cache_key()| method thus {name} is not
-	required to be |String|.
+	|Vital.System.Cache.Memory-instance.cache_key()| method thus {name} is
+	not required to be |String|.
 
-clear()				*Vital.System.Cache.Memory.clear()*
+clear()			*Vital.System.Cache.Memory-instance.clear()*
 
 	Clear a cache dictionary.
 
-on_changed()			*Vital.System.Cache.Memory.on_changed()*
+on_changed()		*Vital.System.Cache.Memory-instance.on_changed()*
 
 	A user defined hook method. This method is called when the content of
-	the cache is changed, namely after |Vital.System.Cache.Memory.set()|,
-	|Vital.System.Cache.Memory.remove()|, or
-	|Vital.System.Cache.Memory.clear()| methods.
+	the cache is changed, namely after the following methods:
+	- |Vital.System.Cache.Memory-instance.set()|
+	- |Vital.System.Cache.Memory-instance.remove()|
+	- |Vital.System.Cache.Memory-instance.clear()|
 
 
 ==============================================================================

--- a/doc/vital-system-cache-memory.txt
+++ b/doc/vital-system-cache-memory.txt
@@ -30,10 +30,6 @@ calculated values.
 	let s:C = s:V.import('System.Cache.Memory')
 
 	let s:factorial_cache = s:C.new()
-	" override 'cache_key' method to use an integer values as a cache name
-	function! s:factorial_cache.cache_key(n)
-	  return "" . a:n
-	endfunction
 
 	function! s:factorial(n)
 	  if a:n == 0

--- a/doc/vital-system-cache-singlefile.txt
+++ b/doc/vital-system-cache-singlefile.txt
@@ -16,8 +16,8 @@ Methods			|Vital.System.Cache.SingleFile-methods|
 INTRODUCTIONS				*Vital.System.Cache.SingleFile-intro*
 
 *Vital.System.Cache.SingleFile* is a single file based cache system.
-It store a cache dictionary into a single cache file, mean that it is similar
-to |Vital.System.Cache.Memory| but the cache is permanent.
+It stores a cache dictionary into a single cache file, mean that it is similar
+to |Vital.System.Cache.Memory| but the cache is persistent.
 If you prefer to store key and value into individual files, use
 |Vital.System.Cache.File| instead.
 
@@ -68,13 +68,13 @@ METHODS					*Vital.System.Cache.SingleFile-methods*
 dump()				*Vital.System.Cache.SingleFile.dump()*
 
 	Dump a cache content into the 'cache_file'.
-	It will automatically be called when the cache content is changed.
+	It will be automatically called when the cache content is changed.
 	Users can call this method to dump the cache content manually.
 
 load()				*Vital.System.Cache.SingleFile.load()*
 
 	Load a cache content from the 'cache_file'.
-	It will automatically be called when the cache instance is created (in
+	It will be automatically called when the cache instance is created (in
 	|Vital.System.Cache.SingleFile.new()|.
 	Users can call this method to load the cache content manually.
 	Note that this method call triggers to call

--- a/doc/vital-system-cache-singlefile.txt
+++ b/doc/vital-system-cache-singlefile.txt
@@ -65,67 +65,68 @@ new([{options}])			*Vital.System.Cache.SingleFile.new()*
 ==============================================================================
 METHODS					*Vital.System.Cache.SingleFile-methods*
 
-dump()				*Vital.System.Cache.SingleFile.dump()*
+dump()			*Vital.System.Cache.SingleFile-instance.dump()*
 
 	Dump a cache content into the 'cache_file'.
 	It will be automatically called when the cache content is changed.
 	Users can call this method to dump the cache content manually.
 
-load()				*Vital.System.Cache.SingleFile.load()*
+load()			*Vital.System.Cache.SingleFile-instance.load()*
 
 	Load a cache content from the 'cache_file'.
 	It will be automatically called when the cache instance is created (in
 	|Vital.System.Cache.SingleFile.new()|.
 	Users can call this method to load the cache content manually.
-	Note that this method call triggers to call
-	|Vital.System.Cache.SingleFile.on_changed()| hook.
+	Note that this method call may trigger to call
+	|Vital.System.Cache.SingleFile-instance.on_changed()| hook.
 
-cache_key({obj})		*Vital.System.Cache.SingleFile.cache_key()*
+cache_key({obj})	*Vital.System.Cache.SingleFile-instance.cache_key()*
 
 	See |Vital.System.Cache.Base.cache_key()|
 
-has({name})			*Vital.System.Cache.SingleFile.has()*
+has({name})		*Vital.System.Cache.SingleFile-instance.has()*
 
 	Return 1 if the cache instance has {name} in its cache dictionary.
 	Otherwise 0.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.SingleFile.cache_key()| method thus {name} is not
-	required to be |String|.
+	|Vital.System.Cache.SingleFile-instance.cache_key()| method thus {name}
+	is not required to be |String|.
 
-get({name}, [, {default}])	*Vital.System.Cache.SingleFile.get()*
+                        *Vital.System.Cache.SingleFile-instance.get()*
+get({name}[, {default}])
 
 	Return a cached value of {name} in a cache dictionary. It return
 	{default} if no value is found.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.SingleFile.cache_key()| method thus {name} is not
-	required to be |String|.
+	|Vital.System.Cache.SingleFile-instance.cache_key()| method thus {name}
+	is not required to be |String|.
 
 	{default} (optional)
 	A default value. It will be returned when no value is found in the
 	cache dictionary.
 
-set({name}, {value})		*Vital.System.Cache.SingleFile.set()*
+set({name}, {value})	*Vital.System.Cache.SingleFile-instance.set()*
 
 	Save {value} into a cache dictionary as {name} and dump the cache
 	dictionary into 'cache_file'.
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.SingleFile.cache_key()| method thus {name} is not
-	required to be |String|.
+	|Vital.System.Cache.SingleFile-instance.cache_key()| method thus {name}
+	is not required to be |String|.
 
 	{value} (required)
 	A value of the cache.
 
-keys()				*Vital.System.Cache.SingleFile.keys()*
+keys()			*Vital.System.Cache.SingleFile-instance.keys()*
 
 	Return a list of cache keys
 
-remove({name})			*Vital.System.Cache.SingleFile.remove()*
+remove({name})		*Vital.System.Cache.SingleFile-instance.remove()*
 
 	Remove {name} from a cache dictionary and dump the cache dictionary
 	into 'cache_file'. It does nothing when the specified {name} is not
@@ -133,22 +134,22 @@ remove({name})			*Vital.System.Cache.SingleFile.remove()*
 
 	{name} (required)
 	A name of the cache. An actual cache key will be created via
-	|Vital.System.Cache.SingleFile.cache_key()| method thus {name} is not
-	required to be |String|.
+	|Vital.System.Cache.SingleFile-instance.cache_key()| method thus {name}
+	is not required to be |String|.
 
-clear()				*Vital.System.Cache.SingleFile.clear()*
+clear()			*Vital.System.Cache.SingleFile-instance.clear()*
 
 	Clear a cache dictionary and dump the cache dictionary into
 	'cache_file'.
 
-on_changed()			*Vital.System.Cache.SingleFile.on_changed()*
+on_changed()		*Vital.System.Cache.SingleFile-instance.on_changed()*
 
 	A user defined hook method. This method is called when the content of
-	the cache is changed, namely after
-	|Vital.System.Cache.SingleFile.set()|,
-	|Vital.System.Cache.SingleFile.remove()|,
-	|Vital.System.Cache.SingleFile.clear()|, or
-	|Vital.System.Cache.SingleFile.load()| methods.
+	the cache is changed, namely after the following methods:
+	- |Vital.System.Cache.SingleFile-instance.set()|
+	- |Vital.System.Cache.SingleFile-instance.remove()|
+	- |Vital.System.Cache.SingleFile-instance.clear()|
+	- |Vital.System.Cache.SingleFile-instance.load()|
 
 
 ==============================================================================

--- a/doc/vital-system-cache-singlefile.txt
+++ b/doc/vital-system-cache-singlefile.txt
@@ -1,0 +1,155 @@
+*vital-system-cache-singlefile.txt*	A single file based cache system
+
+Maintainer: Alisue <lambdalisue@hashnote.net>
+
+
+==============================================================================
+CONTENTS			*Vital.System.Cache.SingleFile-contents*
+
+Introductions		|Vital.System.Cache.SingleFile-intro|
+Usage			|Vital.System.Cache.SingleFile-usage|
+Functions		|Vital.System.Cache.SingleFile-functions|
+Methods			|Vital.System.Cache.SingleFile-methods|
+
+
+==============================================================================
+INTRODUCTIONS				*Vital.System.Cache.SingleFile-intro*
+
+*Vital.System.Cache.SingleFile* is a single file based cache system.
+It store a cache dictionary into a single cache file, mean that it is similar
+to |Vital.System.Cache.Memory| but the cache is permanent.
+If you prefer to store key and value into individual files, use
+|Vital.System.Cache.File| instead.
+
+
+==============================================================================
+USAGE					*Vital.System.Cache.SingleFile-usage*
+
+|Vital.System.Cache.SingleFile| have all required API of unified cache system and
+values are stored in a |Dictionary| instance.
+In the following example, |Vital.System.Cache.SingleFile| is used for memorize
+the calculated values.
+>
+	let s:V = vital#of('vital')
+	let s:C = s:V.import('System.Cache.SingleFile')
+
+	let s:factorial_cache = s:C.new({'cache_file': '.cache'})
+
+	function! s:factorial(n)
+	  if a:n == 0
+	    return 1
+	  elseif s:factorial_cache.has(a:n)
+	    return s:factorial_cache.get(a:n)
+	  else
+	    let x = s:factorial(a:n - 1) * a:n
+	    call s:factorial_cache.set(a:n, x)
+	    return x
+	  endif
+	endfunction
+
+	echo s:factorial(10)
+<
+
+==============================================================================
+FUNCTIONS				*Vital.System.Cache.SingleFile-functions*
+
+new([{options}])			*Vital.System.Cache.SingleFile.new()*
+
+	Create a new instance of System.Cache.SingleFile.
+	It requires 'cache_file' option in {options}. If no 'cache_file' is
+	specified, it will throw an exception.
+	The parent directory of 'cache_file' will automatically be created if
+	missing.
+
+
+==============================================================================
+METHODS					*Vital.System.Cache.SingleFile-methods*
+
+dump()				*Vital.System.Cache.SingleFile.dump()*
+
+	Dump a cache content into the 'cache_file'.
+	It will automatically be called when the cache content is changed.
+	Users can call this method to dump the cache content manually.
+
+load()				*Vital.System.Cache.SingleFile.load()*
+
+	Load a cache content from the 'cache_file'.
+	It will automatically be called when the cache instance is created (in
+	|Vital.System.Cache.SingleFile.new()|.
+	Users can call this method to load the cache content manually.
+	Note that this method call triggers to call
+	|Vital.System.Cache.SingleFile.on_changed()| hook.
+
+cache_key({obj})		*Vital.System.Cache.SingleFile.cache_key()*
+
+	See |Vital.System.Cache.Base.cache_key()|
+
+has({name})			*Vital.System.Cache.SingleFile.has()*
+
+	Return 1 if the cache instance has {name} in its cache dictionary.
+	Otherwise 0.
+
+	{name} (required)
+	A name of the cache. An actual cache key will be created via
+	|Vital.System.Cache.SingleFile.cache_key()| method thus {name} is not
+	required to be |String|.
+
+get({name}, [, {default}])	*Vital.System.Cache.SingleFile.get()*
+
+	Return a cached value of {name} in a cache dictionary. It return
+	{default} if no value is found.
+
+	{name} (required)
+	A name of the cache. An actual cache key will be created via
+	|Vital.System.Cache.SingleFile.cache_key()| method thus {name} is not
+	required to be |String|.
+
+	{default} (optional)
+	A default value. It will be returned when no value is found in the
+	cache dictionary.
+
+set({name}, {value})		*Vital.System.Cache.SingleFile.set()*
+
+	Save {value} into a cache dictionary as {name} and dump the cache
+	dictionary into 'cache_file'.
+
+	{name} (required)
+	A name of the cache. An actual cache key will be created via
+	|Vital.System.Cache.SingleFile.cache_key()| method thus {name} is not
+	required to be |String|.
+
+	{value} (required)
+	A value of the cache.
+
+keys()				*Vital.System.Cache.SingleFile.keys()*
+
+	Return a list of cache keys
+
+remove({name})			*Vital.System.Cache.SingleFile.remove()*
+
+	Remove {name} from a cache dictionary and dump the cache dictionary
+	into 'cache_file'. It does nothing when the specified {name} is not
+	found in the cache.
+
+	{name} (required)
+	A name of the cache. An actual cache key will be created via
+	|Vital.System.Cache.SingleFile.cache_key()| method thus {name} is not
+	required to be |String|.
+
+clear()				*Vital.System.Cache.SingleFile.clear()*
+
+	Clear a cache dictionary and dump the cache dictionary into
+	'cache_file'.
+
+on_changed()			*Vital.System.Cache.SingleFile.on_changed()*
+
+	A user defined hook method. This method is called when the content of
+	the cache is changed, namely after
+	|Vital.System.Cache.SingleFile.set()|,
+	|Vital.System.Cache.SingleFile.remove()|,
+	|Vital.System.Cache.SingleFile.clear()|, or
+	|Vital.System.Cache.SingleFile.load()| methods.
+
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache-singlefile.txt
+++ b/doc/vital-system-cache-singlefile.txt
@@ -10,6 +10,7 @@ Introductions		|Vital.System.Cache.SingleFile-intro|
 Usage			|Vital.System.Cache.SingleFile-usage|
 Functions		|Vital.System.Cache.SingleFile-functions|
 Methods			|Vital.System.Cache.SingleFile-methods|
+Properties		|Vital.System.Cache.SingleFile-properties|
 
 
 ==============================================================================
@@ -60,6 +61,8 @@ new([{options}])			*Vital.System.Cache.SingleFile.new()*
 	specified, it will throw an exception.
 	The parent directory of 'cache_file' will automatically be created if
 	missing.
+	Users can use a 'autodump' option in {options} to set the initial value
+	of |Vital.System.Cache.SingleFile-instance.autodump|.
 
 
 ==============================================================================
@@ -68,8 +71,9 @@ METHODS					*Vital.System.Cache.SingleFile-methods*
 dump()			*Vital.System.Cache.SingleFile-instance.dump()*
 
 	Dump a cache content into the 'cache_file'.
-	It will be automatically called when the cache content is changed.
-	Users can call this method to dump the cache content manually.
+	It will be automatically called when the cache content is changed if
+	|Vital.System.Cache.SingleFile-instance.autodump| is 1. Otherwise users
+	need to call this method to dump the cache content into a cache file.
 
 load()			*Vital.System.Cache.SingleFile-instance.load()*
 
@@ -153,4 +157,21 @@ on_changed()		*Vital.System.Cache.SingleFile-instance.on_changed()*
 
 
 ==============================================================================
+PROPERTIES			*Vital.System.Cache.SingleFile-properties*
+
+cache_file		*Vital.System.Cache.SingleFile-instance.cache_file*
+
+	A file path where the cache content is saved.
+	The directory of this file need to be exists if users re-define this
+	property after the |Vital.System.Cache.SingleFile.new()| function call.
+
+autodump		*Vital.System.Cache.SingleFile-instance.autodump*
+
+	A boolean to enable/disable autodump feature.
+	If the value is 1, |Vital.System.Cache.SingleFile-instance.dump()|
+	will be automatically calledn when the cache content is changed.
+	Otherwise users need to call the method manually to dump the cache
+	content into a cache file.
+
+
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache.txt
+++ b/doc/vital-system-cache.txt
@@ -186,5 +186,12 @@ clear()				*Vital.System.Cache-instance.clear()*
 
 	Clear all caches
 
+on_changed()			*Vital.System.Cache-instance.on_changed()*
+
+	A user defined hook method. This method is called when the content of
+	the cache is changed, namely after |Vital.System.Cache-instance.set()|,
+	|Vital.System.Cache-instance.remove()|, or
+	|Vital.System.Cache-instance.clear()| methods.
+
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-system-cache.txt
+++ b/doc/vital-system-cache.txt
@@ -20,9 +20,10 @@ INTRODUCTIONS				*Vital.System.Cache-intro*
 the application interface so users can easily switch to a different cache
 variant. Currently the following variants are available.
 
-- |Vital.System.Cache.Dummy|  : A dummy cache system which cache nothing
-- |Vital.System.Cache.Memory| : A dictionary instance based cache system
-- |Vital.System.Cache.File|   : A file based cache system
+- |Vital.System.Cache.Dummy|      : A dummy cache system which cache nothing
+- |Vital.System.Cache.Memory|     : A dictionary instance based cache system
+- |Vital.System.Cache.File|       : A file based cache system
+- |Vital.System.Cache.SingleFile| : A single file based cache system
 
 Note |Vital.System.Cache| is replaced with a new unified cache system. An old
 version have been moved into |Vital.System.Cache.Deprecated|.
@@ -113,6 +114,9 @@ new({name}[, {options}])		*Vital.System.Cache.new()*
 
 	"file"
 	A filesystem based cache system (|Vital.System.Cache.File|)
+
+	"singlefile"
+	A single file based cache system (|Vital.System.Cache.SingleFile|)
 
 	The second argument {options} will be passed to a new method of a
 	specified variant. See a document of new function in each variant to

--- a/doc/vital-system-cache.txt
+++ b/doc/vital-system-cache.txt
@@ -41,9 +41,10 @@ function. The following assume that you want to use a file based cache system.
 The |Vital.System.Cache.new()| function take one or two arguments. The first
 argument is a name of a variant and currently the followings are available:
 
-- "dummy"  : For |Vital.System.Cache.Dummy|
-- "memory" : For |Vital.System.Cache.Memory|
-- "file"   : For |Vital.System.Cache.File|
+- "dummy"      : For |Vital.System.Cache.Dummy|
+- "memory"     : For |Vital.System.Cache.Memory|
+- "file"       : For |Vital.System.Cache.File|
+- "singlefile" : For |Vital.System.Cache.SingleFile|
 
 The second argument is a variant specified option dictionary. For example,
 |Vital.System.Cache.File| require 'cache_dir' option so the example code above
@@ -146,7 +147,7 @@ has({name})			*Vital.System.Cache-instance.has()*
 	cache_key() method of each variant thus {name} is not required to be
 	|String|.
 
-get({name}, [, {default}])	*Vital.System.Cache-instance.get()*
+get({name}[, {default}])	*Vital.System.Cache-instance.get()*
 
 	Return a value from a {name} cache. It no {name} cache is found, it
 	return {default} or an empty |String|.
@@ -193,9 +194,10 @@ clear()				*Vital.System.Cache-instance.clear()*
 on_changed()			*Vital.System.Cache-instance.on_changed()*
 
 	A user defined hook method. This method is called when the content of
-	the cache is changed, namely after |Vital.System.Cache-instance.set()|,
-	|Vital.System.Cache-instance.remove()|, or
-	|Vital.System.Cache-instance.clear()| methods.
+	the cache is changed, namely after the following methods:
+	- |Vital.System.Cache-instance.set()|
+	- |Vital.System.Cache-instance.remove()|
+	- |Vital.System.Cache-instance.clear()|
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/System/Cache/Base.vimspec
+++ b/test/System/Cache/Base.vimspec
@@ -23,7 +23,7 @@ Describe System.Cache.Base
       let cache = s:C.new()
     End
 
-    Context .cache_key({obj})
+    Context .cache_key()
       It should return an original string if a string is specified
         let r = cache.cache_key('foo')
         Assert Equals(r, 'foo')
@@ -37,20 +37,20 @@ Describe System.Cache.Base
       End
     End
 
-    Context .has({name})
+    Context .has()
       It should throw an exception
         Throws 'has({name}) is not implemented', cache.has('foo')
       End
     End
 
-    Context .get({name}[, {default}])
+    Context .get()
       It should throw an exception
         Throws 'get({name}[, {default}]) is not implemented', cache.get('foo')
         Throws 'get({name}[, {default}]) is not implemented', cache.get('foo', 'foo')
       End
     End
 
-    Context .set({name}, {value})
+    Context .set()
       It should throw an exception
         Throws 'set({name}, {value}) is not implemented', cache.set('foo', 'foo')
       End
@@ -62,7 +62,7 @@ Describe System.Cache.Base
       End
     End
 
-    Context .remove({name})
+    Context .remove()
       It should throw an exception
         Throws 'remove({name}) is not implemented', cache.remove('foo')
       End

--- a/test/System/Cache/Dummy.vimspec
+++ b/test/System/Cache/Dummy.vimspec
@@ -44,14 +44,14 @@ Describe System.Cache.Dummy
       let cache = s:C.new()
     End
 
-    Context .has({name})
+    Context .has()
       It should always return 0
         let r = cache.has('foo')
         Assert Equals(r, 0)
       End
     End
 
-    Context .get({name}[, {default}])
+    Context .get()
       It should always return an empty string
         let r = cache.get('foo')
         Assert Equals(r, '')
@@ -63,7 +63,7 @@ Describe System.Cache.Dummy
       End
     End
 
-    Context .set({name}, {value})
+    Context .set()
       It should do nothing
         call cache.set('foo', 'bar')
       End
@@ -76,7 +76,7 @@ Describe System.Cache.Dummy
       End
     End
 
-    Context .remove({name})
+    Context .remove()
       It should do nothing
         call cache.remove('foo')
       End

--- a/test/System/Cache/File.vimspec
+++ b/test/System/Cache/File.vimspec
@@ -35,7 +35,7 @@ Describe System.Cache.File
     End
   End
 
-  Context .new({config})
+  Context .new()
     Before each
       let cache_dir = tempname()
     End
@@ -72,14 +72,14 @@ Describe System.Cache.File
       endif
     End
 
-    Context .cache_key({str})
+    Context .cache_key()
       It should return an original string in default
         let r = cache.cache_key('foo')
         Assert Equals(r, 'foo')
       End
     End
 
-    Context .has({name})
+    Context .has()
       It should return 0 if a named cache is not found
         let r = cache.has('undefined_cache_name')
         Assert False(r)
@@ -94,7 +94,7 @@ Describe System.Cache.File
       End
     End
 
-    Context .get({name}[, {default}])
+    Context .get()
       It should return an empty string if a named cache is not found
         let r = cache.get('foo')
         Assert Equals(r, '')
@@ -117,7 +117,7 @@ Describe System.Cache.File
       End
     End
 
-    Context .set({name}, {value})
+    Context .set()
       It should save 'value' into a cache file with given 'name'
         let filename = s:P.join(cache_dir, 'foo')
         call cache.set('foo', 'foo')
@@ -142,7 +142,7 @@ Describe System.Cache.File
       End
     End
 
-    Context .remove({name})
+    Context .remove()
       It should do nothing if a named cache is not found
         call cache.remove('foo')
       End
@@ -155,7 +155,7 @@ Describe System.Cache.File
       End
     End
 
-    Context .clear({name})
+    Context .clear()
       It should clear a cache directory
         let filename1 = s:P.join(cache_dir, 'foo')
         let filename2 = s:P.join(cache_dir, 'bar')

--- a/test/System/Cache/File.vimspec
+++ b/test/System/Cache/File.vimspec
@@ -56,7 +56,8 @@ Describe System.Cache.File
     End
 
     It should raise an exception if 'cache_dir' option is not specified.
-      Throw call s:C.new(), 'No "cache_dir" option is specified'
+      let C = s:C
+      Throw /"cache_dir" option is specified/ :call C.new()
     End
   End
 

--- a/test/System/Cache/File.vimspec
+++ b/test/System/Cache/File.vimspec
@@ -60,6 +60,70 @@ Describe System.Cache.File
     End
   End
 
+  Context .load()
+    Before
+      let cache_dir = tempname()
+      call mkdir(cache_dir, 'p')
+    End
+
+    After
+      if isdirectory(cache_dir)
+        call s:F.rmdir(cache_dir, 'r')
+      endif
+    End
+
+    It should return an empty dictionary if a specified file is not readable
+      let r = s:C.load('unreadable_file.txt')
+      Assert Equals(r, {})
+    End
+
+    It should return 'default' if a specified file is not readable
+      let r1 = s:C.load('unreadable_file.txt', 'hello')
+      Assert Equals(r1, 'hello')
+
+      let r2 = s:C.load('unreadable_file.txt', 0)
+      Assert Equals(r2, 0)
+    End
+
+    It should return an object of content if a specified file is readable
+      let filename = s:P.join(cache_dir, 'foo')
+      call writefile(["{'foo': 'bar'}"], filename)
+      let r1 = s:C.load(filename)
+      Assert Equals(r1, {'foo': 'bar'})
+
+      call writefile(["['foo', 'bar']"], filename)
+      let r2 = s:C.load(filename)
+      Assert Equals(r2, ['foo', 'bar'])
+      call delete(filename)
+    End
+  End
+
+  Context .dump()
+    Before
+      let cache_dir = tempname()
+      call mkdir(cache_dir, 'p')
+    End
+
+    After
+      if isdirectory(cache_dir)
+        call s:F.rmdir(cache_dir, 'r')
+      endif
+    End
+
+    It should save 'obj' into a cache file
+      let filename = s:P.join(cache_dir, 'foo')
+      let obj1 = { 'foo': 'bar' }
+      call s:C.dump(filename, obj1)
+      Assert Equals(readfile(filename), ["{'foo': 'bar'}"])
+
+      let obj2 = [ 'foo', 'bar' ]
+      call s:C.dump(filename, obj2)
+      Assert Equals(readfile(filename), ["['foo', 'bar']"])
+
+      call delete(filename)
+    End
+  End
+
   Context instance
     Before
       let cache_dir = tempname()

--- a/test/System/Cache/Memory.vimspec
+++ b/test/System/Cache/Memory.vimspec
@@ -46,14 +46,14 @@ Describe System.Cache.Memory
       Assert !has_key(cache2._cached, 'foo')
     End
 
-    Context .cache_key({str})
+    Context .cache_key()
       It should return an original string in default
         let r = cache.cache_key('foo')
         Assert Equals(r, 'foo')
       End
     End
 
-    Context .has({name})
+    Context .has()
       It should return 0 if a named cache is not found
         let r = cache.has('foo')
         Assert False(r)
@@ -66,7 +66,7 @@ Describe System.Cache.Memory
       End
     End
 
-    Context .get({name}[, {default}])
+    Context .get()
       It should return an empty string if a named cache is not found
         let r = cache.get('foo')
         Assert Equals(r, '')
@@ -87,7 +87,7 @@ Describe System.Cache.Memory
       End
     End
 
-    Context .set({name}, {value})
+    Context .set()
       It should save 'value' into a cache dictionary with given 'name'
         call cache.set('foo', 'foo')
         Assert HasKey(cache._cached, 'foo')
@@ -106,7 +106,7 @@ Describe System.Cache.Memory
       End
     End
 
-    Context .remove({name})
+    Context .remove()
       It should do nothing if a named cache is not found
         call cache.remove('foo')
       End

--- a/test/System/Cache/SingleFile.vimspec
+++ b/test/System/Cache/SingleFile.vimspec
@@ -1,0 +1,182 @@
+" Use vim-themis to execute this test
+let s:V = vital#of('vital')
+let s:F = s:V.import('System.File')
+let s:P = s:V.import('System.Filepath')
+
+Describe System.Cache.SingleFile
+  let s:C = s:V.import('System.Cache.SingleFile')
+
+  Context Usage (Factorial)
+    Before
+      let cache_file = tempname()
+      let s:factorial_cache = s:C.new({ 'cache_file': cache_file })
+    End
+    After
+      if filereadable(cache_file)
+        call delete(cache_file)
+      endif
+    End
+
+    function! s:factorial(n)
+      if a:n == 0
+        return 1
+      elseif s:factorial_cache.has(a:n)
+        return s:factorial_cache.get(a:n)
+      else
+        let x = s:factorial(a:n - 1) * a:n
+        call s:factorial_cache.set(a:n, x)
+        return x
+      endif
+    endfunction
+
+    It should return correct factorial value
+      let r = s:factorial(10)
+      Assert Equals(r, 1*2*3*4*5*6*7*8*9*10)
+    End
+  End
+
+  Context .new()
+    Before
+      let cache_file = tempname()
+    End
+    After
+      if filereadable(cache_file)
+        call delete(cache_file)
+      endif
+    End
+
+    It should return an instance
+      let cache = s:C.new({ 'cache_file': cache_file })
+      Assert HasKey(cache, 'cache_file')
+      Assert HasKey(cache, 'load')
+      Assert HasKey(cache, 'dump')
+    End
+
+    It should automatically create a parent directory of a specified cache file
+      let cache_dir = tempname()
+      let cache_file = s:P.join(cache_dir, 'cachefile')
+      call s:C.new({ 'cache_file': cache_file })
+      Assert True(isdirectory(cache_dir))
+      if isdirectory(cache_dir)
+        call s:F.rmdir(cache_dir, 'r')
+      endif
+    End
+
+    It should raise an exception if 'cache_file' option is not specified.
+      Throw call s:C.new(), '"cache_file" option is empty'
+    End
+
+    It should load cache from 'cache_file'
+      call writefile(["{'foo': 'foo', 'bar': 'bar'}"], cache_file)
+      let cache = s:C.new({ 'cache_file': cache_file })
+      Assert True(cache.has('foo'))
+      Assert True(cache.has('bar'))
+      Assert Equals(cache.get('foo'), 'foo')
+      Assert Equals(cache.get('bar'), 'bar')
+    End
+  End
+
+  Context instance
+    Before
+      let cache_file = tempname()
+      let cache = s:C.new({ 'cache_file': cache_file })
+    End
+
+    After
+      if filereadable(cache_file)
+        call delete(cache_file)
+      endif
+    End
+
+    Context .cache_key()
+      It should return an original string in default
+        let r = cache.cache_key('foo')
+        Assert Equals(r, 'foo')
+      End
+    End
+
+    Context .has()
+      It should return 0 if a named cache is not found
+        let r = cache.has('foo')
+        Assert False(r)
+      End
+
+      It should return 1 if a named cache is found
+        let cache._memory._cached = {'foo': 'bar'}
+        let r = cache.has('foo')
+        Assert True(r)
+      End
+    End
+
+    Context .get()
+      It should return an empty string if a named cache is not found
+        let r = cache.get('foo')
+        Assert Equals(r, '')
+      End
+
+      It should return 'default' if a named cache is not found and 'default' is specified
+        let r1 = cache.get('foo', 'hello')
+        Assert Equals(r1, 'hello')
+
+        let r2 = cache.get('foo', 0)
+        Assert Equals(r2, 0)
+      End
+
+      It should return a value if a named cache is found
+        let cache._memory._cached = {'foo': 'bar'}
+        let r = cache.get('foo')
+        Assert Equals(r, 'bar')
+      End
+    End
+
+    Context .set()
+      It should save 'value' into a cache dictionary with given 'name' and cache_file
+        call cache.set('foo', 'foo')
+        Assert HasKey(cache._memory._cached, 'foo')
+        Assert Equals(cache._memory._cached['foo'], 'foo')
+        let content = readfile(cache.cache_file)
+        Assert Equals(content, ["{'foo': 'foo'}"])
+      End
+    End
+
+    Context .keys()
+      It should return a list of keys
+        let cache._memory._cached = {
+              \ 'foo': 'foo',
+              \ 'bar': 'bar',
+              \}
+        let r = cache.keys()
+        Assert Equals(sort(r), sort(['foo', 'bar']))
+      End
+    End
+
+    Context .remove()
+      It should do nothing if a named cache is not found
+        call cache.remove('foo')
+      End
+
+      It should remove a named cache from a cache dictionary
+        let cache._memory._cached = {'foo': 'bar'}
+        call writefile(["{'foo': 'bar'}"], cache.cache_file)
+        call cache.remove('foo')
+        Assert !has_key(cache._memory._cached, 'foo')
+        let content = readfile(cache.cache_file)
+        Assert Equals(content, ["{}"])
+      End
+    End
+
+    Context .clear()
+      It should clear a cache dictionary
+        let cache._memory._cached = {
+              \ 'foo': 'foo',
+              \ 'bar': 'bar',
+              \}
+        call writefile(["{'foo': 'foo', 'bar': 'bar'}"], cache.cache_file)
+        call cache.clear()
+        Assert Equals(cache._memory._cached, {})
+        let content = readfile(cache.cache_file)
+        Assert Equals(content, ["{}"])
+      End
+    End
+  End
+End

--- a/test/System/Cache/SingleFile.vimspec
+++ b/test/System/Cache/SingleFile.vimspec
@@ -64,7 +64,8 @@ Describe System.Cache.SingleFile
     End
 
     It should raise an exception if 'cache_file' option is not specified.
-      Throw call s:C.new(), '"cache_file" option is empty'
+      let C = s:C
+      Throw /"cache_file" option is empty/ :call C.new()
     End
 
     It should load cache from 'cache_file'

--- a/test/System/Cache/SingleFile.vimspec
+++ b/test/System/Cache/SingleFile.vimspec
@@ -48,6 +48,7 @@ Describe System.Cache.SingleFile
     It should return an instance
       let cache = s:C.new({ 'cache_file': cache_file })
       Assert HasKey(cache, 'cache_file')
+      Assert HasKey(cache, 'autodump')
       Assert HasKey(cache, 'load')
       Assert HasKey(cache, 'dump')
     End
@@ -73,6 +74,11 @@ Describe System.Cache.SingleFile
       Assert True(cache.has('bar'))
       Assert Equals(cache.get('foo'), 'foo')
       Assert Equals(cache.get('bar'), 'bar')
+    End
+
+    It should disable autodump when {'autodump': 0} is specified
+      let cache = s:C.new({ 'cache_file': cache_file, 'autodump': 0 })
+      Assert False(cache.autodump)
     End
   End
 
@@ -130,12 +136,20 @@ Describe System.Cache.SingleFile
     End
 
     Context .set()
-      It should save 'value' into a cache dictionary with given 'name' and cache_file
+      It should save 'value' into a cache dictionary with given 'name' and the dictionary into the cache_file
         call cache.set('foo', 'foo')
         Assert HasKey(cache._memory._cached, 'foo')
         Assert Equals(cache._memory._cached['foo'], 'foo')
         let content = readfile(cache.cache_file)
         Assert Equals(content, ["{'foo': 'foo'}"])
+      End
+
+      It should save 'value' into a cache dictionary with given 'name' only when autodump is 0
+        let cache.autodump = 0
+        call cache.set('foo', 'foo')
+        Assert HasKey(cache._memory._cached, 'foo')
+        Assert Equals(cache._memory._cached['foo'], 'foo')
+        Assert False(filereadable(cache.cache_file))
       End
     End
 
@@ -155,7 +169,7 @@ Describe System.Cache.SingleFile
         call cache.remove('foo')
       End
 
-      It should remove a named cache from a cache dictionary
+      It should remove a named cache from a cache dictionary and save the dictionary into the cache_file
         let cache._memory._cached = {'foo': 'bar'}
         call writefile(["{'foo': 'bar'}"], cache.cache_file)
         call cache.remove('foo')
@@ -163,10 +177,20 @@ Describe System.Cache.SingleFile
         let content = readfile(cache.cache_file)
         Assert Equals(content, ["{}"])
       End
+
+      It should remove a named cache from a cache dictionary only when autodump is 0
+        let cache._memory._cached = {'foo': 'bar'}
+        call writefile(["{'foo': 'bar'}"], cache.cache_file)
+        let cache.autodump = 0
+        call cache.remove('foo')
+        Assert !has_key(cache._memory._cached, 'foo')
+        let content = readfile(cache.cache_file)
+        Assert Equals(content, ["{'foo': 'bar'}"])
+      End
     End
 
     Context .clear()
-      It should clear a cache dictionary
+      It should clear a cache dictionary and save the dictionary into the cache_file
         let cache._memory._cached = {
               \ 'foo': 'foo',
               \ 'bar': 'bar',
@@ -176,6 +200,18 @@ Describe System.Cache.SingleFile
         Assert Equals(cache._memory._cached, {})
         let content = readfile(cache.cache_file)
         Assert Equals(content, ["{}"])
+      End
+      It should clear a cache dictionary only when autodump is 0
+        let cache._memory._cached = {
+              \ 'foo': 'foo',
+              \ 'bar': 'bar',
+              \}
+        call writefile(["{'foo': 'foo', 'bar': 'bar'}"], cache.cache_file)
+        let cache.autodump = 0
+        call cache.clear()
+        Assert Equals(cache._memory._cached, {})
+        let content = readfile(cache.cache_file)
+        Assert Equals(content, ["{'foo': 'foo', 'bar': 'bar'}"])
       End
     End
   End


### PR DESCRIPTION
While `System.Cache.File` create individual files for individual keys, I made a new cache module which use a single file to store a dictionary of `System.Cache.Memory`.

Users can use this new cache module as a permanent memory cache module.