### PR TITLE
Vim.Python: Add a new module for +python/+python3 compatibility functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Module						 | Description
 [Vim.Buffer](doc/vital-vim-buffer.txt)		 | Vim's buffer related stuff in general
 [Vim.BufferManager](doc/vital-vim-buffer_manager.txt)  | buffer manager
 [Vim.Compat](doc/vital-vim-compat.txt)		 | Vim compatibility wrapper functions
+[Vim.Python](doc/vital-vim-python.txt)		 | +python/+python3 compatibility functions
 [Vim.Message](doc/vital-vim-message.txt)	 | Vim message functions
 [Vim.Search](doc/vital-vim-search.txt)		 | Vim's [I like function
 [Vim.ScriptLocal](doc/vital-vim-script_local.txt) | Get script-local things

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ install:
   - 'appveyor DownloadFile https://github.com/Shougo/vimproc.vim/releases/download/ver.9.2/vimproc_win64.dll -FileName %TEMP%\vimproc\lib\vimproc_win64.dll'
 
   - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5 --single-branch --depth 1 %TEMP%\vim-themis'
+  - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
+  - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'
 build: off
 test_script:
   - '%THEMIS_VIM% --version'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,5 @@ install:
 build: off
 test_script:
   - '%THEMIS_VIM% --version'
-  - '%TEMP%\vim-themis\bin\themis.bat --runtimepath %TEMP%\vimproc --exclude ConcurrentProcess'
+  - '%TEMP%\vim-themis\bin\themis.bat --runtimepath %TEMP%\vimproc --exclude ConcurrentProcess --reporter dot'
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,5 +17,5 @@ install:
 build: off
 test_script:
   - '%THEMIS_VIM% --version'
-  - '%TEMP%\vim-themis\bin\themis.bat --runtimepath %TEMP%\vimproc --exclude ConcurrentProcess --reporter dot'
+  - '%TEMP%\vim-themis\bin\themis.bat --runtimepath %TEMP%\vimproc --exclude ConcurrentProcess'
 deploy: off

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -1,0 +1,80 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+
+let s:has_python2 = has('python')
+let s:has_python3 = has('python3')
+let s:current_major_version = 0
+let s:default_major_version = 2
+
+function! s:_throw(msg) abort
+  throw printf('vital: Vim.Python: %s', a:msg)
+endfunction
+
+function! s:_get_valid_major_version(version) abort
+  if a:version == 2 && !s:has_python2
+    call s:_throw('+python is required')
+  elseif a:version == 3 && !s:has_python3
+    call s:_throw('+python3 is required')
+  elseif !s:has_python2 && !s:has_python3
+    call s:_throw('+python and/or +python3 is required')
+  endif
+  return a:version == 0
+        \ ? s:current_major_version == 0
+        \   ? s:default_major_version
+        \   : s:current_major_version
+        \ : a:version
+endfunction
+
+
+function! s:is_enabled() abort
+  return s:has_python2 || s:has_python3
+endfunction
+
+function! s:get_major_version() abort
+  if s:has_python2 && s:has_python3
+    return s:_get_valid_major_version(s:current_major_version)
+  elseif s:has_python2 || s:has_python3
+    return s:has_python2 ? 2 : 3
+  endif
+  return 0
+endfunction
+
+function! s:set_major_version(version) abort
+  let s:current_major_version = s:_get_valid_major_version(a:version)
+endfunction
+
+function! s:exec_file(path, ...) abort
+  let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
+  if s:has_python2 && s:has_python3
+    let exec = major_version == 2 ? 'pyfile' : 'py3file'
+  else
+    let exec = s:has_python2 ? 'pyfile' : 'py3file'
+  endif
+  execute printf('%s %s', exec, a:path)
+endfunction
+
+function! s:exec_code(code, ...) abort
+  let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
+  let code = type(a:code) == type('') ? a:code : join(a:code, "\n")
+  if s:has_python2 && s:has_python3
+    let exec = major_version == 2 ? 'python' : 'python3'
+  else
+    let exec = s:has_python2 ? 'python' : 'python3'
+  endif
+  execute printf('%s %s', exec, code)
+endfunction
+
+function! s:eval_expr(expr, ...) abort
+  let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
+  if s:has_python2 && s:has_python3
+    return major_version == 2 ? pyeval(a:expr) : py3eval(a:expr)
+  else
+    return s:has_python2 ? pyeval(a:expr) : py3eval(a:expr)
+  endif
+endfunction
+
+
+let &cpo = s:save_cpo
+unlet! s:save_cpo
+" vim:set et ts=2 sts=2 sw=2 tw=0 fdm=marker:

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -67,10 +67,11 @@ endfunction
 if v:version >= 704 || (v:version == 703 && has('patch601'))
   function! s:eval_expr(expr, ...) abort
     let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
+    let expr = type(a:expr) == type('') ? a:expr : join(a:expr, "\n")
     if s:has_python2 && s:has_python3
-      return major_version == 2 ? pyeval(a:expr) : py3eval(a:expr)
+      return major_version == 2 ? pyeval(expr) : py3eval(expr)
     else
-      return s:has_python2 ? pyeval(a:expr) : py3eval(a:expr)
+      return s:has_python2 ? pyeval(expr) : py3eval(expr)
     endif
   endfunction
 else

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -39,7 +39,7 @@ function! s:is_python2_enabled() abort
     let s:is_python2_enabled = 0
   else
     try
-      python import sys
+      python 0
       let s:is_python2_enabled = 1
     catch /^Vim\%((\a\+)\)\=:\%(E263\|E264\|E887\)/
       let s:is_python2_enabled = 0
@@ -55,7 +55,7 @@ function! s:is_python3_enabled() abort
     let s:is_python3_enabled = 0
   else
     try
-      python3 import sys
+      python3 0
       let s:is_python3_enabled = 1
     catch /^Vim\%((\a\+)\)\=:\%(E263\|E264\|E887\)/
       let s:is_python3_enabled = 0

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -50,7 +50,7 @@ function! s:exec_file(path, ...) abort
   else
     let exec = s:has_python2 ? 'pyfile' : 'py3file'
   endif
-  execute printf('%s %s', exec, a:path)
+  return printf('%s %s', exec, a:path)
 endfunction
 
 function! s:exec_code(code, ...) abort
@@ -61,7 +61,7 @@ function! s:exec_code(code, ...) abort
   else
     let exec = s:has_python2 ? 'python' : 'python3'
   endif
-  execute printf('%s %s', exec, code)
+  return printf('%s %s', exec, code)
 endfunction
 
 if v:version >= 704 || (v:version == 703 && has('patch601'))

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -11,7 +11,9 @@ function! s:_throw(msg) abort
 endfunction
 
 function! s:_get_valid_major_version(version) abort
-  if a:version == 2 && !s:has_python2
+  if index([0, 2, 3], a:version) == -1
+    call s:_throw('"version" requires to be 0, 2, or 3')
+  elseif a:version == 2 && !s:has_python2
     call s:_throw('+python is required')
   elseif a:version == 3 && !s:has_python3
     call s:_throw('+python3 is required')

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -1,8 +1,6 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:has_python2 = has('python')
-let s:has_python3 = has('python3')
 let s:current_major_version = 0
 let s:default_major_version = 2
 

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -2,7 +2,6 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 let s:current_major_version = 0
-let s:default_major_version = 2
 
 function! s:_throw(msg) abort
   throw printf('vital: Vim.Python: %s', a:msg)
@@ -20,7 +19,9 @@ function! s:_get_valid_major_version(version) abort
   endif
   return a:version == 0
         \ ? s:current_major_version == 0
