### PR TITLE
[RFC] System.Filepath: Add to_slash/from_slash to implement across OSs.

### DIFF
--- a/autoload/vital/__latest__/System/Filepath.vim
+++ b/autoload/vital/__latest__/System/Filepath.vim
@@ -220,6 +220,20 @@ function! s:is_root_directory(path) abort
   return (has('win32') || has('win64')) && a:path =~ '^[a-zA-Z]:[/\\]$'
 endfunction
 
+function! s:to_slash(path) abort
+  if (has('win32') || has('win64'))
+    return substitute(a:path, '\', '/', 'g')
+  endif
+  return a:path
+endfunction
+
+function! s:from_slash(path) abort
+  if (has('win32') || has('win64'))
+    return substitute(a:path, '/', '\', 'g')
+  endif
+  return a:path
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 


### PR DESCRIPTION
OS間で共通的な実装を行う為に from_slash, to_slash を System.FilePathOS間で共通的な実装を行う為に from_slash, to_slash を System.FilePath に入れるべきだと思います。

UNIX OS では実質何もしません。
Windows のみ、`\` と `/` の交換を行います。
