### PR TITLE
Web.JSON: Encode JSON with indents

### DIFF
--- a/autoload/vital/__latest__/Web/JSON.vim
+++ b/autoload/vital/__latest__/Web/JSON.vim
@@ -13,11 +13,6 @@ function! s:_null() abort
   return 0
 endfunction
 
-let s:const = {}
-let s:const.true = function('s:_true')
-let s:const.false = function('s:_false')
-let s:const.null = function('s:_null')
-
 function! s:_resolve(val, prefix) abort
   let t = type(a:val)
   if t == type('')
@@ -34,6 +29,13 @@ endfunction
 
 function! s:_vital_created(module) abort
   " define constant variables
+  if !exists('s:const')
+    let s:const = {}
+    let s:const.true = function('s:_true')
+    let s:const.false = function('s:_false')
+    let s:const.null = function('s:_null')
+    lockvar s:const
+  endif
   call extend(a:module, s:const)
 endfunction
 

--- a/autoload/vital/__latest__/Web/JSON.vim
+++ b/autoload/vital/__latest__/Web/JSON.vim
@@ -107,6 +107,8 @@ function! s:encode(val, ...) abort
     return string(a:val)
   endif
 endfunction
+
+" @vimlint(EVL102, 1, l:ns)
 function! s:_encode_list(val, settings) abort
   if empty(a:val)
     return '[]'
@@ -130,6 +132,9 @@ function! s:_encode_list(val, settings) abort
           \)
   endif
 endfunction
+" @vimlint(EVL102, 0, l:ns)
+
+" @vimlint(EVL102, 1, l:ns)
 function! s:_encode_dict(val, settings) abort
   if empty(a:val)
     return '{}'
@@ -156,6 +161,7 @@ function! s:_encode_dict(val, settings) abort
           \)
   endif
 endfunction
+" @vimlint(EVL102, 0, l:ns)
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/doc/vital-web-json.txt
+++ b/doc/vital-web-json.txt
@@ -51,12 +51,12 @@ encode({object}[, {settings}])		*Vital.Web.JSON.encode()*
 	echo s:JSON.encode([s:JSON.true, s:JSON.false, s:JSON.null])
 	" => '[true, false, null]'
 <
-	{settings} is a |Dictionary| which allow the following:
+	{settings} is a |Dictionary| which allows the following:
 
 	'indent'
-	The number of spaces used as an indent. When the value is grater than
-	0, the encoded JSON will be formatted with the specified indent level.
-	The default value is 0.
+	The number of spaces used as an indentation. When the value is greater
+	than 0, the encoded JSON will be formatted with the specified indent
+	level. The default value is 0.
 >
 	echo s:JSON.encode({'a': 0, 'b': 1})
 	" => '{"a":0,"b":1}'
@@ -68,11 +68,11 @@ encode({object}[, {settings}])		*Vital.Web.JSON.encode()*
 <
 decode({json}[, {settings}])		*Vital.Web.JSON.decode()*
 	Decode a JSON string into an object that vim can treat.
-	{settings} is a |Dictionary| which allow the following:
+	{settings} is a |Dictionary| which allows the following:
 
 	'use_token'
-	Use special tokens (e.g. |Vital.Web.JSON.true|) to represent coresponding
-	javascript tokens (e.g. 'true').
+	Use special tokens (e.g. |Vital.Web.JSON.true|) to represent
+	corresponding javascript tokens (e.g. 'true').
 	Otherwise 1 or 0 are used to represent these.
 	The default value is 0.
 >

--- a/doc/vital-web-json.txt
+++ b/doc/vital-web-json.txt
@@ -1,6 +1,7 @@
 *vital-web-json.txt*			JSON parser written in pure Vim script.
 
 Maintainer: mattn <mattn.jp@gmail.com>
+            lambdalisue <lambdalisue@hashnote.net>
 
 ==============================================================================
 CONTENTS				*Vital.Web.JSON-contents*
@@ -17,6 +18,7 @@ INTRODUCTION				*Vital.Web.JSON-introduction*
 
 ==============================================================================
 INTERFACE				*Vital.Web.JSON-interface*
+
 ------------------------------------------------------------------------------
 CONSTS					*Vital.Web.JSON-consts*
 
@@ -41,31 +43,44 @@ null					*Vital.Web.JSON.null*
 ------------------------------------------------------------------------------
 FUNCTIONS				*Vital.Web.JSON-functions*
 
-encode({object})			*Vital.Web.JSON.encode()*
+encode({object}[, {settings}])		*Vital.Web.JSON.encode()*
 	Encode an object into a JSON string. Special tokens
 	(e.g. |Vital.Web.JSON.true|) are encoded into corresponding javascript
 	tokens (e.g. 'true').
 >