-        \   ? s:default_major_version
+        \   ? s:is_python2_enabled()
+        \     ? 2
+        \     : 3
         \   : s:current_major_version
         \ : a:version
 endfunction

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -1,7 +1,6 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-
 let s:has_python2 = has('python')
 let s:has_python3 = has('python3')
 let s:current_major_version = 0
@@ -65,14 +64,20 @@ function! s:exec_code(code, ...) abort
   execute printf('%s %s', exec, code)
 endfunction
 
-function! s:eval_expr(expr, ...) abort
-  let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
-  if s:has_python2 && s:has_python3
-    return major_version == 2 ? pyeval(a:expr) : py3eval(a:expr)
-  else
-    return s:has_python2 ? pyeval(a:expr) : py3eval(a:expr)
-  endif
-endfunction
+if v:version >= 704 || (v:version == 703 && has('patch601'))
+  function! s:eval_expr(expr, ...) abort
+    let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
+    if s:has_python2 && s:has_python3
+      return major_version == 2 ? pyeval(a:expr) : py3eval(a:expr)
+    else
+      return s:has_python2 ? pyeval(a:expr) : py3eval(a:expr)
+    endif
+  endfunction
+else
+  function! s:eval_expr(expr, ...) abort
+    call s:_throw('eval_expr() requires Vim 7.3.601 or later')
+  endfunction
+endif
 
 
 let &cpo = s:save_cpo

--- a/autoload/vital/__latest__/Vim/Python.vim
+++ b/autoload/vital/__latest__/Vim/Python.vim
@@ -13,11 +13,11 @@ endfunction
 function! s:_get_valid_major_version(version) abort
   if index([0, 2, 3], a:version) == -1
     call s:_throw('"version" requires to be 0, 2, or 3')
-  elseif a:version == 2 && !s:has_python2
+  elseif a:version == 2 && !s:is_python2_enabled()
     call s:_throw('+python is required')
-  elseif a:version == 3 && !s:has_python3
+  elseif a:version == 3 && !s:is_python3_enabled()
     call s:_throw('+python3 is required')
-  elseif !s:has_python2 && !s:has_python3
+  elseif !s:is_enabled()
     call s:_throw('+python and/or +python3 is required')
   endif
   return a:version == 0
@@ -29,14 +29,46 @@ endfunction
 
 
 function! s:is_enabled() abort
-  return s:has_python2 || s:has_python3
+  return s:is_python2_enabled() || s:is_python3_enabled()
+endfunction
+function! s:is_python2_enabled() abort
+  if exists('s:is_python2_enabled')
+    return s:is_python2_enabled
+  endif
+  if !has('python')
+    let s:is_python2_enabled = 0
+  else
+    try
+      python import sys
+      let s:is_python2_enabled = 1
+    catch /^Vim\%((\a\+)\)\=:\%(E263\|E264\|E887\)/
+      let s:is_python2_enabled = 0
+    endtry
+  endif
+  return s:is_python2_enabled
+endfunction
+function! s:is_python3_enabled() abort
+  if exists('s:is_python3_enabled')
+    return s:is_python3_enabled
+  endif
+  if !has('python3')
+    let s:is_python3_enabled = 0
+  else
+    try
+      python3 import sys
+      let s:is_python3_enabled = 1
+    catch /^Vim\%((\a\+)\)\=:\%(E263\|E264\|E887\)/
+      let s:is_python3_enabled = 0
+    endtry
+  endif
+  return s:is_python3_enabled
 endfunction
 
 function! s:get_major_version() abort
-  if s:has_python2 && s:has_python3
+  if s:is_python2_enabled() && s:is_python3_enabled()
     return s:_get_valid_major_version(s:current_major_version)
-  elseif s:has_python2 || s:has_python3
-    return s:has_python2 ? 2 : 3
+  elseif s:is_enabled()
+    return s:is_python2_enabled() ? 2 : 3
   endif
   return 0
 endfunction
@@ -47,10 +79,10 @@ endfunction
 
 function! s:exec_file(path, ...) abort
   let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
-  if s:has_python2 && s:has_python3
+  if s:is_python2_enabled() && s:is_python3_enabled()
     let exec = major_version == 2 ? 'pyfile' : 'py3file'
   else
-    let exec = s:has_python2 ? 'pyfile' : 'py3file'
+    let exec = s:is_python2_enabled() ? 'pyfile' : 'py3file'
   endif
   return printf('%s %s', exec, a:path)
 endfunction
@@ -58,10 +90,10 @@ endfunction
 function! s:exec_code(code, ...) abort
   let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
   let code = type(a:code) == type('') ? a:code : join(a:code, "\n")
-  if s:has_python2 && s:has_python3
+  if s:is_python2_enabled() && s:is_python3_enabled()
     let exec = major_version == 2 ? 'python' : 'python3'
   else
-    let exec = s:has_python2 ? 'python' : 'python3'
+    let exec = s:is_python2_enabled() ? 'python' : 'python3'
   endif
   return printf('%s %s', exec, code)
 endfunction
@@ -70,10 +102,10 @@ if v:version >= 704 || (v:version == 703 && has('patch601'))
   function! s:eval_expr(expr, ...) abort
     let major_version = s:_get_valid_major_version(get(a:000, 0, 0))
     let expr = type(a:expr) == type('') ? a:expr : join(a:expr, "\n")
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled() && s:is_python3_enabled()
       return major_version == 2 ? pyeval(expr) : py3eval(expr)
     else
-      return s:has_python2 ? pyeval(expr) : py3eval(expr)
+      return s:is_python2_enabled() ? pyeval(expr) : py3eval(expr)
     endif
   endfunction
 else

--- a/doc/vital-vim-python.txt
+++ b/doc/vital-vim-python.txt
@@ -63,13 +63,13 @@ is_python2_enabled()			*Vital.Vim.Python.is_python2_enabled()*
 
 	Return 1 if |+python| and the following code exit without exceptions.
 >
-        python import sys
+        python 0
 <
 is_python3_enabled()			*Vital.Vim.Python.is_python3_enabled()*
 
 	Return 1 if |+python3| and the following code exit without exceptions.
 >
-        python3 import sys
+        python3 0
 <
 get_major_version()			*Vital.Vim.Python.get_major_version()*
 

