### PR TITLE
Data.List: Fix order of args for Assert Equals()

### DIFF
--- a/test/Data/List.vimspec
+++ b/test/Data/List.vimspec
@@ -6,13 +6,13 @@ Describe Data.List
   Describe .pop()
     It removes the last element from a list and returns that element
       let a = [1,2,3]
-      Assert Equals(3, List.pop(a))
-      Assert Equals([1, 2], a)
-      Assert Equals(2, List.pop(a))
-      Assert Equals([1], a)
-      Assert Equals(1, List.pop(a))
-      Assert Equals([], a)
-      Assert Equals(9, List.pop(range(10)))
+      Assert Equals(List.pop(a), 3)
+      Assert Equals(a, [1, 2])
+      Assert Equals(List.pop(a), 2)
+      Assert Equals(a, [1])
+      Assert Equals(List.pop(a), 1)
+      Assert Equals(a, [])
+      Assert Equals(List.pop(range(10)), 9)
     End
 
     It causes an error when the list is empty
@@ -23,25 +23,25 @@ Describe Data.List
   Describe .push()
     It appends an element to a list and returns the list itself
       let a = []
-      Assert Equals([1], List.push(a, 1))
-      Assert Equals([1], a)
-      Assert Equals([1,2], List.push(a, 2))
-      Assert Equals([1,2], a)
-      Assert Equals([1, 2, 3, 4], List.push([1, 2, 3], 4))
-      Assert Equals([7, 8, 9, 10], List.push(range(7, 9), 10))
+      Assert Equals(List.push(a, 1), [1])
+      Assert Equals(a, [1])
+      Assert Equals(List.push(a, 2), [1,2])
+      Assert Equals(a, [1,2])
+      Assert Equals(List.push([1, 2, 3], 4), [1, 2, 3, 4])
+      Assert Equals(List.push(range(7, 9), 10), [7, 8, 9, 10])
     End
   End
 
   Describe .shift()
     It removes the first element from a list and returns that element
       let a = [1,2,3]
-      Assert Equals(1, List.shift(a))
-      Assert Equals([2,3], a)
-      Assert Equals(2, List.shift(a))
-      Assert Equals([3], a)
-      Assert Equals(3, List.shift(a))
-      Assert Equals([], a)
-      Assert Equals(0, List.shift(range(10)))
+      Assert Equals(List.shift(a), 1)
+      Assert Equals(a, [2,3])
+      Assert Equals(List.shift(a), 2)
+      Assert Equals(a, [3])
+      Assert Equals(List.shift(a), 3)
+      Assert Equals(a, [])
+      Assert Equals(List.shift(range(10)), 0)
     End
 
     It causes an error when the list is empty
@@ -52,12 +52,12 @@ Describe Data.List
   Describe .unshift()
     It inserts an element to the head of a list and returns the list itself
       let a = []
-      Assert Equals([1], List.unshift(a, 1))
-      Assert Equals([1], a)
-      Assert Equals([2,1], List.unshift(a, 2))
-      Assert Equals([2,1], a)
-      Assert Equals([4, 1, 2, 3], List.unshift([1, 2, 3], 4))
-      Assert Equals([10, 7, 8, 9], List.unshift(range(7, 9), 10))
+      Assert Equals(List.unshift(a, 1), [1])
+      Assert Equals(a, [1])
+      Assert Equals(List.unshift(a, 2), [2,1])
+      Assert Equals(a, [2,1])
+      Assert Equals(List.unshift([1, 2, 3], 4), [4, 1, 2, 3])
+      Assert Equals(List.unshift(range(7, 9), 10), [10, 7, 8, 9])
     End
   End
 
@@ -65,10 +65,10 @@ Describe Data.List
     It makes new list which first item is {val} and the rest of items are {list}.
       let a = []
       Assert Equals(List.cons(1, a), [1])
-      Assert Equals([], a)
+      Assert Equals(a, [])
       let a = [1]
       Assert Equals(List.cons(2, a), [2, 1])