-    " it will echo '[true, false, null]'
-    echo s:JSON.encode([s:JSON.true, s:JSON.false, s:JSON.null])
->
-
-decode({json} [, {settings}])  		*Vital.Web.JSON.decode()*
-	Decode a JSON string into an object that vim can treat.
-	{settings} is a |Dictionary| which contains the following items:
-
-	"use_token"	    Default: 0
-		Use special tokens (e.g. |Vital.Web.JSON.true|) to
-		represent coresponding javascript tokens (e.g. 'true').
-		Otherwise 1 or 0 are used to represent these.
-
->
-    " a == [1, 0, 0]
-    let a = s:JSON.decode('[true, false, null]')
-    " b == [s:JSON.true, s:JSON.false, s:JSON.null]
-    let b = s:JSON.decode('[true, false, null]', {'use_token': 1})
+	echo s:JSON.encode([s:JSON.true, s:JSON.false, s:JSON.null])
+	" => '[true, false, null]'
 <
+	{settings} is a |Dictionary| which allow the following:
 
+	'indent'
+	The number of spaces used as an indent. When the value is grater than
+	0, the encoded JSON will be formatted with the specified indent level.
+	The default value is 0.
+>
+	echo s:JSON.encode({'a': 0, 'b': 1})
+	" => '{"a":0,"b":1}'
+	echo s:JSON.encode({'a': 0, 'b': 1}, {'indent': 2})
+	" => '{
+	"   "a": 0,
+	"   "b": 1
+	" }'
+<
+decode({json}[, {settings}])		*Vital.Web.JSON.decode()*
+	Decode a JSON string into an object that vim can treat.
+	{settings} is a |Dictionary| which allow the following:
+
+	'use_token'
+	Use special tokens (e.g. |Vital.Web.JSON.true|) to represent coresponding
+	javascript tokens (e.g. 'true').
+	Otherwise 1 or 0 are used to represent these.
+	The default value is 0.
+>
+	echo s:JSON.decode('[true, false, null]')
+	" => [1, 0, 0]
+	echo s:JSON.decode('[true, false, null]', {'use_token': 1})
+	" => [s:JSON.true, s:JSON.false, s:JSON.null]
+<
 
 =============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/Web/JSON.vimspec
+++ b/test/Web/JSON.vimspec
@@ -105,6 +105,49 @@ Describe Web.JSON
             \)
     End
 