--- a/doc/vital-vim-python.txt
+++ b/doc/vital-vim-python.txt
@@ -88,9 +88,9 @@ exec_code({code}[, {version})		*Vital.Vim.Python.exex_code()*
 
 eval_expr({expr}[, {version})		*Vital.Vim.Python.eval_expr()*
 
-	Evaluate a Python {expr} (|String|) with a specified {version} of Python
-	and return the result. If {version} is 0 or omitted, it uses a version
-	value returned from |Vital.Vim.Python.get_major_version()|.
+	Evaluate a Python {expr} (|String| or |List|) with a specified {version} of
+	Python and return the result. If {version} is 0 or omitted, it uses a
+	version value returned from |Vital.Vim.Python.get_major_version()|.
 	It throws an exception if the specified {version} is not available.
 
 	This function requires a Vim 7.3.601 or later.

--- a/doc/vital-vim-python.txt
+++ b/doc/vital-vim-python.txt
@@ -56,8 +56,21 @@ FUNCTIONS				*Vital.Vim.Python-functions*
 
 is_enabled()				*Vital.Vim.Python.is_enabled()*
 
-	Return 1 if |+python| and/or |+python3| features are available.
+	Return 1 if |Vital.Vim.Python.is_python2_enabled()| or
+	|Vital.Vim.Python.is_python3_enabled()| return 1.
 
+is_python2_enabled()			*Vital.Vim.Python.is_python2_enabled()*
+
+	Return 1 if |+python| and the following code exit without exceptions.
+>
+        python import sys
+<
+is_python3_enabled()			*Vital.Vim.Python.is_python3_enabled()*
+
+	Return 1 if |+python3| and the following code exit without exceptions.
+>
+        python3 import sys
+<
 get_major_version()			*Vital.Vim.Python.get_major_version()*
 
 	Return 0, 2, or 3. Depends on |+python| and/or |+python3| features.

--- a/doc/vital-vim-python.txt
+++ b/doc/vital-vim-python.txt
@@ -36,7 +36,7 @@ It automatically uses a correct function/command to execute a Python code/file.
 
 	" Get a current major version
 	echo s:P.get_major_version()
-	" => 2 or 3, depends on +python/+python3
+	" => 0, 2, or 3, depends on +python/+python3
 
 	" Set a current major versioin
 	" NOTE: It only affects when a Vim was compiled with +python/+python3
@@ -68,9 +68,11 @@ get_major_version()			*Vital.Vim.Python.get_major_version()*
 
 set_major_version({version})		*Vital.Vim.Python.set_major_version()*
 
-	Set a current major version to {version}. It throws an exception if the
-	specified {version} is not available, namely, calling this function
-	does not make any sense in a Vim not compiled with |+python|/|+python3|.
+	Set a current major version to {version}. It throws an exception if
+	the specified {version} is not available or an invalid {version} is
+	specified.
+	Calling this function does not make any sense in a Vim not compiled
+	with |+python|/|+python3|.
 
 exec_file({path}[, {version})		*Vital.Vim.Python.exex_file()*
 
@@ -80,7 +82,8 @@ exec_file({path}[, {version})		*Vital.Vim.Python.exex_file()*
 	function local variables in the Python (|python-eval|).
 	If {version} is 0 or omitted, it uses a version value returned from
 	|Vital.Vim.Python.get_major_version()|.
-	It throws an exception if the specified {version} is not available.
+	It throws an exception if the specified {version} is not available or
+	an invalid {version} is specified.
 >
 	" Note: use 'execute' instead of 'call'
 	execute Python.exec_file('your/python/file.py')
@@ -94,7 +97,8 @@ exec_code({code}[, {version})		*Vital.Vim.Python.exex_code()*
 	function local variables in the Python (|python-eval|).
 	If {version} is 0 or omitted, it uses a version value returned
 	from |Vital.Vim.Python.get_major_version()|.
-	It throws an exception if the specified {version} is not available.
+	It throws an exception if the specified {version} is not available or
+	an invalid {version} is specified.
 >
 	" Note: use 'execute' instead of 'call'
 	execute Python.exec_code('print("hello")')
@@ -105,7 +109,8 @@ eval_expr({expr}[, {version})		*Vital.Vim.Python.eval_expr()*
 	Evaluate a Python {expr} (|String| or |List|) with a specified {version} of
 	Python and return the result. If {version} is 0 or omitted, it uses a
 	version value returned from |Vital.Vim.Python.get_major_version()|.
-	It throws an exception if the specified {version} is not available.
+	It throws an exception if the specified {version} is not available or
+	an invalid {version} is specified.
 
 	This function requires a Vim 7.3.601 or later.
 

--- a/doc/vital-vim-python.txt
+++ b/doc/vital-vim-python.txt
@@ -1,0 +1,98 @@
+*vital-vim-python.txt*	Vim python/python3 compatible function
+
+Maintainer: lambdalisue <lambdalisue@hashnote.net>
+
+==============================================================================
+CONTENTS				*Vital.Vim.Python-contents*
+
+INTRODUCTION			|Vital.Vim.Python-introduction|
+INTERFACE			|Vital.Vim.Python-interface|
+  FUNCTIONS			  |Vital.Vim.Python-functions|
+
+
+
+==============================================================================
+INTRODUCTION				*Vital.Vim.Python-introduction*
+
+*Vital.Vim.Python* provides compatible functions of |python|, |pyfile|, and |pyeval|.
+It automatically uses a correct function/command to execute a Python code/file.
+>
+	let s:V = vital#of('vital')
+	let s:P = s:V.import('Vim.Python')
+
+	" Check if Python is enabled
+	echo s:P.is_enabled()
+	" => 0 or 1, depends on +python/+python3
+
+	" Execute a Python file
+	call s:P.exec_file('your/python/file.py')
+
+	" Execute a Python code
+	call s:P.exec_code('print("Hello Python")')
+
+	" Evaluate a Python expression and return
+	echo s:P.eval_expr('1 + 1')
+	" => 2
+
+	" Get a current major version
+	echo s:P.get_major_version()
+	" => 2 or 3, depends on +python/+python3
+
+	" Set a current major versioin
+	" NOTE: It only affects when a Vim was compiled with +python/+python3
+	call s:P.set_major_version(2)
+	echo s:P.eval_expr('print(sys.version_info.major)')
+	" => 2
+	call s:P.set_major_version(3)
+	echo s:P.eval_expr('print(sys.version_info.major)')
+	" => 3
+<
+
+==============================================================================
+INTERFACE				*Vital.Vim.Python-interface*
+
+------------------------------------------------------------------------------
+FUNCTIONS				*Vital.Vim.Python-functions*
+
+is_enabled()				*Vital.Vim.Python.is_enabled()*
+
+	Return 1 if |+python| and/or |+python3| features are available.
+
+get_major_version()			*Vital.Vim.Python.get_major_version()*
+
+	Return 0, 2, or 3. Depends on |+python| and/or |+python3| features.
+	In case of |+python|/|+python3|, it returns a current major version.
+	In case of |+python|/-python3, it always returns 2.
+	In case of -python/|+python3|, it always returns 3.
+	In case of -python/-python3, it always returns 0.
+
+set_major_version({version})		*Vital.Vim.Python.set_major_version()*
+
+	Set a current major version to {version}. It throws an exception if the
+	specified {version} is not available, namely, calling this function
+	does not make any sense in a Vim not compiled with |+python|/|+python3|.
+
+exec_file({path}[, {version})		*Vital.Vim.Python.exex_file()*
+
+	Execute a Python file {path} (|String|) with a specified {version} of
+	Python. If {version} is 0 or omitted, it uses a version value returned
+	from |Vital.Vim.Python.get_major_version()|.
+	It throws an exception if the specified {version} is not available.
+
+exec_code({code}[, {version})		*Vital.Vim.Python.exex_code()*
+
+	Execute a Python {code} (|String| or |List|) with a specified {version} of
+	Python. If {version} is 0 or omitted, it uses a version value returned
+	from |Vital.Vim.Python.get_major_version()|.
+	It throws an exception if the specified {version} is not available.
+
+eval_expr({expr}[, {version})		*Vital.Vim.Python.eval_expr()*
+
+	Evaluate a Python {expr} (|String|) with a specified {version} of Python
+	and return the result. If {version} is 0 or omitted, it uses a version
+	value returned from |Vital.Vim.Python.get_major_version()|.
+	It throws an exception if the specified {version} is not available.
+
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-vim-python.txt
+++ b/doc/vital-vim-python.txt
@@ -74,17 +74,31 @@ set_major_version({version})		*Vital.Vim.Python.set_major_version()*
 
 exec_file({path}[, {version})		*Vital.Vim.Python.exex_file()*
 
-	Execute a Python file {path} (|String|) with a specified {version} of
-	Python. If {version} is 0 or omitted, it uses a version value returned
-	from |Vital.Vim.Python.get_major_version()|.
+	Return an executable |String| to execute a Python file {path} (|String|)
+	with a specified {version} of Python.
+	It is required to be called with |execute| to enable script local or
+	function local variables in the Python (|python-eval|).
+	If {version} is 0 or omitted, it uses a version value returned from
+	|Vital.Vim.Python.get_major_version()|.
 	It throws an exception if the specified {version} is not available.
+>
+	" Note: use 'execute' instead of 'call'
+	execute Python.exec_file('your/python/file.py')
+<
 
 exec_code({code}[, {version})		*Vital.Vim.Python.exex_code()*
 
-	Execute a Python {code} (|String| or |List|) with a specified {version} of
-	Python. If {version} is 0 or omitted, it uses a version value returned
+	Return an executable |String| to execute a Python {code} (|String| or |List|)
+	with a specified {version} of Python.
+	It is required to be called with |execute| to enable script local or
+	function local variables in the Python (|python-eval|).
+	If {version} is 0 or omitted, it uses a version value returned
 	from |Vital.Vim.Python.get_major_version()|.
 	It throws an exception if the specified {version} is not available.
+>
+	" Note: use 'execute' instead of 'call'
+	execute Python.exec_code('print("hello")')
+<
 
 eval_expr({expr}[, {version})		*Vital.Vim.Python.eval_expr()*
 

--- a/doc/vital-vim-python.txt
+++ b/doc/vital-vim-python.txt
@@ -93,6 +93,8 @@ eval_expr({expr}[, {version})		*Vital.Vim.Python.eval_expr()*
 	value returned from |Vital.Vim.Python.get_major_version()|.
 	It throws an exception if the specified {version} is not available.
 
+	This function requires a Vim 7.3.601 or later.
+
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital.txt
+++ b/doc/vital.txt
@@ -180,6 +180,7 @@ LINKS					*Vital-links*
   |vital-vim-buffer.txt|	  Vim's buffer related stuff in general
   |vital-vim-buffer_manager.txt|    buffer manager
   |vital-vim-compat.txt|	  Vim compatibility wrapper functions
+  |vital-vim-python.txt|	  +python/+python3 compatibility functions
   |vital-vim-message.txt|	  Vim message functions
   |vital-vim-search.txt|	  Vim's [I like function
   |vital-vim-script_local.txt|	  Get script-local things

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -70,6 +70,11 @@ Describe Vim.Python
         call Python.set_major_version(3)
         Assert Equals(Python.get_major_version(), 3)
       End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version(1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('3')
+      End
     elseif s:has_python2
       It does nothing if 0 is specified [+python/-python3]
         call Python.set_major_version(0)
@@ -80,6 +85,11 @@ Describe Vim.Python
       End
       It throws an exception if 3 is specified [+python/-python3]
         Throw /+python3 is required/ Python.set_major_version(3)
+      End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version(1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('3')
       End
     elseif s:has_python3
       It does nothing if 0 is specified [-python/+python3]
@@ -92,6 +102,11 @@ Describe Vim.Python
         call Python.set_major_version(3)
         Assert Equals(Python.get_major_version(), 3)
       End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version(1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('3')
+      End
     else
       It throws an exception if 0 is specified [-python/-python3]
         Throw /+python is required/ Python.set_major_version(0)
@@ -101,6 +116,11 @@ Describe Vim.Python
       End
       It throws an exception if 3 is specified [-python/-python3]
         Throw /+python3 is required/ Python.set_major_version(3)
+      End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version(1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('3')
       End
     endif
   End
@@ -131,6 +151,11 @@ Describe Vim.Python
         redir END
         Assert Equals(content, "\nPython 3")
       End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, 1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '3')
+      End
     elseif s:has_python2
       It executes a python file when 0 is specified [+python/-python3]
         let prefix = "Python"
@@ -148,6 +173,11 @@ Describe Vim.Python
       End
       It throws an exception if 3 is specified [+python/-python3]
         Throw /+python3 is required/ Python.exec_file(path, 3)
+      End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, 1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '3')
       End
     elseif s:has_python3
       It executes a python file when 0 is specified [-python/+python3]
@@ -167,6 +197,11 @@ Describe Vim.Python
         redir END
         Assert Equals(content, "\nPython 3")
       End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, 1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '3')
+      End
     else
       It throws an exception if 0 is specified [-python/-python3]
         Throw /+python is required/ Python.exec_file(path, 0)
@@ -176,6 +211,11 @@ Describe Vim.Python
       End
       It throws an exception if 3 is specified [-python/-python3]
         Throw /+python3 is required/ Python.exec_file(path, 3)
+      End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, 1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '3')
       End
     endif
   End
@@ -212,6 +252,11 @@ Describe Vim.Python
         redir END
         Assert Equals(content, "\nPython 3")
       End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, 1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '3')
+      End
     elseif s:has_python2
       It executes a python code when 0 is specified [+python/-python3]
         let prefix = "Python"
@@ -229,6 +274,11 @@ Describe Vim.Python
       End
       It throws an exception if 3 is specified [+python/-python3]
         Throw /+python3 is required/ Python.exec_code(code, 3)
+      End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, 1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '3')
       End
     elseif s:has_python3
       It executes a python code when 0 is specified [-python/+python3]
@@ -248,6 +298,11 @@ Describe Vim.Python
         redir END
         Assert Equals(content, "\nPython 3")
       End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, 1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '3')
+      End
     else
       It throws an exception if 0 is specified [-python/-python3]
         Throw /+python is required/ Python.exec_code(code, 0)
@@ -257,6 +312,11 @@ Describe Vim.Python
       End
       It throws an exception if 2 is specified [-python/-python3]
         Throw /+python3 is required/ Python.exec_code(code, 3)
+      End
+      It throws an exception if value which is not 0, 2, or 3 is specified
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, 1)
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '2')
+        Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '3')
       End
     endif
   End
@@ -281,6 +341,11 @@ Describe Vim.Python
         It execute a python code when 3 is specified [+python/+python3]
           Assert Equals(Python.eval_expr(expr, 3), 3)
         End
+        It throws an exception if value which is not 0, 2, or 3 is specified
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, 1)
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '2')
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '3')
+        End
       elseif s:has_python2
         It evaluate a python expr when 0 is specified [+python/-python3]
           Assert Equals(Python.eval_expr(expr, 0), 2)
@@ -290,6 +355,11 @@ Describe Vim.Python
         End
         It throws an exception if 3 is specified [+python/-python3]
           Throw /+python3 is required/ Python.eval_expr(expr, 3)
+        End
+        It throws an exception if value which is not 0, 2, or 3 is specified
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, 1)
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '2')
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '3')
         End
       elseif s:has_python3
         It evaluate a python expr when 0 is specified [-python/+python3]
@@ -301,6 +371,11 @@ Describe Vim.Python
         It executes a python code when 3 is specified [-python/+python3]
           Assert Equals(Python.eval_expr(expr, 3), 3)
         End
+        It throws an exception if value which is not 0, 2, or 3 is specified
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, 1)
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '2')
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '3')
+        End
       else
         It throws an exception if 0 is specified [-python/-python3]
           Throw /+python is required/ Python.eval_expr(expr, 0)