-      Assert Equals([1], a)
+      Assert Equals(a, [1])
       Assert Equals(List.cons(1, [2, 3]), [1, 2, 3])
       Assert Equals(List.cons(1, []), [1])
       Assert Equals(List.cons([1], [2, 3]), [[1], 2, 3])
@@ -79,10 +79,10 @@ Describe Data.List
     It makes new list which last items are {val} and the preceding items remain {list}.
       let a = []
       Assert Equals(List.conj(a, 1), [1])
-      Assert Equals([], a)
+      Assert Equals(a, [])
       let a = [1]
       Assert Equals(List.conj(a, 2), [1, 2])
-      Assert Equals([1], a)
+      Assert Equals(a, [1])
       Assert Equals(List.conj([2, 3], 1), [2, 3, 1])
       Assert Equals(List.conj([], 1), [1])
       Assert Equals(List.conj([2, 3], [1]), [2, 3, [1]])
@@ -92,28 +92,28 @@ Describe Data.List
   Describe .uniq()
     It makes a list unique
       let a = ['vim', 'emacs', 'vim', 'vim']
-      Assert Equals(['vim', 'emacs'], List.uniq(a))
+      Assert Equals(List.uniq(a), ['vim', 'emacs'])
       Assert Equals(a, ['vim', 'emacs', 'vim', 'vim'])
-      Assert Equals([1.23, [1]], List.uniq([1.23, [1], [1], 1.23]))
-      Assert Equals([{'a': 0, 'b': 1}], List.uniq([{'a': 0, 'b': 1}, {'b': 1, 'a': 0}]))
+      Assert Equals(List.uniq([1.23, [1], [1], 1.23]), [1.23, [1]])
+      Assert Equals(List.uniq([{'a': 0, 'b': 1}, {'b': 1, 'a': 0}]), [{'a': 0, 'b': 1}])
     End
 
     It supports empty strings as well
-      Assert Equals(['', 'v', 'vv'], List.uniq(['', '', 'v', 'vv', '', 'vv', 'v']))
+      Assert Equals(List.uniq(['', '', 'v', 'vv', '', 'vv', 'v']), ['', 'v', 'vv'])
     End
   End
 
   Describe .uniq_by()
     It makes a list unique based on given expression
       Assert Equals(
-      \ [
-      \   'vim', 'emacs', 'gVim'
-      \ ],
       \ List.uniq_by([
       \       'vim', 'Vim', 'VIM', 'emacs', 'Emacs', 'EMACS', 'gVim', 'GVIM'
       \     ],
       \     'tolower(v:val)'
-      \   )
+      \   ),
+      \ [
+      \   'vim', 'emacs', 'gVim'
+      \ ]
       \ )
     End
   End
@@ -121,7 +121,7 @@ Describe Data.List
   Describe .clear()
     It clears the all items of a list
       let list = [1, 2, 3]
-      Assert Equals([], List.clear(list))
+      Assert Equals(List.clear(list), [])
       Assert Equals(list, [])
     End
 
@@ -140,66 +140,66 @@ Describe Data.List
 
   Describe .max_by()
     It returns a maximum value in the list through the given expr.
-      Assert Equals('hehehe', List.max_by(['hoge', 'foo', 'hehehe', 'yahoo'], 'len(v:val)'))
-      Assert Equals(-50, List.max_by([20, -50, -15, 30], 'abs(v:val)'))
+      Assert Equals(List.max_by(['hoge', 'foo', 'hehehe', 'yahoo'], 'len(v:val)'), 'hehehe')
+      Assert Equals(List.max_by([20, -50, -15, 30], 'abs(v:val)'), -50)
     End
     It returns 0 if the list is empty.
-      Assert Equals(0, List.max_by([], 'v:val'))
+      Assert Equals(List.max_by([], 'v:val'), 0)
     End
   End
 
   Describe .min_by()
     It returns a minimum value in the list through the given expr.