+    It encodes lists with indent when {settings.indent} > 0
+      let s = { 'indent': 2 }
+      Assert Equals(JSON.encode([], s), '[]')
+      Assert Equals(
+            \ JSON.encode([0, 1, 2], s),
+            \ join([
+            \   '[',
+            \   '  0,',
+            \   '  1,',
+            \   '  2',
+            \   ']',
+            \ ], "\n"),
+            \)
+      Assert Equals(
+            \ JSON.encode(['a', 'b', 'c'], s),
+            \ join([
+            \   '[',
+            \   '  "a",',
+            \   '  "b",',
+            \   '  "c"',
+            \   ']',
+            \ ], "\n"),
+            \)
+      " list should be encoded recursively
+      Assert Equals(
+            \ JSON.encode([[0, 1, 2, ['a', 'b', 'c']]], s),
+            \ join([
+            \   '[',
+            \   '  [',
+            \   '    0,',
+            \   '    1,',
+            \   '    2,',
+            \   '    [',
+            \   '      "a",',
+            \   '      "b",',
+            \   '      "c"',
+            \   '    ]',
+            \   '  ]',
+            \   ']',
+            \ ], "\n"),
+            \)
+    End
+
     It encodes dictionaries
       Assert Equals(JSON.encode({}), '{}')
       Assert Equals(
@@ -119,6 +162,48 @@ Describe Web.JSON
       Assert Equals(
             \ JSON.encode({'a': {'b': {'c': [0, 1, 2]}}}),
             \ '{"a":{"b":{"c":[0,1,2]}}}',
+            \)
+    End
+
+    It encodes dictionaries with indent when {settings.indent} > 0
+      let s = { 'indent': 2 }
+      Assert Equals(JSON.encode({}, s), '{}')
+      Assert Equals(
+            \ JSON.encode({'a': 0, 'b': 1, 'c': 2}, s),
+            \ join([
+            \   '{',
+            \   '  "a": 0,',
+            \   '  "b": 1,',
+            \   '  "c": 2',
+            \   '}'
+            \ ], "\n")
+            \)
+      Assert Equals(
+            \ JSON.encode({'a': '0', 'b': '1', 'c': '2'}, s),
+            \ join([
+            \   '{',
+            \   '  "a": "0",',
+            \   '  "b": "1",',
+            \   '  "c": "2"',
+            \   '}'
+            \ ], "\n")
+            \)
+      " dictionary should be encoded recursively
+      Assert Equals(
+            \ JSON.encode({'a': {'b': {'c': [0, 1, 2]}}}, s),
+            \ join([
+            \   '{',
+            \   '  "a": {',
+            \   '    "b": {',
+            \   '      "c": [',
+            \   '        0,',
+            \   '        1,',
+            \   '        2',
+            \   '      ]',
+            \   '    }',
+            \   '  }',
+            \   '}',
+            \ ], "\n")
             \)
     End
 

--- a/test/Web/JSON.vimspec
+++ b/test/Web/JSON.vimspec
@@ -13,94 +13,120 @@ Describe Web.JSON
 
   Describe .decode()
     It decodes numbers
-      Assert Equals(0, JSON.decode(0))
-      Assert Equals(10, JSON.decode(10))
-      Assert Equals(100, JSON.decode(100))
+      Assert Equals(JSON.decode(0), 0)
+      Assert Equals(JSON.decode(10), 10)
+      Assert Equals(JSON.decode(100), 100)
     End
 
     It decodes strings
-      Assert Equals("", JSON.decode('""'))
-      Assert Equals("a", JSON.decode('"a"'))
-      Assert Equals("a\rb", JSON.decode('"a\rb"'))
-      Assert Equals("a\nb", JSON.decode('"a\nb"'))
-      Assert Equals("a\tb", JSON.decode('"a\tb"'))
+      Assert Equals(JSON.decode('""'), '')
+      Assert Equals(JSON.decode('"a"'), 'a')
+      Assert Equals(JSON.decode('"a\rb"'), "a\rb")
+      Assert Equals(JSON.decode('"a\nb"'), "a\nb")
+      Assert Equals(JSON.decode('"a\tb"'), "a\tb")
       " double quotation
-      Assert Equals('He said "I''m a vimmer"', JSON.decode('"He said \"I''m a vimmer\""'))
+      Assert Equals(
+            \ JSON.decode('"He said \"I''m a vimmer\""'),
+            \ 'He said "I''m a vimmer"'
+            \)
       " there should be iconv tests as well
     End
 
     It decodes lists
-      Assert Equals([], JSON.decode('[]'))
-      Assert Equals([0,1,2], JSON.decode('[0, 1, 2]'))
-      Assert Equals(["a","b","c"], JSON.decode('["a", "b", "c"]'))
+      Assert Equals(JSON.decode('[]'), [])
+      Assert Equals(JSON.decode('[0, 1, 2]'), [0, 1, 2])
+      Assert Equals(JSON.decode('["a", "b", "c"]'), ['a', 'b', 'c'])
       " list should be encoded recursively
-      Assert Equals([[0,1,2],["a","b","c"]], JSON.decode('[[0,1,2],["a","b","c"]]'))
+      Assert Equals(
+            \ JSON.decode('[[0, 1, 2], ["a", "b", "c"]]'),
+            \ [[0, 1, 2], ['a', 'b', 'c']]
+            \)
     End
 
     It decodes dictionaries
-      Assert Equals({}, JSON.decode('{}'))
-      Assert Equals({"a":0,"b":1,"c":2}, JSON.decode('{"a":0,"b":1,"c":2}'))
-      Assert Equals({'a':'0','b':'1','c':'2'}, JSON.decode('{"a":"0","b":"1","c":"2"}'))
+      Assert Equals(JSON.decode('{}'), {})
+      Assert Equals(
+            \ JSON.decode('{"a": 0, "b": 1, "c": 2}'),
+            \ {'a': 0, 'b': 1, 'c': 2}
+            \)
+      Assert Equals(
+            \ JSON.decode('{"a": "0", "b": "1", "c": "2"}'),
+            \ {'a': '0', 'b': '1', 'c': '2'}
+            \)
       " dictionary should be encoded recursively
-      Assert Equals({"a":{"b":{"c":[0,1,2]}}}, JSON.decode('{"a":{"b":{"c":[0,1,2]}}}'))
+      Assert Equals(
+            \ JSON.decode('{"a": {"b": {"c": [0, 1, 2]}}}'),
+            \ {'a': {'b': {'c': [0, 1, 2]}}}
+            \)
     End
 
     It decodes special tokens (true/false/null)
       " true/false/null
-      Assert Equals(1, JSON.decode('true'))
-      Assert Equals(0, JSON.decode('false'))
-      Assert Equals(0, JSON.decode('null'))
+      Assert Equals(JSON.decode('true'), 1)
+      Assert Equals(JSON.decode('false'), 0)
+      Assert Equals(JSON.decode('null'), 0)
 
-      Assert Equals(JSON.true, JSON.decode('true', {'use_token': 1}))
-      Assert Equals(JSON.false, JSON.decode('false', {'use_token': 1}))
-      Assert Equals(JSON.null, JSON.decode('null', {'use_token': 1}))
+      let s = { 'use_token': 1 }
+      Assert Equals(JSON.decode('true', s), JSON.true)
+      Assert Equals(JSON.decode('false', s), JSON.false)
+      Assert Equals(JSON.decode('null', s), JSON.null)
     End
   End
 
   Describe .encode()
     It encodes numbers
-      Assert Equals(0, JSON.encode(0))
-      Assert Equals(10, JSON.encode(10))
-      Assert Equals(100, JSON.encode(100))
+      Assert Equals(JSON.encode(0), 0)
+      Assert Equals(JSON.encode(10), 10)
+      Assert Equals(JSON.encode(100), 100)
     End
 
     It encodes strings
-      Assert Equals('""', JSON.encode(""))
-      Assert Equals('"a"', JSON.encode("a"))
-      Assert Equals('"a\rb"', JSON.encode("a\rb"))
-      Assert Equals('"a\nb"', JSON.encode("a\nb"))
-      Assert Equals('"a\tb"', JSON.encode("a\tb"))
+      Assert Equals(JSON.encode(''), '""')
+      Assert Equals(JSON.encode('a'), '"a"')
+      Assert Equals(JSON.encode("a\rb"), '"a\rb"')
+      Assert Equals(JSON.encode("a\nb"), '"a\nb"')
+      Assert Equals(JSON.encode("a\tb"), '"a\tb"')
       " double quotation should be escaped
-      Assert Equals('"He said \"I''m a vimmer\""', JSON.encode('He said "I''m a vimmer"'))
+      Assert Equals(
+            \ JSON.encode('He said "I''m a vimmer"'),
+            \ '"He said \"I''m a vimmer\""'
+            \)
       " there should be iconv tests as well
     End
 
     It encodes lists
-      Assert Equals('[]', JSON.encode([]))
-      Assert Equals('[0,1,2]', JSON.encode([0, 1, 2]))
-      Assert Equals('["a","b","c"]', JSON.encode(["a", "b", "c"]))
+      Assert Equals(JSON.encode([]), '[]')
+      Assert Equals(JSON.encode([0, 1, 2]), '[0,1,2]')
+      Assert Equals(JSON.encode(['a', 'b', 'c']), '["a","b","c"]')
       " list should be encoded recursively
-      Assert Equals('[[0,1,2],["a","b","c"]]', JSON.encode([
-            \ [0, 1, 2],
-            \ ["a", "b", "c"],
-            \]))
+      Assert Equals(
+            \ JSON.encode([[0, 1, 2], ['a', 'b', 'c']]),
+            \ '[[0,1,2],["a","b","c"]]'
+            \)
     End
 
     It encodes dictionaries
-      Assert Equals('{}', JSON.encode({}))
-      Assert Equals('{"a":0,"b":1,"c":2}', JSON.encode({'a': 0, 'b': 1, 'c': 2}))
-      Assert Equals('{"a":"0","b":"1","c":"2"}', JSON.encode({'a': '0', 'b': '1', 'c': '2'}))
+      Assert Equals(JSON.encode({}), '{}')
+      Assert Equals(
+            \ JSON.encode({'a': 0, 'b': 1, 'c': 2}),
+            \ '{"a":0,"b":1,"c":2}'
+            \)
+      Assert Equals(
+            \ JSON.encode({'a': '0', 'b': '1', 'c': '2'}),
+            \ '{"a":"0","b":"1","c":"2"}'
+            \)
       " dictionary should be encoded recursively
-      Assert Equals('{"a":{"b":{"c":[0,1,2]}}}', JSON.encode(
-            \ {'a': {'b': {'c': [0, 1, 2]}}}
-            \))
+      Assert Equals(
+            \ JSON.encode({'a': {'b': {'c': [0, 1, 2]}}}),
+            \ '{"a":{"b":{"c":[0,1,2]}}}',
+            \)
     End
 
     " JavaScript special tokens
     It encodes special tokens (true/false/null)
-      Assert Equals('true', JSON.encode(JSON.true))
-      Assert Equals('false', JSON.encode(JSON.false))
-      Assert Equals('null', JSON.encode(JSON.null))
+      Assert Equals(JSON.encode(JSON.true), 'true')
+      Assert Equals(JSON.encode(JSON.false), 'false')
+      Assert Equals(JSON.encode(JSON.null), 'null')
     End
   End
 End


### PR DESCRIPTION
With this changes, `s:JSON.encode({obj}, { 'indent': 2 })` encode `{obj}` into a JSON string **with indents**.

```vim
echo s:JSON.encode({'a': 0, 'b': 1})
" => '{"a":0,"b":1}'
echo s:JSON.encode({'a': 0, 'b': 1}, {'indent': 2})
" => '{
"   "a": 0,
"   "b": 1
" }'
```