@@ -310,6 +385,11 @@ Describe Vim.Python
         End
         It throws an exception if 3 is specified [-python/-python3]
           Throw /+python3 is required/ Python.eval_expr(expr, 3)
+        End
+        It throws an exception if value which is not 0, 2, or 3 is specified
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, 1)
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '2')
+          Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '3')
         End
       endif
     else

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -1,0 +1,290 @@
+let s:has_python2 = has('python')
+let s:has_python3 = has('python3')
+
+Describe Vim.Python
+  Before all
+    let V = vital#of('vital')
+    let S = V.import('Vim.ScriptLocal')
+    let P = V.import('System.Filepath')
+    let Python = V.import('Vim.Python')
+  End
+  Before each
+    let sv = S.svars(P.realpath('autoload/vital/__latest__/Vim/Python.vim'))
+    let default_major_version = sv.default_major_version
+    if s:has_python2 && s:has_python3
+      " Make sure s:current_major_version is not set
+      let sv.current_major_version = 0
+    endif
+  End
+
+  Describe .is_enabled()
+    if s:has_python2 && s:has_python3
+      It returns 1 [+python/+python3]
+        Assert True(Python.is_enabled())
+      End
+    elseif s:has_python2
+      It returns 1 [+python/-python3]
+        Assert True(Python.is_enabled())
+      End
+    elseif s:has_python3
+      It returns 1 [-python/+python3]
+        Assert True(Python.is_enabled())
+      End
+    else
+      It returns 0 [-python/-python3]
+        Assert True(Python.is_enabled())
+      End
+    endif
+  End
+
+  Describe .get_major_version()
+    if s:has_python2 && s:has_python3
+      It returns s:default_major_version [+python/+python3]
+        Assert Equals(Python.get_major_version(), default_major_version)
+      End
+    elseif s:has_python2
+      It returns 2 [+python/-python3]
+        Assert Equals(Python.get_major_version(), 2)
+      End
+    elseif s:has_python3
+      It returns 3 [-python/+python3]
+        Assert Equals(Python.get_major_version(), 3)
+      End
+    else
+      It returns 0 [-python/-python3]
+        Assert Equals(Python.get_major_version(), 0)
+      End
+    endif
+  End
+
+  Describe .set_major_version()
+    if s:has_python2 && s:has_python3
+      It does nothing if 0 is specified [+python/+python3]
+        call Python.set_major_version(0)
+      End
+      It assigns a current major version if 2 is specified [+python/+python3]
+        call Python.set_major_version(2)
+        Assert Equals(Python.get_major_version(), 2)
+      End
+      It assigns a current major version if 3 is specified [+python/+python3]
+        call Python.set_major_version(3)
+        Assert Equals(Python.get_major_version(), 3)
+      End
+    elseif s:has_python2
+      It does nothing if 0 is specified [+python/-python3]
+        call Python.set_major_version(0)
+      End
+      It assigns a current major version if 2 is specified [+python/-python3]
+        call Python.set_major_version(2)
+        Assert Equals(Python.get_major_version(), 2)
+      End
+      It throws an exception if 3 is specified [+python/-python3]
+        Throw /+python3 is required/ Python.set_major_version(3)
+      End
+    elseif s:has_python3
+      It does nothing if 0 is specified [-python/+python3]
+        call Python.set_major_version(0)
+      End
+      It throws an exception if 2 is specified [-python/+python3]
+        Throw /+python is required/ Python.set_major_version(2)
+      End
+      It assigns a current major version if 3 is specified [0python/+python3]
+        call Python.set_major_version(3)
+        Assert Equals(Python.get_major_version(), 3)
+      End
+    else
+      It throws an exception if 0 is specified [-python/-python3]
+        Throw /+python is required/ Python.set_major_version(0)
+      End
+      It throws an exception if 2 is specified [-python/-python3]
+        Throw /+python is required/ Python.set_major_version(2)
+      End
+      It throws an exception if 3 is specified [-python/-python3]
+        Throw /+python3 is required/ Python.set_major_version(3)
+      End
+    endif
+  End
+
+  Describe .exec_file()
+    Before
+      let path = P.realpath('test/_testdata/Vim/Python/test.py')
+    End
+    if s:has_python2 && s:has_python3
+      It executes a python file when 0 is specified [+python/+python3]
+        redir => content
+        call Python.exec_file(path, 0)
+        redir END
+        Assert Equals(content, printf("\nPython %d", default_major_version))
+      End
+      It executes a python file when 2 is specified [+python/+python3]
+        redir => content
+        call Python.exec_file(path, 2)
+        redir END
+        Assert Equals(content, "\nPython 2")
+      End
+      It execute a python file when 3 is specified [+python/+python3]
+        redir => content
+        call Python.exec_file(path, 3)
+        redir END
+        Assert Equals(content, "\nPython 3")
+      End
+    elseif s:has_python2
+      It executes a python file when 0 is specified [+python/-python3]
+        redir => content
+        call Python.exec_file(path, 0)
+        redir END
+        Assert Equals(content, "\nPython 2")
+      End
+      It executes a python file when 2 is specified [+python/-python3]
+        redir => content
+        call Python.exec_file(path, 2)
+        redir END
+        Assert Equals(content, "\nPython 2")
+      End
+      It throws an exception if 3 is specified [+python/-python3]
+        Throw /+python3 is required/ Python.exec_file(path, 3)
+      End
+    elseif s:has_python3
+      It executes a python file when 0 is specified [-python/+python3]
+        redir => content
+        call Python.exec_file(path, 0)
+        redir END
+        Assert Equals(content, "\nPython 3")
+      End
+      It throws an exception if 2 is specified [-python/+python3]
+        Throw /+python is required/ Python.exec_file(path, 2)
+      End
+      It executes a python file when 3 is specified [-python/+python3]
+        redir => content
+        call Python.exec_file(path, 3)
+        redir END
+        Assert Equals(content, "\nPython 3")
+      End
+    else
+      It throws an exception if 0 is specified [-python/-python3]
+        Throw /+python is required/ Python.exec_file(path, 0)
+      End
+      It throws an exception if 2 is specified [-python/-python3]
+        Throw /+python is required/ Python.exec_file(path, 2)
+      End
+      It throws an exception if 3 is specified [-python/-python3]
+        Throw /+python3 is required/ Python.exec_file(path, 3)
+      End
+    endif
+  End
+
+  Describe .exec_code()
+    Before
+      let code = 'import sys; print("Python %s" % sys.version_info.major)'
+    End
+    if s:has_python2 && s:has_python3
+      It executes a python code when 0 is specified [+python/+python3]
+        redir => content
+        call Python.exec_code(code, 0)
+        redir END
+        Assert Equals(content, printf("\nPython %d", default_major_version))
+      End
+      It executes a python code when 2 is specified [+python/+python3]
+        redir => content
+        call Python.exec_code(code, 2)
+        redir END
+        Assert Equals(content, "\nPython 2")
+      End
+      It execute a python code when 3 is specified [+python/+python3]
+        redir => content
+        call Python.exec_code(code, 3)
+        redir END
+        Assert Equals(content, "\nPython 3")
+      End
+    elseif s:has_python2
+      It executes a python code when 0 is specified [+python/-python3]
+        redir => content
+        call Python.exec_code(code, 0)
+        redir END
+        Assert Equals(content, "\nPython 2")
+      End
+      It executes a python code when 2 is specified [+python/-python3]
+        redir => content
+        call Python.exec_code(code, 2)
+        redir END
+        Assert Equals(content, "\nPython 2")
+      End
+      It throws an exception if 3 is specified [+python/-python3]
+        Throw /+python3 is required/ Python.exec_code(code, 3)
+      End
+    elseif s:has_python3
+      It executes a python code when 0 is specified [-python/+python3]
+        redir => content
+        call Python.exec_code(code, 0)
+        redir END
+        Assert Equals(content, "\nPython 3")
+      End
+      It throws an exception if 2 is specified [-python/+python3]
+        Throw /+python is required/ Python.exec_code(code, 2)
+      End
+      It executes a python code when 3 is specified [-python/+python3]
+        redir => content
+        call Python.exec_code(code, 3)
+        redir END
+        Assert Equals(content, "\nPython 3")
+      End
+    else
+      It throws an exception if 0 is specified [-python/-python3]
+        Throw /+python is required/ Python.exec_code(code, 0)
+      End
+      It throws an exception if 2 is specified [-python/-python3]
+        Throw /+python is required/ Python.exec_code(code, 2)
+      End
+      It throws an exception if 2 is specified [-python/-python3]
+        Throw /+python3 is required/ Python.exec_code(code, 3)
+      End
+    endif
+  End
+
+  Describe .eval_expr()
+    Before
+      let expr = 'sys.version_info.major'
+    End
+    if s:has_python2 && s:has_python3
+      It evaluate a python expr when 0 is specified [+python/+python3]
+        Assert Equals(Python.eval_expr(expr, 0), 2)
+      End
+      It executes a python code when 2 is specified [+python/+python3]
+        Assert Equals(Python.eval_expr(expr, 2), 2)
+      End
+      It execute a python code when 3 is specified [+python/+python3]
+        Assert Equals(Python.eval_expr(expr, 3), 3)
+      End
+    elseif s:has_python2
+      It evaluate a python expr when 0 is specified [+python/-python3]
+        Assert Equals(Python.eval_expr(expr, 0), 2)
+      End
+      It execute a python code when 2 is specified [+python/-python3]
+        Assert Equals(Python.eval_expr(expr, 2), 2)
+      End
+      It throws an exception if 3 is specified [+python/-python3]
+        Throw /+python3 is required/ Python.eval_expr(expr, 3)
+      End
+    elseif s:has_python3
+      It evaluate a python expr when 0 is specified [-python/+python3]
+        Assert Equals(Python.eval_expr(expr, 0), 3)
+      End
+      It throws an exception if 2 is specified [-python/+python3]
+        Throw /+python is required/ Python.eval_expr(expr, 2)
+      End
+      It executes a python code when 3 is specified [-python/+python3]
+        Assert Equals(Python.eval_expr(expr, 3), 3)
+      End
+    else
+      It throws an exception if 0 is specified [-python/-python3]
+        Throw /+python is required/ Python.eval_expr(expr, 0)
+      End
+      It throws an exception if 2 is specified [-python/-python3]
+        Throw /+python is required/ Python.eval_expr(expr, 2)
+      End
+      It throws an exception if 3 is specified [-python/-python3]
+        Throw /+python3 is required/ Python.eval_expr(expr, 3)
+      End
+    endif
+  End
+End

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -32,7 +32,7 @@ Describe Vim.Python
       End
     else
       It returns 0 [-python/-python3]