-      Assert Equals('foo', List.min_by(['hoge', 'foo', 'hehehe', 'yahoo'], 'len(v:val)'))
-      Assert Equals(-15, List.min_by([20, -50, -15, 30], 'abs(v:val)'))
+      Assert Equals(List.min_by(['hoge', 'foo', 'hehehe', 'yahoo'], 'len(v:val)'), 'foo')
+      Assert Equals(List.min_by([20, -50, -15, 30], 'abs(v:val)'), -15)
     End
     It returns 0 if the list is empty.
-      Assert Equals(0, List.min_by([], 'v:val'))
+      Assert Equals(List.min_by([], 'v:val'), 0)
     End
   End
 
   Describe .span()
     It splits a list into two lists. The former is until the given condition doesn't satisfy.
-      Assert Equals([[1, 3], [5, 2]], List.span('v:val < 5', [1, 3, 5, 2]))
-      Assert Equals([[], [1, 2, 3, 4, 5]], List.span('v:val > 3', [1, 2, 3, 4, 5]))
-      Assert Equals([[1, 2], [3, 4, 5]], List.span('v:val < 3', [1, 2, 3, 4, 5]))
+      Assert Equals(List.span('v:val < 5', [1, 3, 5, 2]), [[1, 3], [5, 2]])
+      Assert Equals(List.span('v:val > 3', [1, 2, 3, 4, 5]), [[], [1, 2, 3, 4, 5]])
+      Assert Equals(List.span('v:val < 3', [1, 2, 3, 4, 5]), [[1, 2], [3, 4, 5]])
     End
 
     It of course handles list of list.
-      Assert Equals([[[1], [2, 3]], [[], [4]]],
-            \ List.span('len(v:val) > 0', [[1], [2, 3], [], [4]]))
+      Assert Equals(List.span('len(v:val) > 0', [[1], [2, 3], [], [4]]),
+            \ [[[1], [2, 3]], [[], [4]]])
     End
   End
 
   Describe .break()
     It splits a list into two lists. The latter is from the given condition satisfies.
-      Assert Equals([[1, 3], [5, 2]], List.break('v:val == 5', [1, 3, 5, 2]))
-      Assert Equals([[1, 2, 3], [4, 5]], List.break('v:val > 3', [1, 2, 3, 4, 5]))
-      Assert Equals([[], [1, 2, 3, 4, 5]], List.break('v:val < 3', [1, 2, 3, 4, 5]))
+      Assert Equals(List.break('v:val == 5', [1, 3, 5, 2]), [[1, 3], [5, 2]])
+      Assert Equals(List.break('v:val > 3', [1, 2, 3, 4, 5]), [[1, 2, 3], [4, 5]])
+      Assert Equals(List.break('v:val < 3', [1, 2, 3, 4, 5]), [[], [1, 2, 3, 4, 5]])
     End
 
     It of course handles list of list.
-      Assert Equals([[[1], [2, 3]], [[], [4]]],
-            \ List.break('len(v:val) == 0', [[1], [2, 3], [], [4]]))
+      Assert Equals(List.break('len(v:val) == 0', [[1], [2, 3], [], [4]]),
+            \ [[[1], [2, 3]], [[], [4]]],)
     End
   End
 
   Describe .take_while()
     It creates a list from another one, it inspects the original list and takes from its elements to the moment when the condition fails, then it stops processing
-      Assert Equals([1, 3], List.take_while('v:val < 5', [1, 3, 5, 2]))
-      Assert Equals([], List.take_while('v:val > 3', [1, 2, 3, 4, 5]))
-      Assert Equals([1, 2], List.take_while('v:val < 3', [1, 2, 3, 4, 5]))
+      Assert Equals(List.take_while('v:val < 5', [1, 3, 5, 2]), [1, 3])
+      Assert Equals(List.take_while('v:val > 3', [1, 2, 3, 4, 5]), [])
+      Assert Equals(List.take_while('v:val < 3', [1, 2, 3, 4, 5]), [1, 2])
     End
 
     It of course handles list of list.