-        Assert True(Python.is_enabled())
+        Assert False(Python.is_enabled())
       End
     endif
   End
@@ -109,7 +109,7 @@ Describe Vim.Python
       End
     else
       It throws an exception if 0 is specified [-python/-python3]
-        Throw /+python is required/ Python.set_major_version(0)
+        Throw /+python and\/or +python3 is required/ Python.set_major_version(0)
       End
       It throws an exception if 2 is specified [-python/-python3]
         Throw /+python is required/ Python.set_major_version(2)
@@ -204,7 +204,7 @@ Describe Vim.Python
       End
     else
       It throws an exception if 0 is specified [-python/-python3]
-        Throw /+python is required/ Python.exec_file(path, 0)
+        Throw /+python and\/or +python3 is required/ Python.exec_file(path, 0)
       End
       It throws an exception if 2 is specified [-python/-python3]
         Throw /+python is required/ Python.exec_file(path, 2)
@@ -305,7 +305,7 @@ Describe Vim.Python
       End
     else
       It throws an exception if 0 is specified [-python/-python3]
-        Throw /+python is required/ Python.exec_code(code, 0)
+        Throw /+python and\/or +python3 is required/ Python.exec_code(code, 0)
       End
       It throws an exception if 2 is specified [-python/-python3]
         Throw /+python is required/ Python.exec_code(code, 2)