-      Assert Equals([[1], [2, 3]],
-            \ List.take_while('len(v:val) > 0', [[1], [2, 3], [], [4]]))
+      Assert Equals(List.take_while('len(v:val) > 0', [[1], [2, 3], [], [4]]),
+            \ [[1], [2, 3]])
     End
   End
 
   Describe .partition()
     It takes a predicate a list and returns the pair of lists of elements which do and do not satisfy the predicate.
-      Assert Equals([[0, 2, 4], [1, 3]], List.partition('v:val % 2 == 0', range(5)))
+      Assert Equals(List.partition('v:val % 2 == 0', range(5)), [[0, 2, 4], [1, 3]])
     End
   End
 
@@ -254,27 +254,27 @@ Describe Data.List
 
   Describe .map_accum()
     It is similar to map() but holds previous accumulator as well
-      Assert Equals([11, 12, 13], List.map_accum('[v:val + v:memo, v:memo]', [1, 2, 3], 10))
-      Assert Equals([11, 13, 15], List.map_accum('[v:val + v:memo, v:memo + 1]', [1, 2, 3], 10))
+      Assert Equals(List.map_accum('[v:val + v:memo, v:memo]', [1, 2, 3], 10), [11, 12, 13])
+      Assert Equals(List.map_accum('[v:val + v:memo, v:memo + 1]', [1, 2, 3], 10), [11, 13, 15])
     End
     " TODO test more details
   End
 
   Describe .foldl()
     It folds a list from left
-      Assert Equals(55, List.foldl('v:memo + v:val', 0, range(1, 10)))
-      Assert Equals([[[], 1], 2], List.foldl('[v:memo, v:val]', [], [1, 2]))
+      Assert Equals(List.foldl('v:memo + v:val', 0, range(1, 10)), 55)
+      Assert Equals(List.foldl('[v:memo, v:val]', [], [1, 2]), [[[], 1], 2])
     End
 
     It does nothing if the list is empty
-      Assert Equals(123, List.foldl('echoerr omg', 123, []))
+      Assert Equals(List.foldl('echoerr omg', 123, []), 123)
     End
   End
 
   Describe .foldl1()
     It folds a list from left
-      Assert Equals(55, List.foldl1('v:memo + v:val', range(1, 10)))
-      Assert Equals([1, 2], List.foldl1('[v:memo, v:val]', [1, 2]))
+      Assert Equals(List.foldl1('v:memo + v:val', range(1, 10)), 55)
+      Assert Equals(List.foldl1('[v:memo, v:val]', [1, 2]), [1, 2])
     End
 
     It causes an error when the list is empty
@@ -284,19 +284,19 @@ Describe Data.List
 
   Describe .foldr()
     It folds a list from right
-      Assert Equals(55, List.foldr('v:memo + v:val', 0, range(1, 10)))
-      Assert Equals([[[], 2], 1], List.foldr('[v:memo, v:val]', [], [1, 2]))
+      Assert Equals(List.foldr('v:memo + v:val', 0, range(1, 10)), 55)
+      Assert Equals(List.foldr('[v:memo, v:val]', [], [1, 2]), [[[], 2], 1])
     End
 
     It does nothing if the list is empty
-      Assert Equals(123, List.foldr('echoerr omg', 123, []))
+      Assert Equals(List.foldr('echoerr omg', 123, []), 123)
     End
   End
 
   Describe .foldr1()
     It folds a list from left
-      Assert Equals(55, List.foldr1('v:memo + v:val', range(1, 10)))
-      Assert Equals([2, 1], List.foldr1('[v:memo, v:val]', [1, 2]))
+      Assert Equals(List.foldr1('v:memo + v:val', range(1, 10)), 55)
+      Assert Equals(List.foldr1('[v:memo, v:val]', [1, 2]), [2, 1])
     End
 
     It causes an error when the list is empty


### PR DESCRIPTION
いい感じにパースしてや...りたかったんですがちょっと面倒そうだったので
sideways.vimとマクロを使って目視で変更しました．

`/\vAssert Equals\([^Lla]` した限りでは修正抜けは無いことになっています．