@@ -378,7 +378,7 @@ Describe Vim.Python
         End
       else
         It throws an exception if 0 is specified [-python/-python3]
-          Throw /+python is required/ Python.eval_expr(expr, 0)
+          Throw /+python and\/or +python3 is required/ Python.eval_expr(expr, 0)
         End
         It throws an exception if 2 is specified [-python/-python3]
           Throw /+python is required/ Python.eval_expr(expr, 2)

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -111,33 +111,38 @@ Describe Vim.Python
     End
     if s:has_python2 && s:has_python3
       It executes a python file when 0 is specified [+python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_file(path, 0)
+        execute Python.exec_file(path, 0)
         redir END
         Assert Equals(content, printf("\nPython %d", default_major_version))
       End
       It executes a python file when 2 is specified [+python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_file(path, 2)
+        execute Python.exec_file(path, 2)
         redir END
         Assert Equals(content, "\nPython 2")
       End
       It execute a python file when 3 is specified [+python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_file(path, 3)
+        execute Python.exec_file(path, 3)
         redir END
         Assert Equals(content, "\nPython 3")
       End
     elseif s:has_python2
       It executes a python file when 0 is specified [+python/-python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_file(path, 0)
+        execute Python.exec_file(path, 0)
         redir END
         Assert Equals(content, "\nPython 2")
       End
       It executes a python file when 2 is specified [+python/-python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_file(path, 2)
+        execute Python.exec_file(path, 2)
         redir END
         Assert Equals(content, "\nPython 2")
       End
@@ -146,8 +151,9 @@ Describe Vim.Python
       End
     elseif s:has_python3
       It executes a python file when 0 is specified [-python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_file(path, 0)
+        execute Python.exec_file(path, 0)
         redir END
         Assert Equals(content, "\nPython 3")
       End
@@ -155,8 +161,9 @@ Describe Vim.Python
         Throw /+python is required/ Python.exec_file(path, 2)
       End
       It executes a python file when 3 is specified [-python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_file(path, 3)
+        execute Python.exec_file(path, 3)
         redir END
         Assert Equals(content, "\nPython 3")
       End
@@ -176,39 +183,47 @@ Describe Vim.Python
   Describe .exec_code()
     Before
       let code = [
-            \ 'import sys',
-            \ 'print("Python %s" % sys.version_info.major)',
+            \ 'import sys, vim',
+            \ 'print("%s %d" % (',
+            \ '  vim.eval("prefix"),',
+            \ '  sys.version_info.major,',
+            \ '))',
             \]
     End
     if s:has_python2 && s:has_python3
       It executes a python code when 0 is specified [+python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_code(code, 0)
+        execute Python.exec_code(code, 0)
         redir END
         Assert Equals(content, printf("\nPython %d", default_major_version))
       End
       It executes a python code when 2 is specified [+python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_code(code, 2)
+        execute Python.exec_code(code, 2)
         redir END
         Assert Equals(content, "\nPython 2")
       End
       It execute a python code when 3 is specified [+python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_code(code, 3)
+        execute Python.exec_code(code, 3)
         redir END
         Assert Equals(content, "\nPython 3")
       End
     elseif s:has_python2
       It executes a python code when 0 is specified [+python/-python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_code(code, 0)
+        execute Python.exec_code(code, 0)
         redir END
         Assert Equals(content, "\nPython 2")
       End
       It executes a python code when 2 is specified [+python/-python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_code(code, 2)
+        execute Python.exec_code(code, 2)
         redir END
         Assert Equals(content, "\nPython 2")
       End
@@ -217,8 +232,9 @@ Describe Vim.Python
       End
     elseif s:has_python3
       It executes a python code when 0 is specified [-python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_code(code, 0)
+        execute Python.exec_code(code, 0)
         redir END
         Assert Equals(content, "\nPython 3")
       End
@@ -226,8 +242,9 @@ Describe Vim.Python
         Throw /+python is required/ Python.exec_code(code, 2)
       End
       It executes a python code when 3 is specified [-python/+python3]
+        let prefix = "Python"
         redir => content
-        call Python.exec_code(code, 3)
+        execute Python.exec_code(code, 3)
         redir END
         Assert Equals(content, "\nPython 3")
       End

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -242,48 +242,54 @@ Describe Vim.Python
   End
 
   Describe .eval_expr()
-    Before
-      let expr = 'sys.version_info.major'
-    End
-    if s:has_python2 && s:has_python3
-      It evaluate a python expr when 0 is specified [+python/+python3]
-        Assert Equals(Python.eval_expr(expr, 0), 2)
+    if v:version >= 704 || (v:version == 703 && has('patch601'))
+      Before
+        let expr = 'sys.version_info.major'
       End
-      It executes a python code when 2 is specified [+python/+python3]
-        Assert Equals(Python.eval_expr(expr, 2), 2)
-      End
-      It execute a python code when 3 is specified [+python/+python3]
-        Assert Equals(Python.eval_expr(expr, 3), 3)
-      End
-    elseif s:has_python2
-      It evaluate a python expr when 0 is specified [+python/-python3]
-        Assert Equals(Python.eval_expr(expr, 0), 2)
-      End
-      It execute a python code when 2 is specified [+python/-python3]
-        Assert Equals(Python.eval_expr(expr, 2), 2)
-      End
-      It throws an exception if 3 is specified [+python/-python3]
-        Throw /+python3 is required/ Python.eval_expr(expr, 3)
-      End
-    elseif s:has_python3
-      It evaluate a python expr when 0 is specified [-python/+python3]
-        Assert Equals(Python.eval_expr(expr, 0), 3)
-      End
-      It throws an exception if 2 is specified [-python/+python3]
-        Throw /+python is required/ Python.eval_expr(expr, 2)
-      End
-      It executes a python code when 3 is specified [-python/+python3]
-        Assert Equals(Python.eval_expr(expr, 3), 3)
-      End
+      if s:has_python2 && s:has_python3
+        It evaluate a python expr when 0 is specified [+python/+python3]
+          Assert Equals(Python.eval_expr(expr, 0), 2)
+        End
+        It executes a python code when 2 is specified [+python/+python3]
+          Assert Equals(Python.eval_expr(expr, 2), 2)
+        End
+        It execute a python code when 3 is specified [+python/+python3]
+          Assert Equals(Python.eval_expr(expr, 3), 3)
+        End
+      elseif s:has_python2
+        It evaluate a python expr when 0 is specified [+python/-python3]
+          Assert Equals(Python.eval_expr(expr, 0), 2)
+        End
+        It execute a python code when 2 is specified [+python/-python3]
+          Assert Equals(Python.eval_expr(expr, 2), 2)
+        End
+        It throws an exception if 3 is specified [+python/-python3]
+          Throw /+python3 is required/ Python.eval_expr(expr, 3)
+        End
+      elseif s:has_python3
+        It evaluate a python expr when 0 is specified [-python/+python3]
+          Assert Equals(Python.eval_expr(expr, 0), 3)
+        End
+        It throws an exception if 2 is specified [-python/+python3]
+          Throw /+python is required/ Python.eval_expr(expr, 2)
+        End
+        It executes a python code when 3 is specified [-python/+python3]
+          Assert Equals(Python.eval_expr(expr, 3), 3)
+        End
+      else
+        It throws an exception if 0 is specified [-python/-python3]
+          Throw /+python is required/ Python.eval_expr(expr, 0)
+        End
+        It throws an exception if 2 is specified [-python/-python3]
+          Throw /+python is required/ Python.eval_expr(expr, 2)
+        End
+        It throws an exception if 3 is specified [-python/-python3]
+          Throw /+python3 is required/ Python.eval_expr(expr, 3)
+        End
+      endif
     else
-      It throws an exception if 0 is specified [-python/-python3]
-        Throw /+python is required/ Python.eval_expr(expr, 0)
-      End
-      It throws an exception if 2 is specified [-python/-python3]
-        Throw /+python is required/ Python.eval_expr(expr, 2)
-      End
-      It throws an exception if 3 is specified [-python/-python3]
-        Throw /+python3 is required/ Python.eval_expr(expr, 3)
+      It throws an exception in Vim 7.3.600 or earlier
+        Throw /eval_expr() requires Vim 7\.3\.601 or later/ Python.eval_expr('')
       End
     endif
   End

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -1,5 +1,7 @@
-let s:has_python2 = has('python')
-let s:has_python3 = has('python3')
+let s:V = vital#of('vital')
+let s:P = s:V.import('Vim.Python')
+let s:is_python2_enabled = s:P.is_python2_enabled()
+let s:is_python3_enabled = s:P.is_python3_enabled()
 
 Describe Vim.Python
   Before all
@@ -11,22 +13,22 @@ Describe Vim.Python
   Before each
     let sv = S.svars(P.realpath('autoload/vital/__latest__/Vim/Python.vim'))
     let default_major_version = sv.default_major_version
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled && s:is_python3_enabled
       " Make sure s:current_major_version is not set
       let sv.current_major_version = 0
     endif
   End
 
   Describe .is_enabled()
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled && s:is_python3_enabled
       It returns 1 [+python/+python3]
         Assert True(Python.is_enabled())
       End
-    elseif s:has_python2
+    elseif s:is_python2_enabled
       It returns 1 [+python/-python3]
         Assert True(Python.is_enabled())
       End
-    elseif s:has_python3
+    elseif s:is_python3_enabled
       It returns 1 [-python/+python3]
         Assert True(Python.is_enabled())
       End
@@ -37,15 +39,15 @@ Describe Vim.Python
     endif
   End
   Describe .is_python2_enabled()
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled && s:is_python3_enabled
       It returns 1 [+python/+python3]
         Assert True(Python.is_python2_enabled())
       End
-    elseif s:has_python2
+    elseif s:is_python2_enabled
       It returns 1 [+python/-python3]
         Assert True(Python.is_python2_enabled())
       End
-    elseif s:has_python3
+    elseif s:is_python3_enabled
       It returns 0 [-python/+python3]
         Assert False(Python.is_python2_enabled())
       End
@@ -56,15 +58,15 @@ Describe Vim.Python
     endif
   End
   Describe .is_python3_enabled()
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled && s:is_python3_enabled
       It returns 1 [+python/+python3]
         Assert True(Python.is_python3_enabled())
       End
-    elseif s:has_python2
+    elseif s:is_python2_enabled
       It returns 1 [+python/-python3]
         Assert False(Python.is_python3_enabled())
       End
-    elseif s:has_python3
+    elseif s:is_python3_enabled
       It returns 0 [-python/+python3]
         Assert True(Python.is_python3_enabled())
       End
@@ -76,15 +78,15 @@ Describe Vim.Python
   End
 
   Describe .get_major_version()
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled && s:is_python3_enabled
       It returns s:default_major_version [+python/+python3]
         Assert Equals(Python.get_major_version(), default_major_version)
       End
-    elseif s:has_python2
+    elseif s:is_python2_enabled
       It returns 2 [+python/-python3]
         Assert Equals(Python.get_major_version(), 2)
       End
-    elseif s:has_python3
+    elseif s:is_python3_enabled
       It returns 3 [-python/+python3]
         Assert Equals(Python.get_major_version(), 3)
       End
@@ -96,7 +98,7 @@ Describe Vim.Python
   End
 
   Describe .set_major_version()
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled && s:is_python3_enabled
       It does nothing if 0 is specified [+python/+python3]
         call Python.set_major_version(0)
       End
@@ -113,7 +115,7 @@ Describe Vim.Python
         Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('2')
         Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('3')
       End
-    elseif s:has_python2
+    elseif s:is_python2_enabled
       It does nothing if 0 is specified [+python/-python3]
         call Python.set_major_version(0)
       End
@@ -129,7 +131,7 @@ Describe Vim.Python
         Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('2')
         Throw /"version" requires to be 0, 2, or 3/ Python.set_major_version('3')
       End
-    elseif s:has_python3
+    elseif s:is_python3_enabled
       It does nothing if 0 is specified [-python/+python3]
         call Python.set_major_version(0)
       End
@@ -167,7 +169,7 @@ Describe Vim.Python
     Before
       let path = P.realpath('test/_testdata/Vim/Python/test.py')
     End
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled && s:is_python3_enabled
       It executes a python file when 0 is specified [+python/+python3]
         let prefix = "Python"
         redir => content
@@ -194,7 +196,7 @@ Describe Vim.Python
         Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '2')
         Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '3')
       End
-    elseif s:has_python2
+    elseif s:is_python2_enabled
       It executes a python file when 0 is specified [+python/-python3]
         let prefix = "Python"
         redir => content
@@ -217,7 +219,7 @@ Describe Vim.Python
         Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '2')
         Throw /"version" requires to be 0, 2, or 3/ Python.exec_file(path, '3')
       End
-    elseif s:has_python3
+    elseif s:is_python3_enabled
       It executes a python file when 0 is specified [-python/+python3]
         let prefix = "Python"
         redir => content
@@ -268,7 +270,7 @@ Describe Vim.Python
             \ '))',
             \]
     End
-    if s:has_python2 && s:has_python3
+    if s:is_python2_enabled && s:is_python3_enabled
       It executes a python code when 0 is specified [+python/+python3]
         let prefix = "Python"
         redir => content
@@ -295,7 +297,7 @@ Describe Vim.Python
         Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '2')
         Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '3')
       End
-    elseif s:has_python2
+    elseif s:is_python2_enabled
       It executes a python code when 0 is specified [+python/-python3]
         let prefix = "Python"
         redir => content
@@ -318,7 +320,7 @@ Describe Vim.Python
         Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '2')
         Throw /"version" requires to be 0, 2, or 3/ Python.exec_code(code, '3')
       End
-    elseif s:has_python3
+    elseif s:is_python3_enabled
       It executes a python code when 0 is specified [-python/+python3]
         let prefix = "Python"
         redir => content
@@ -369,7 +371,7 @@ Describe Vim.Python
               \ ')',
               \]
       End
-      if s:has_python2 && s:has_python3
+      if s:is_python2_enabled && s:is_python3_enabled
         It evaluate a python expr when 0 is specified [+python/+python3]
           Assert Equals(Python.eval_expr(expr, 0), 2)
         End
@@ -384,7 +386,7 @@ Describe Vim.Python
           Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '2')
           Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '3')
         End
-      elseif s:has_python2
+      elseif s:is_python2_enabled
         It evaluate a python expr when 0 is specified [+python/-python3]
           Assert Equals(Python.eval_expr(expr, 0), 2)
         End
@@ -399,7 +401,7 @@ Describe Vim.Python
           Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '2')
           Throw /"version" requires to be 0, 2, or 3/ Python.eval_expr(expr, '3')
         End
-      elseif s:has_python3
+      elseif s:is_python3_enabled
         It evaluate a python expr when 0 is specified [-python/+python3]
           Assert Equals(Python.eval_expr(expr, 0), 3)
         End

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -36,6 +36,44 @@ Describe Vim.Python
       End
     endif
   End
+  Describe .is_python2_enabled()
+    if s:has_python2 && s:has_python3
+      It returns 1 [+python/+python3]
+        Assert True(Python.is_python2_enabled())
+      End
+    elseif s:has_python2
+      It returns 1 [+python/-python3]
+        Assert True(Python.is_python2_enabled())
+      End
+    elseif s:has_python3
+      It returns 0 [-python/+python3]
+        Assert False(Python.is_python2_enabled())
+      End
+    else
+      It returns 0 [-python/-python3]
+        Assert False(Python.is_python2_enabled())
+      End
+    endif
+  End
+  Describe .is_python3_enabled()
+    if s:has_python2 && s:has_python3
+      It returns 1 [+python/+python3]
+        Assert True(Python.is_python3_enabled())
+      End
+    elseif s:has_python2
+      It returns 1 [+python/-python3]
+        Assert False(Python.is_python3_enabled())
+      End
+    elseif s:has_python3
+      It returns 0 [-python/+python3]
+        Assert True(Python.is_python3_enabled())
+      End
+    else
+      It returns 0 [-python/-python3]
+        Assert False(Python.is_python3_enabled())
+      End
+    endif
+  End
 
   Describe .get_major_version()
     if s:has_python2 && s:has_python3

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -12,7 +12,6 @@ Describe Vim.Python
   End
   Before each
     let sv = S.svars(P.realpath('autoload/vital/__latest__/Vim/Python.vim'))
-    let default_major_version = sv.default_major_version
     if s:is_python2_enabled && s:is_python3_enabled
       " Make sure s:current_major_version is not set
       let sv.current_major_version = 0
@@ -79,8 +78,8 @@ Describe Vim.Python
 
   Describe .get_major_version()
     if s:is_python2_enabled && s:is_python3_enabled
-      It returns s:default_major_version [+python/+python3]
-        Assert Equals(Python.get_major_version(), default_major_version)
+      It returns 2 [+python/+python3]
+        Assert Equals(Python.get_major_version(), 2)
       End
     elseif s:is_python2_enabled
       It returns 2 [+python/-python3]
@@ -175,7 +174,7 @@ Describe Vim.Python
         redir => content
         execute Python.exec_file(path, 0)
         redir END
-        Assert Equals(content, printf("\nPython %d", default_major_version))
+        Assert Equals(content, printf("\nPython %d", 2))
       End
       It executes a python file when 2 is specified [+python/+python3]
         let prefix = "Python"
@@ -276,7 +275,7 @@ Describe Vim.Python
         redir => content
         execute Python.exec_code(code, 0)
         redir END
-        Assert Equals(content, printf("\nPython %d", default_major_version))
+        Assert Equals(content, printf("\nPython %d", 2))
       End
       It executes a python code when 2 is specified [+python/+python3]
         let prefix = "Python"

--- a/test/Vim/Python.vimspec
+++ b/test/Vim/Python.vimspec
@@ -175,7 +175,10 @@ Describe Vim.Python
 
   Describe .exec_code()
     Before
-      let code = 'import sys; print("Python %s" % sys.version_info.major)'
+      let code = [
+            \ 'import sys',
+            \ 'print("Python %s" % sys.version_info.major)',
+            \]
     End
     if s:has_python2 && s:has_python3
       It executes a python code when 0 is specified [+python/+python3]
@@ -244,7 +247,12 @@ Describe Vim.Python
   Describe .eval_expr()
     if v:version >= 704 || (v:version == 703 && has('patch601'))
       Before
-        let expr = 'sys.version_info.major'
+        let expr = [
+              \ 'max(',
+              \ '  sys.version_info.major,',
+              \ '  0',
+              \ ')',
+              \]
       End
       if s:has_python2 && s:has_python3
         It evaluate a python expr when 0 is specified [+python/+python3]

--- a/test/_testdata/Vim/Python/test.py
+++ b/test/_testdata/Vim/Python/test.py
@@ -1,4 +1,5 @@
 import sys, vim
+
 print("%s %d" % (
     vim.eval('prefix'),
     sys.version_info.major,

--- a/test/_testdata/Vim/Python/test.py
+++ b/test/_testdata/Vim/Python/test.py
@@ -1,0 +1,2 @@
+import sys
+print("Python %d" % sys.version_info.major)

--- a/test/_testdata/Vim/Python/test.py
+++ b/test/_testdata/Vim/Python/test.py
@@ -1,2 +1,5 @@
-import sys
-print("Python %d" % sys.version_info.major)
+import sys, vim
+print("%s %d" % (
+    vim.eval('prefix'),
+    sys.version_info.major,
+))


### PR DESCRIPTION
I needed. I wrote.

- [x] Tested on `+python/+python3`
- [x] Tested on `+python/-python3`
- [x] Tested on `-python/+python3`
- [x] Tested on `-python/-python3`

