### PR TITLE
Web.URI: Make each URI component configurable

### DIFF
--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -250,14 +250,24 @@ function! s:_uri_path(...) dict abort
   return "/" . self.__path
 endfunction
 
+function! s:_uri_authority(...) dict abort
+  if a:0
+    " TODO
+    throw 'vital: Web.URI: uri.authority(value) does not support yet.'
+  endif
+  return
+  \   (self.__userinfo != '' ? self.__userinfo . '@' : '')
+  \   . self.__host
+  \   . (self.__port !=# '' ? ':' . self.__port : '')
+endfunction
+
 function! s:_uri_opaque(...) dict abort
   if a:0
     " TODO
     throw 'vital: Web.URI: uri.opaque(value) does not support yet.'
   endif
-  return printf('//%s%s/%s',
-  \           self.__host,
-  \           (self.__port !=# '' ? ':' . self.__port : ''),
+  return printf('//%s/%s',
+  \           self.authority(),
   \           self.__path)
 endfunction
 
@@ -286,11 +296,9 @@ endfunction
 function! s:_uri_to_iri() dict abort
   " Same as uri.to_string(), but do unescape for self.__path.
   return printf(
-  \   '%s://%s%s%s/%s%s%s',
+  \   '%s://%s/%s%s%s',
   \   self.__scheme,
-  \   (self.__userinfo != '' ? self.__userinfo . '@' : ''),
-  \   self.__host,
-  \   (self.__port !=# '' ? ':' . self.__port : ''),
+  \   self.authority(),
   \   s:HTTP.decodeURI(self.__path),
   \   (self.__query != '' ? '?' . self.__query : ''),
   \   (self.__fragment != '' ? '#' . self.__fragment : ''),
@@ -299,11 +307,9 @@ endfunction
 
 function! s:_uri_to_string() dict abort
   return printf(
-  \   '%s://%s%s%s/%s%s%s',
+  \   '%s://%s/%s%s%s',
   \   self.__scheme,
-  \   (self.__userinfo != '' ? self.__userinfo . '@' : ''),
-  \   self.__host,
-  \   (self.__port !=# '' ? ':' . self.__port : ''),
+  \   self.authority(),
   \   self.__path,
   \   (self.__query != '' ? '?' . self.__query : ''),
   \   (self.__fragment != '' ? '#' . self.__fragment : ''),
@@ -370,6 +376,7 @@ let s:URI = {
 \ 'host': s:_local_func('_uri_host'),
 \ 'port': s:_local_func('_uri_port'),
 \ 'path': s:_local_func('_uri_path'),
+\ 'authority': s:_local_func('_uri_authority'),
 \ 'opaque': s:_local_func('_uri_opaque'),
 \ 'query': s:_local_func('_uri_query'),
 \ 'fragment': s:_local_func('_uri_fragment'),

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -148,7 +148,7 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
     let port = ''
   endif
 
-  " path (string after authority in hier-part)
+  " path
   let [path, rest] = s:_eat_path(rest, a:pattern_set)
 
   " query
@@ -172,7 +172,7 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
   let obj = deepcopy(s:URI)
   let obj.__pattern_set = a:pattern_set
   " TODO: No need to use setter?
-  " Just set property to directly.
+  " Just set the values to each property directly.
   call obj.scheme(scheme)
   call obj.userinfo(userinfo)
   call obj.host(host)

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -446,7 +446,9 @@ let s:URI = {
 let s:DefaultPatternSet = {'_cache': {}}
 
 function! s:new_default_pattern_set() abort
-  return deepcopy(s:DefaultPatternSet)
+  let pattern_set = deepcopy(s:DefaultPatternSet)
+  let pattern_set._cache = {}
+  return pattern_set
 endfunction
 
 " Memoize

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -125,9 +125,6 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
 
   " scheme
   let [scheme, rest] = s:_eat_scheme(rest, a:pattern_set)
-  if scheme ==# ''
-    throw 'uri parse error: could not parse scheme.'
-  endif
 
   let rest = s:_eat_em(rest, '^://')[1]
 
@@ -143,9 +140,6 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
 
   " host
   let [host, rest] = s:_eat_host(rest, a:pattern_set)
-  if host ==# ''
-    throw 'uri parse error: could not parse host.'
-  endif
 
   " port
   if rest[0] ==# ':'

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -425,16 +425,13 @@ function! s:DefaultPatternSet.get(component, ...) abort
   return ret
 endfunction
 
-function! s:DefaultPatternSet.hexdig() abort
-  return '[0-9A-Fa-f]'
-endfunction
 " unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
 function! s:DefaultPatternSet.unreserved() abort
   return '[[:alpha:]0-9._~-]'
 endfunction
 " pct-encoded   = "%" HEXDIG HEXDIG
 function! s:DefaultPatternSet.pct_encoded() abort
-  return '%' . self.hexdig() . self.hexdig()
+  return '%\x\x'
 endfunction
 " sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
 "               / "*" / "+" / "," / ";" / "="
@@ -482,7 +479,7 @@ endfunction
 " h16 = 1*4HEXDIG
 "     ; 16 bits of address represented in hexadecimal
 function! s:DefaultPatternSet.h16() abort
-  return '\%(' . self.hexdig() . '\)\{1,4}'
+  return '\%(\x\)\{1,4}'
 endfunction
 " ls32 = ( h16 ":" h16 ) / IPv4address
 "      ; least-significant 32 bits of address
@@ -491,7 +488,7 @@ function! s:DefaultPatternSet.ls32() abort
 endfunction
 " IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
 function! s:DefaultPatternSet.ipv_future() abort
-  return 'v\%(' . self.hexdig() . '\)\+\.'
+  return 'v\%(\x\)\+\.'
   \    . '\%(' . join([self.unreserved(), self.sub_delims(), ':'], '\|') . '\)\+'
 endfunction
 " IP-Literal = "[" ( IPv6address / IPvFuture  ) "]"

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -14,59 +14,65 @@ endfunction
 
 " }}}
 
-" Autoload Functions {{{
+" Public Functions {{{
 
 let s:NONE = []
 
-function! s:_uri_new_sandbox(args, retall, NothrowValue) abort
+function! s:_uri_new_sandbox(uri, ignore_rest, pattern_set, retall, NothrowValue) abort "{{{
   try
-    let results = call('s:_uri_new', a:args)
+    let results = call('s:_uri_new', [a:uri, a:ignore_rest, a:pattern_set])
     return a:retall ? results : results[0]
   catch
     if a:NothrowValue isnot s:NONE && s:_is_own_exception(v:exception)
       return a:NothrowValue
     else
-      throw substitute(v:exception, '^Vim([^()]\+):', '', '')
+      let ex = substitute(v:exception, '^Vim([^()]\+):', '', '')
+      throw ex . ' @ ' . v:throwpoint
     endif
   endtry
-endfunction
+endfunction "}}}
 
-function! s:_is_own_exception(str) abort
+function! s:_is_own_exception(str) abort "{{{
   return a:str =~# '^uri parse error:'
-endfunction
+endfunction "}}}
 
-function! s:new(uri, ...) abort
-  let NothrowValue = a:0 ? a:1 : s:NONE
+function! s:new(uri, ...) abort "{{{
+  let NothrowValue = get(a:000, 0, s:NONE)
+  let pattern_set = get(a:000, 1, s:DefaultPatternSet)
   return s:_uri_new_sandbox(
-  \   [a:uri], 0, NothrowValue)
-endfunction
+  \   a:uri, 0, pattern_set, 0, NothrowValue)
+endfunction "}}}
 
-function! s:new_from_uri_like_string(str, ...) abort
-  let str = a:str
-  if str !~# s:RX_SCHEME    " no scheme.
-    let str = 'http://' . str
+function! s:new_from_uri_like_string(str, ...) abort "{{{
+  let NothrowValue = get(a:000, 0, s:NONE)
+  let pattern_set  = get(a:000, 1, s:DefaultPatternSet)
+  " Prepend http if no scheme.
+  if a:str !~# '^'.pattern_set.get('scheme')
+    let str = 'http://' . a:str
+  else
+    let str = a:str
   endif
 
-  let NothrowValue = a:0 ? a:1 : s:NONE
   return s:_uri_new_sandbox(
-  \   [str], 0, NothrowValue)
-endfunction
+  \   str, 0, pattern_set, 0, NothrowValue)
+endfunction "}}}
 
-function! s:new_from_seq_string(uri, ...) abort
-  let NothrowValue = a:0 ? a:1 : s:NONE
+function! s:new_from_seq_string(uri, ...) abort "{{{
+  let NothrowValue = get(a:000, 0, s:NONE)
+  let pattern_set  = get(a:000, 1, s:DefaultPatternSet)
   return s:_uri_new_sandbox(
-  \   [a:uri, 1], 1, NothrowValue)
-endfunction
+  \   a:uri, 1, pattern_set, 1, NothrowValue)
+endfunction "}}}
 
-function! s:is_uri(str) abort
+function! s:is_uri(str) abort "{{{
   let ERROR = []
   return s:new(a:str, ERROR) isnot ERROR
-endfunction
+endfunction "}}}
 
-function! s:like_uri(str) abort
+function! s:like_uri(str) abort "{{{
   let ERROR = []
   return s:new_from_uri_like_string(a:str, ERROR) isnot ERROR
-endfunction
+endfunction "}}}
 
 function! s:encode(str, ...) abort
   let encoding = a:0 ? a:1 : 'utf-8'
@@ -100,187 +106,73 @@ endfunction
 
 " }}}
 
-" URI Object {{{
-
-function! s:_uri_new(str, ...) abort
-  let ignore_rest = (a:0 ? a:1 : 0)
-  let [result, rest] = s:_parse_uri(a:str, ignore_rest)
-  " TODO: Support punycode
-  " let result.host = ...
-
-  let obj = deepcopy(s:uri)
-  for [where, value] in items(result)
-    call s:_validate_{where}(value)         " Validate the value.
-    call call(obj[where], [value], obj)    " Set the value.
-  endfor
-
-  let original_url = a:str[: len(a:str)-len(rest)-1]
-  return [obj, original_url, rest]
-endfunction
-
-function! s:_uri_scheme(...) dict abort
-  if a:0 && s:_is_scheme(a:1)
-    let self.__scheme = a:1
-  endif
-  return self.__scheme
-endfunction
-
-function! s:_uri_host(...) dict abort
-  if a:0 && s:_is_host(a:1)
-    let self.__host = a:1
-  endif
-  return self.__host
-endfunction
-
-function! s:_uri_port(...) dict abort
-  if a:0 && s:_is_port(a:1)
-    let self.__port = a:1
-  endif
-  return self.__port
-endfunction
-
-function! s:_uri_path(...) dict abort
-  if a:0
-    " NOTE: self.__path must not have "/" as prefix.
-    let path = substitute(a:1, '^/\+', '', '')
-    if s:_is_path(path)
-      let self.__path = path
-    endif
-  endif
-  return "/" . self.__path
-endfunction
-
-function! s:_uri_opaque(...) dict abort
-  if a:0
-    " TODO
-    throw 'vital: Web.URI: uri.opaque(value) does not support yet.'
-  endif
-  return printf('//%s%s/%s',
-  \           self.__host,
-  \           (self.__port !=# '' ? ':' . self.__port : ''),
-  \           self.__path)
-endfunction
-
-function! s:_uri_fragment(...) dict abort
-  if a:0
-    " NOTE: self.__fragment must not have "#" as prefix.
-    let fragment = substitute(a:1, '^#', '', '')
-    if s:_is_fragment(fragment)
-      let self.__fragment = fragment
-    endif
-  endif
-  return self.__fragment
-endfunction
-
-function! s:_uri_query(...) dict abort
-  if a:0
-    " NOTE: self.__query must not have "?" as prefix.
-    let query = substitute(a:1, '^?', '', '')
-    if s:_is_query(query)
-      let self.__query = query
-    endif
-  endif
-  return self.__query
-endfunction
-
-function! s:_uri_to_iri() dict abort
-  " Same as uri.to_string(), but do unescape for self.__path.
-  return printf(
-  \   '%s://%s%s/%s%s%s',
-  \   self.__scheme,
-  \   self.__host,
-  \   (self.__port !=# '' ? ':' . self.__port : ''),
-  \   s:HTTP.decodeURI(self.__path),
-  \   (self.__query != '' ? '?' . self.__query : ''),
-  \   (self.__fragment != '' ? '#' . self.__fragment : ''),
-  \)
-endfunction
-
-function! s:_uri_to_string() dict abort
-  return printf(
-  \   '%s://%s%s/%s%s%s',
-  \   self.__scheme,
-  \   self.__host,
-  \   (self.__port !=# '' ? ':' . self.__port : ''),
-  \   self.__path,
-  \   (self.__query != '' ? '?' . self.__query : ''),
-  \   (self.__fragment != '' ? '#' . self.__fragment : ''),
-  \)
-endfunction
-
-
-
-function! s:_local_func(name) abort
-  let sid = matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__local_func$')
-  return function('<SNR>' . sid . '_' . a:name)
-endfunction
-
-let s:uri = {
-\ '__scheme': '',
-\ '__host': '',
-\ '__port': '',
-\ '__path': '',
-\ '__query': '',
-\ '__fragment': '',
-\
-\ 'scheme': s:_local_func('_uri_scheme'),
-\ 'host': s:_local_func('_uri_host'),
-\ 'port': s:_local_func('_uri_port'),
-\ 'path': s:_local_func('_uri_path'),
-\ 'opaque': s:_local_func('_uri_opaque'),
-\ 'query': s:_local_func('_uri_query'),
-\ 'fragment': s:_local_func('_uri_fragment'),
-\ 'to_iri': s:_local_func('_uri_to_iri'),
-\ 'to_string': s:_local_func('_uri_to_string'),
-\}
-" }}}
-
 " Parsing Functions {{{
 
-function! s:_parse_uri(str, ignore_rest) abort
+" @return instance of s:URI .
+"
+" TODO: Support punycode
+"
+" Quoted the outline of RFC3986 here.
+" RFC3986: http://tools.ietf.org/html/rfc3986
+"
+" URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+" hier-part = "//" authority path-abempty
+"           / path-absolute
+"           / path-noscheme
+"           / path-rootless
+"           / path-empty
+" authority = [ userinfo "@" ] host [ ":" port ]
+function! s:_parse_uri(str, ignore_rest, pattern_set) abort "{{{
   let rest = a:str
 
   " Ignore leading/trailing whitespaces.
   let rest = substitute(rest, '^\s\+', '', '')
   let rest = substitute(rest, '\s\+$', '', '')
 
-  " URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
-  " hier-part = "//" authority path-abempty
-  "           / path-absolute
-  "           / path-rootless
-  "           / path-empty
-  " authority = [ userinfo "@" ] host [ ":" port ]
-
   " scheme
-  let [scheme, rest] = s:_eat_scheme(rest)
+  let [scheme, rest] = s:_eat_scheme(rest, a:pattern_set)
+  if scheme ==# ''
+    throw 'uri parse error: could not parse scheme.'
+  endif
 
   let rest = s:_eat_em(rest, '^://')[1]
 
-  " TODO: userinfo
+  " userinfo
+  try
+    let oldrest = rest
+    let [userinfo, rest] = s:_eat_userinfo(rest, a:pattern_set)
+    let rest = s:_eat_em(rest, '^@')[1]
+  catch
+    let rest = oldrest
+    let userinfo = ''
+  endtry
 
   " host
-  let [host, rest] = s:_eat_host(rest)
+  let [host, rest] = s:_eat_host(rest, a:pattern_set)
+  if host ==# ''
+    throw 'uri parse error: could not parse host.'
+  endif
 
   " port
   if rest[0] ==# ':'
-    let [port, rest] = s:_eat_port(rest[1:])
+    let [port, rest] = s:_eat_port(rest[1:], a:pattern_set)
   else
     let port = ''
   endif
 
   " path (string after authority in hier-part)
-  let [path, rest] = s:_eat_path(rest)
+  let [path, rest] = s:_eat_path(rest, a:pattern_set)
 
   " query
   if rest[0] ==# '?'
-    let [query, rest] = s:_eat_query(rest[1:])
+    let [query, rest] = s:_eat_query(rest[1:], a:pattern_set)
   else
     let query = ''
   endif
 
   " fragment
   if rest[0] ==# '#'
-    let [fragment, rest] = s:_eat_fragment(rest[1:])
+    let [fragment, rest] = s:_eat_fragment(rest[1:], a:pattern_set)
   else
     let fragment = ''
   endif
@@ -289,29 +181,224 @@ function! s:_parse_uri(str, ignore_rest) abort
     throw 'uri parse error: unnecessary string at the end.'
   endif
 
-  return [{
-  \ 'scheme': scheme,
-  \ 'host': host,
-  \ 'port': port,
-  \ 'path': path,
-  \ 'query': query,
-  \ 'fragment': fragment,
-  \}, rest]
-endfunction
-function! s:_eat_em(str, pat) abort
+  let obj = deepcopy(s:URI)
+  let obj.__pattern_set = a:pattern_set
+  " TODO: No need to use setter?
+  " Just set property to directly.
+  call obj.scheme(scheme)
+  call obj.userinfo(userinfo)
+  call obj.host(host)
+  call obj.port(port)
+  call obj.path(path)
+  call obj.query(query)
+  call obj.fragment(fragment)
+  return [obj, rest]
+endfunction "}}}
+
+function! s:_eat_em(str, pat) abort "{{{
   let pat = a:pat.'\C'
-  let m = matchlist(a:str, pat)
-  if empty(m)
+  let match = matchstr(a:str, pat)
+  if match ==# ''
     throw 'uri parse error: '
     \   . printf("can't parse '%s' with '%s'.", a:str, pat)
   endif
-  let [match, want] = m[0:1]
   let rest = strpart(a:str, strlen(match))
-  return [want, rest]
+  return [match, rest]
+endfunction "}}}
+
+" NOTE: More s:_eat_*() functions are defined by s:_create_eat_functions().
+
+" }}}
+
+" s:URI {{{
+
+function! s:_uri_new(str, ignore_rest, pattern_set) abort "{{{
+  let [obj, rest] = s:_parse_uri(a:str, a:ignore_rest, a:pattern_set)
+  if a:ignore_rest
+    let original_url = a:str[: len(a:str)-len(rest)-1]
+    return [obj, original_url, rest]
+  else
+    return [obj, a:str, '']
+  endif
+endfunction "}}}
+
+function! s:_uri_scheme(...) dict abort "{{{
+  if a:0 && self.is_scheme(a:1)
+    let self.__scheme = a:1
+  endif
+  return self.__scheme
+endfunction "}}}
+
+function! s:_uri_userinfo(...) dict abort "{{{
+  if a:0 && self.is_userinfo(a:1)
+    let self.__userinfo = a:1
+  endif
+  return self.__userinfo
+endfunction "}}}
+
+function! s:_uri_host(...) dict abort "{{{
+  if a:0 && self.is_host(a:1)
+    let self.__host = a:1
+  endif
+  return self.__host
+endfunction "}}}
+
+function! s:_uri_port(...) dict abort "{{{
+  if a:0 && self.is_port(a:1)
+    let self.__port = a:1
+  endif
+  return self.__port
+endfunction "}}}
+
+function! s:_uri_path(...) dict abort "{{{
+  if a:0
+    " NOTE: self.__path must not have "/" as prefix.
+    let path = substitute(a:1, '^/\+', '', '')
+    if self.is_path(path)
+      let self.__path = path
+    endif
+  endif
+  return "/" . self.__path
+endfunction "}}}
+
+function! s:_uri_opaque(...) dict abort "{{{
+  if a:0
+    " TODO
+    throw 'vital: Web.URI: uri.opaque(value) does not support yet.'
+  endif
+  return printf('//%s%s/%s',
+  \           self.__host,
+  \           (self.__port !=# '' ? ':' . self.__port : ''),
+  \           self.__path)
+endfunction "}}}
+
+function! s:_uri_query(...) dict abort "{{{
+  if a:0
+    " NOTE: self.__query must not have "?" as prefix.
+    let query = substitute(a:1, '^?', '', '')
+    if self.is_query(query)
+      let self.__query = query
+    endif
+  endif
+  return self.__query
+endfunction "}}}
+
+function! s:_uri_fragment(...) dict abort "{{{
+  if a:0
+    " NOTE: self.__fragment must not have "#" as prefix.
+    let fragment = substitute(a:1, '^#', '', '')
+    if self.is_fragment(fragment)
+      let self.__fragment = fragment
+    endif
+  endif
+  return self.__fragment
+endfunction "}}}
+
+function! s:_uri_to_iri() dict abort "{{{
+  " Same as uri.to_string(), but do unescape for self.__path.
+  return printf(
+  \   '%s://%s%s%s/%s%s%s',
+  \   self.__scheme,
+  \   (self.__userinfo != '' ? self.__userinfo . '@' : ''),
+  \   self.__host,
+  \   (self.__port !=# '' ? ':' . self.__port : ''),
+  \   s:HTTP.decodeURI(self.__path),
+  \   (self.__query != '' ? '?' . self.__query : ''),
+  \   (self.__fragment != '' ? '#' . self.__fragment : ''),
+  \)
+endfunction "}}}
+
+function! s:_uri_to_string() dict abort "{{{
+  return printf(
+  \   '%s://%s%s%s/%s%s%s',
+  \   self.__scheme,
+  \   (self.__userinfo != '' ? self.__userinfo . '@' : ''),
+  \   self.__host,
+  \   (self.__port !=# '' ? ':' . self.__port : ''),
+  \   self.__path,
+  \   (self.__query != '' ? '?' . self.__query : ''),
+  \   (self.__fragment != '' ? '#' . self.__fragment : ''),
+  \)
+endfunction "}}}
+
+
+let s:FUNCTION_DESCS = [
+\ 'scheme', 'userinfo', 'host',
+\ 'port', 'path', 'query', 'fragment'
+\]
+
+" Create s:_eat_*() functions.
+function! s:_create_eat_functions() abort
+  for where in s:FUNCTION_DESCS
+    execute join([
+    \ 'function! s:_eat_'.where.'(str, pattern_set) abort',
+    \   'return s:_eat_em(a:str, "^" . a:pattern_set.get('.string(where).'))',
+    \ 'endfunction',
+    \], "\n")
+  endfor
 endfunction
+call s:_create_eat_functions()
+
+" Create s:_uri_is_*() functions.
+function! s:_has_error(func, args) abort
+  try
+    call call(a:func, a:args)
+    return 0
+  catch
+    return 1
+  endtry
+endfunction
+function! s:_create_check_functions() abort
+  for where in s:FUNCTION_DESCS
+    execute join([
+    \ 'function! s:_uri_is_'.where.'(str) dict abort',
+    \   'return !s:_has_error("s:_eat_'.where.'", [a:str, self.__pattern_set])',
+    \ 'endfunction',
+    \], "\n")
+  endfor
+endfunction
+call s:_create_check_functions()
 
 
-" Patterns for URI syntax {{{
+function! s:_local_func(name) abort "{{{
+  let sid = matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__local_func$')
+  return function('<SNR>' . sid . '_' . a:name)
+endfunction "}}}
+
+let s:URI = {
+\ '__scheme': '',
+\ '__userinfo': '',
+\ '__host': '',
+\ '__port': '',
+\ '__path': '',
+\ '__query': '',
+\ '__fragment': '',
+\
+\ '__pattern_set': {},
+\
+\ 'scheme': s:_local_func('_uri_scheme'),
+\ 'userinfo': s:_local_func('_uri_userinfo'),
+\ 'host': s:_local_func('_uri_host'),
+\ 'port': s:_local_func('_uri_port'),
+\ 'path': s:_local_func('_uri_path'),
+\ 'opaque': s:_local_func('_uri_opaque'),
+\ 'query': s:_local_func('_uri_query'),
+\ 'fragment': s:_local_func('_uri_fragment'),
+\
+\ 'to_iri': s:_local_func('_uri_to_iri'),
+\ 'to_string': s:_local_func('_uri_to_string'),
+\
+\ 'is_scheme': s:_local_func('_uri_is_scheme'),
+\ 'is_userinfo': s:_local_func('_uri_is_userinfo'),
+\ 'is_host': s:_local_func('_uri_is_host'),
+\ 'is_port': s:_local_func('_uri_is_port'),
+\ 'is_path': s:_local_func('_uri_is_path'),
+\ 'is_query': s:_local_func('_uri_is_query'),
+\ 'is_fragment': s:_local_func('_uri_is_fragment'),
+\}
+" }}}
+
+" s:PatternSet: Patterns for URI syntax {{{
 "
 " The main parts of URLs
 "   http://tools.ietf.org/html/rfc1738#section-2.1
@@ -323,76 +410,105 @@ endfunction
 " NOTE: Using this regexp pattern in urilib.vim
 "   http://tools.ietf.org/html/rfc3986#appendix-B
 
-let s:RX_SCHEME   = '^\([^:/?#[:space:]]\+\)'
-let s:RX_HOST     = '^\([^/?#[:space:]]*\)'
-let s:RX_PORT     = '^\(\d*\)'
-let s:RX_PATH     = '^\([^?#[:space:]]*\)'
-let s:RX_QUERY    = '^\([^#[:space:]]*\)'
-let s:RX_FRAGMENT = '^\([^[:space:]]*\)'
-" }}}
+let s:DefaultPatternSet = {'_cache': {}}
 
-" FIXME: make error messages user-friendly.
-let s:FUNCTION_DESCS = {
-\ 'scheme': 'uri parse error: all characters'
-\         . ' in scheme must be [a-z].',
-\ 'host': 'uri parse error: all characters'
-\       . ' in host must be [\x00-\xff].',
-\ 'port': 'uri parse error: all characters'
-\       . ' in port must be digit and the number'
-\       . ' is greater than 0.',
-\ 'path': 'uri parse error: all characters'
-\       . ' in path must be [\x00-\xff].',
-\ 'query': 'uri parse error: all characters'
-\       . ' in query must be [\x00-\xff].',
-\ 'fragment': 'uri parse error: all characters'
-\           . ' in fragment must be [\x00-\xff].',
-\}
+function! s:new_default_pattern_set() abort
+  return deepcopy(s:DefaultPatternSet)
+endfunction
 
-" Create s:_eat_*() functions.
-function! s:_create_eat_functions() abort
-  for where in keys(s:FUNCTION_DESCS)
-    execute join([
-    \ 'function! s:_eat_'.where.'(str) abort',
-    \   'return s:_eat_em(a:str, s:RX_'.toupper(where).')',
-    \ 'endfunction',
-    \], "\n")
-  endfor
+" Memoize
+function! s:DefaultPatternSet.get(component, ...) abort
+  if has_key(self._cache, a:component)
+    return self._cache[a:component]
+  endif
+  let ret = call(self[a:component], a:000, self)
+  let self._cache[a:component] = ret
+  return ret
 endfunction
-call s:_create_eat_functions()
 
-" Create s:_is_*() functions.
-function! s:_has_error(func, args) abort
-  try
-    call call(a:func, a:args)
-    return 0
-  catch
-    return 1
-  endtry
+function! s:DefaultPatternSet.hexdig() abort
+  return '[0-9A-Fa-f]'
 endfunction
-function! s:_create_check_functions() abort
-  for where in keys(s:FUNCTION_DESCS)
-    execute join([
-    \ 'function! s:_is_'.where.'(str) abort',
-    \   'return !s:_has_error("s:_eat_'.where.'", [a:str])',
-    \ 'endfunction',
-    \], "\n")
-  endfor
+function! s:DefaultPatternSet.unreserved() abort
+  return '[[:alpha:]0-9._~-]'
 endfunction
-call s:_create_check_functions()
+function! s:DefaultPatternSet.pct_encoded() abort
+  return '%' . self.hexdig() . self.hexdig()
+endfunction
+function! s:DefaultPatternSet.sub_delims() abort
+  return '[!$&''()*+,;=]'
+endfunction
+function! s:DefaultPatternSet.dec_octet() abort
+  return '\%([0-9]\|[1-9][0-9]\|1[0-9][0-9]\|2[0-4][0-9]\|25[0-5]\)'
+endfunction
+function! s:DefaultPatternSet.ipv4address() abort
+  return self.dec_octet() . '\.' . self.dec_octet() . '\.' . self.dec_octet() . '\.' . self.dec_octet()
+endfunction
+function! s:DefaultPatternSet.ip_literal() abort
+  " TODO
+  " IP-literal    = "[" ( IPv6address / IPvFuture  ) "]"
+  " IPvFuture     = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+  " IPv6address   =                            6( h16 ":" ) ls32
+  "               /                       "::" 5( h16 ":" ) ls32
+  "               / [               h16 ] "::" 4( h16 ":" ) ls32
+  "               / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+  "               / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+  "               / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+  "               / [ *4( h16 ":" ) h16 ] "::"              ls32
+  "               / [ *5( h16 ":" ) h16 ] "::"              h16
+  "               / [ *6( h16 ":" ) h16 ] "::"
+endfunction
+function! s:DefaultPatternSet.reg_name() abort
+  return '\%(' . join([self.unreserved(), self.pct_encoded(), self.sub_delims()], '\|') . '\)*'
+endfunction
+function! s:DefaultPatternSet.pchar() abort
+  return '\%(' . join([self.unreserved(), self.pct_encoded(), self.sub_delims(), ':', '@'], '\|') . '\)'
+endfunction
+function! s:DefaultPatternSet.segment() abort
+  return self.pchar() . '*'
+endfunction
+function! s:DefaultPatternSet.segment_nz() abort
+  return self.pchar()
+endfunction
+function! s:DefaultPatternSet.segment_nz_nc() abort
+  return '\%(' . join([self.unreserved(), self.pct_encoded(), self.sub_delims(), '@'], '\|') . '\)'
+endfunction
+function! s:DefaultPatternSet.path_abempty() abort
+  return '\%(/' . self.segment() . '\)*'
+endfunction
+function! s:DefaultPatternSet.path_absolute() abort
+  return '/\%(' . self.segment_nz() . '\%(/' . self.segment() . '\)*\)\?'
+endfunction
+function! s:DefaultPatternSet.path_noscheme() abort
+  return self.segment_nz_nc() . '\%(/' . self.segment() . '\)'
+endfunction
+function! s:DefaultPatternSet.path_rootless() abort
+  return self.segment_nz() . '\%(/' . self.segment() . '\)*'
+endfunction
 
-" Create s:_validate_*() functions.
-function! s:_create_validate_functions() abort
-  for [where, msg] in items(s:FUNCTION_DESCS)
-    execute join([
-    \ 'function! s:_validate_'.where.'(str) abort',
-    \   'if !s:_is_'.where.'(a:str)',
-    \     'throw '.string(msg),
-    \   'endif',
-    \ 'endfunction',
-    \], "\n")
-  endfor
+function! s:DefaultPatternSet.scheme() abort
+  return '[[:alpha:]][[:alpha:]0-9+.-]*'
 endfunction
-call s:_create_validate_functions()
+function! s:DefaultPatternSet.userinfo() abort
+  return join([self.unreserved(), self.pct_encoded(), self.sub_delims(), ':'], '\|')
+endfunction
+function! s:DefaultPatternSet.host() abort
+  return join([self.ipv4address(), self.reg_name()], '\|')
+  " TODO
+  " return join([self.ip_literal(), self.ipv4address(), self.reg_name()], '\|')
+endfunction
+function! s:DefaultPatternSet.port() abort
+  return '[0-9]\+'
+endfunction
+function! s:DefaultPatternSet.path() abort
+  return join([self.path_abempty(), self.path_absolute(), self.path_noscheme(), self.path_rootless(), ''], '\|')
+endfunction
+function! s:DefaultPatternSet.query() abort
+  return '\%(' . join([self.pchar(), '/', '?'], '\|') . '\)*'
+endfunction
+function! s:DefaultPatternSet.fragment() abort
+  return self.query()
+endfunction
 
 " }}}
 

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -208,7 +208,7 @@ function! s:_eat_hier_part(rest, pattern_set) abort
       let [path, rest] = s:_eat_path_absolute(rest, a:pattern_set)
     elseif rest =~# '^[^:]'    " begins with a non-colon segment
       let [path, rest] = s:_eat_path_noscheme(rest, a:pattern_set)
-    elseif rest =~# a:path.segment_nz()    " begins with a segment
+    elseif rest =~# a:pattern_set.segment_nz()    " begins with a segment
       let [path, rest] = s:_eat_path_rootless(rest, a:pattern_set)
     elseif rest ==# '' || rest =~# '^[?#]'    " zero characters
       let path = ''

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -91,6 +91,7 @@ function! s:_uri_new_sandbox(uri, ignore_rest, pattern_set, retall, NothrowValue
     else
       let ex = substitute(v:exception, '^Vim([^()]\+):', '', '')
       throw 'vital: Web.URI: ' . ex . ' @ ' . v:throwpoint
+      \   . ' (original URI: ' . a:uri . ')'
     endif
   endtry
 endfunction

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -96,7 +96,7 @@ function! s:_uri_new_sandbox(uri, ignore_rest, pattern_set, retall, NothrowValue
 endfunction
 
 function! s:_is_own_exception(str) abort
-  return a:str =~# '^uri parse error:'
+  return a:str =~# '^uri parse error\%((\w\+)\)\?:'
 endfunction
 
 
@@ -183,12 +183,13 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
   return [obj, rest]
 endfunction
 
-function! s:_eat_em(str, pat) abort
+function! s:_eat_em(str, pat, ...) abort
   let pat = a:pat.'\C'
   let m = matchlist(a:str, pat)
   if empty(m)
-    throw 'uri parse error: '
-    \   . printf("can't parse '%s' with '%s'.", a:str, pat)
+    let prefix = printf("uri parse error%s: ", (a:0 ? '('.a:1.')' : ''))
+    let msg = printf("can't parse '%s' with '%s'.", a:str, pat)
+    throw prefix . msg
   endif
   let rest = strpart(a:str, strlen(m[0]))
   return [m[0], rest]
@@ -320,7 +321,7 @@ function! s:_create_eat_functions() abort
   for where in s:FUNCTION_DESCS
     execute join([
     \ 'function! s:_eat_'.where.'(str, pattern_set) abort',
-    \   'return s:_eat_em(a:str, "^" . a:pattern_set.get('.string(where).'))',
+    \   'return s:_eat_em(a:str, "^" . a:pattern_set.get('.string(where).'), '.string(where).')',
     \ 'endfunction',
     \], "\n")
   endfor

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -21,7 +21,7 @@ function! s:new_from_uri_like_string(str, ...) abort
   let NothrowValue = get(a:000, 0, s:NONE)
   let pattern_set  = get(a:000, 1, s:DefaultPatternSet)
   " Prepend http if no scheme.
-  if a:str !~# '^'.pattern_set.get('scheme')
+  if a:str !~# '^' . pattern_set.get('scheme') . '://'
     let str = 'http://' . a:str
   else
     let str = a:str

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -490,7 +490,7 @@ function! s:DefaultPatternSet.scheme() abort
   return '[[:alpha:]][[:alpha:]0-9+.-]*'
 endfunction
 function! s:DefaultPatternSet.userinfo() abort
-  return join([self.unreserved(), self.pct_encoded(), self.sub_delims(), ':'], '\|')
+  return '\%(' . join([self.unreserved(), self.pct_encoded(), self.sub_delims(), ':'], '\|') . '\)*'
 endfunction
 function! s:DefaultPatternSet.host() abort
   return join([self.ipv4address(), self.reg_name()], '\|')

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -1,8 +1,6 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-" Imports {{{
-
 function! s:_vital_loaded(V) abort
   let s:V = a:V
   let s:HTTP = s:V.import('Web.HTTP')
@@ -12,38 +10,14 @@ function! s:_vital_depends() abort
   return ['Web.HTTP']
 endfunction
 
-" }}}
-
-" Public Functions {{{
-
-let s:NONE = []
-
-function! s:_uri_new_sandbox(uri, ignore_rest, pattern_set, retall, NothrowValue) abort "{{{
-  try
-    let results = call('s:_uri_new', [a:uri, a:ignore_rest, a:pattern_set])
-    return a:retall ? results : results[0]
-  catch
-    if a:NothrowValue isnot s:NONE && s:_is_own_exception(v:exception)
-      return a:NothrowValue
-    else
-      let ex = substitute(v:exception, '^Vim([^()]\+):', '', '')
-      throw ex . ' @ ' . v:throwpoint
-    endif
-  endtry
-endfunction "}}}
-
-function! s:_is_own_exception(str) abort "{{{
-  return a:str =~# '^uri parse error:'
-endfunction "}}}
-
-function! s:new(uri, ...) abort "{{{
+function! s:new(uri, ...) abort
   let NothrowValue = get(a:000, 0, s:NONE)
   let pattern_set = get(a:000, 1, s:DefaultPatternSet)
   return s:_uri_new_sandbox(
   \   a:uri, 0, pattern_set, 0, NothrowValue)
-endfunction "}}}
+endfunction
 
-function! s:new_from_uri_like_string(str, ...) abort "{{{
+function! s:new_from_uri_like_string(str, ...) abort
   let NothrowValue = get(a:000, 0, s:NONE)
   let pattern_set  = get(a:000, 1, s:DefaultPatternSet)
   " Prepend http if no scheme.
@@ -55,24 +29,24 @@ function! s:new_from_uri_like_string(str, ...) abort "{{{
 
   return s:_uri_new_sandbox(
   \   str, 0, pattern_set, 0, NothrowValue)
-endfunction "}}}
+endfunction
 
-function! s:new_from_seq_string(uri, ...) abort "{{{
+function! s:new_from_seq_string(uri, ...) abort
   let NothrowValue = get(a:000, 0, s:NONE)
   let pattern_set  = get(a:000, 1, s:DefaultPatternSet)
   return s:_uri_new_sandbox(
   \   a:uri, 1, pattern_set, 1, NothrowValue)
-endfunction "}}}
+endfunction
 
-function! s:is_uri(str) abort "{{{
+function! s:is_uri(str) abort
   let ERROR = []
   return s:new(a:str, ERROR) isnot ERROR
-endfunction "}}}
+endfunction
 
-function! s:like_uri(str) abort "{{{
+function! s:like_uri(str) abort
   let ERROR = []
   return s:new_from_uri_like_string(a:str, ERROR) isnot ERROR
-endfunction "}}}
+endfunction
 
 function! s:encode(str, ...) abort
   let encoding = a:0 ? a:1 : 'utf-8'
@@ -104,9 +78,29 @@ function! s:decode(str, ...) abort
   return iconv(result, encoding, &encoding)
 endfunction
 
-" }}}
 
-" Parsing Functions {{{
+let s:NONE = []
+
+function! s:_uri_new_sandbox(uri, ignore_rest, pattern_set, retall, NothrowValue) abort
+  try
+    let results = call('s:_uri_new', [a:uri, a:ignore_rest, a:pattern_set])
+    return a:retall ? results : results[0]
+  catch
+    if a:NothrowValue isnot s:NONE && s:_is_own_exception(v:exception)
+      return a:NothrowValue
+    else
+      let ex = substitute(v:exception, '^Vim([^()]\+):', '', '')
+      throw ex . ' @ ' . v:throwpoint
+    endif
+  endtry
+endfunction
+
+function! s:_is_own_exception(str) abort
+  return a:str =~# '^uri parse error:'
+endfunction
+
+
+" ================ Parsing Functions ================
 
 " @return instance of s:URI .
 "
@@ -122,7 +116,7 @@ endfunction
 "           / path-rootless
 "           / path-empty
 " authority = [ userinfo "@" ] host [ ":" port ]
-function! s:_parse_uri(str, ignore_rest, pattern_set) abort "{{{
+function! s:_parse_uri(str, ignore_rest, pattern_set) abort
   let rest = a:str
 
   " Ignore leading/trailing whitespaces.
@@ -193,9 +187,9 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort "{{{
   call obj.query(query)
   call obj.fragment(fragment)
   return [obj, rest]
-endfunction "}}}
+endfunction
 
-function! s:_eat_em(str, pat) abort "{{{
+function! s:_eat_em(str, pat) abort
   let pat = a:pat.'\C'
   let match = matchstr(a:str, pat)
   if match ==# ''
@@ -204,15 +198,15 @@ function! s:_eat_em(str, pat) abort "{{{
   endif
   let rest = strpart(a:str, strlen(match))
   return [match, rest]
-endfunction "}}}
+endfunction
 
 " NOTE: More s:_eat_*() functions are defined by s:_create_eat_functions().
+" =============== Parsing Functions ===============
 
-" }}}
 
-" s:URI {{{
+" ===================== s:URI =====================
 
-function! s:_uri_new(str, ignore_rest, pattern_set) abort "{{{
+function! s:_uri_new(str, ignore_rest, pattern_set) abort
   let [obj, rest] = s:_parse_uri(a:str, a:ignore_rest, a:pattern_set)
   if a:ignore_rest
     let original_url = a:str[: len(a:str)-len(rest)-1]
@@ -220,37 +214,37 @@ function! s:_uri_new(str, ignore_rest, pattern_set) abort "{{{
   else
     return [obj, a:str, '']
   endif
-endfunction "}}}
+endfunction
 
-function! s:_uri_scheme(...) dict abort "{{{
+function! s:_uri_scheme(...) dict abort
   if a:0 && self.is_scheme(a:1)
     let self.__scheme = a:1
   endif
   return self.__scheme
-endfunction "}}}
+endfunction
 
-function! s:_uri_userinfo(...) dict abort "{{{
+function! s:_uri_userinfo(...) dict abort
   if a:0 && self.is_userinfo(a:1)
     let self.__userinfo = a:1
   endif
   return self.__userinfo
-endfunction "}}}
+endfunction
 
-function! s:_uri_host(...) dict abort "{{{
+function! s:_uri_host(...) dict abort
   if a:0 && self.is_host(a:1)
     let self.__host = a:1
   endif
   return self.__host
-endfunction "}}}
+endfunction
 
-function! s:_uri_port(...) dict abort "{{{
+function! s:_uri_port(...) dict abort
   if a:0 && self.is_port(a:1)
     let self.__port = a:1
   endif
   return self.__port
-endfunction "}}}
+endfunction
 
-function! s:_uri_path(...) dict abort "{{{
+function! s:_uri_path(...) dict abort
   if a:0
     " NOTE: self.__path must not have "/" as prefix.
     let path = substitute(a:1, '^/\+', '', '')
@@ -259,9 +253,9 @@ function! s:_uri_path(...) dict abort "{{{
     endif
   endif
   return "/" . self.__path
-endfunction "}}}
+endfunction
 
-function! s:_uri_opaque(...) dict abort "{{{
+function! s:_uri_opaque(...) dict abort
   if a:0
     " TODO
     throw 'vital: Web.URI: uri.opaque(value) does not support yet.'
@@ -270,9 +264,9 @@ function! s:_uri_opaque(...) dict abort "{{{
   \           self.__host,
   \           (self.__port !=# '' ? ':' . self.__port : ''),
   \           self.__path)
-endfunction "}}}
+endfunction
 
-function! s:_uri_query(...) dict abort "{{{
+function! s:_uri_query(...) dict abort
   if a:0
     " NOTE: self.__query must not have "?" as prefix.
     let query = substitute(a:1, '^?', '', '')
@@ -281,9 +275,9 @@ function! s:_uri_query(...) dict abort "{{{
     endif
   endif
   return self.__query
-endfunction "}}}
+endfunction
 
-function! s:_uri_fragment(...) dict abort "{{{
+function! s:_uri_fragment(...) dict abort
   if a:0
     " NOTE: self.__fragment must not have "#" as prefix.
     let fragment = substitute(a:1, '^#', '', '')
@@ -292,9 +286,9 @@ function! s:_uri_fragment(...) dict abort "{{{
     endif
   endif
   return self.__fragment
-endfunction "}}}
+endfunction
 
-function! s:_uri_to_iri() dict abort "{{{
+function! s:_uri_to_iri() dict abort
   " Same as uri.to_string(), but do unescape for self.__path.
   return printf(
   \   '%s://%s%s%s/%s%s%s',
@@ -306,9 +300,9 @@ function! s:_uri_to_iri() dict abort "{{{
   \   (self.__query != '' ? '?' . self.__query : ''),
   \   (self.__fragment != '' ? '#' . self.__fragment : ''),
   \)
-endfunction "}}}
+endfunction
 
-function! s:_uri_to_string() dict abort "{{{
+function! s:_uri_to_string() dict abort
   return printf(
   \   '%s://%s%s%s/%s%s%s',
   \   self.__scheme,
@@ -319,7 +313,7 @@ function! s:_uri_to_string() dict abort "{{{
   \   (self.__query != '' ? '?' . self.__query : ''),
   \   (self.__fragment != '' ? '#' . self.__fragment : ''),
   \)
-endfunction "}}}
+endfunction
 
 
 let s:FUNCTION_DESCS = [
@@ -360,10 +354,10 @@ endfunction
 call s:_create_check_functions()
 
 
-function! s:_local_func(name) abort "{{{
+function! s:_local_func(name) abort
   let sid = matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze__local_func$')
   return function('<SNR>' . sid . '_' . a:name)
-endfunction "}}}
+endfunction
 
 let s:URI = {
 \ '__scheme': '',
@@ -396,9 +390,12 @@ let s:URI = {
 \ 'is_query': s:_local_func('_uri_is_query'),
 \ 'is_fragment': s:_local_func('_uri_is_fragment'),
 \}
-" }}}
 
-" s:PatternSet: Patterns for URI syntax {{{
+" ===================== s:URI =====================
+
+
+" ================= s:PatternSet ==================
+" s:PatternSet: Patterns for URI syntax
 "
 " The main parts of URLs
 "   http://tools.ietf.org/html/rfc1738#section-2.1
@@ -510,6 +507,6 @@ function! s:DefaultPatternSet.fragment() abort
   return self.query()
 endfunction
 
-" }}}
+" ================= s:PatternSet ==================
 
 " vim:set et ts=2 sts=2 sw=2 tw=0:fen:

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -90,7 +90,7 @@ function! s:_uri_new_sandbox(uri, ignore_rest, pattern_set, retall, NothrowValue
       return a:NothrowValue
     else
       let ex = substitute(v:exception, '^Vim([^()]\+):', '', '')
-      throw ex . ' @ ' . v:throwpoint
+      throw 'vital: Web.URI: ' . ex . ' @ ' . v:throwpoint
     endif
   endtry
 endfunction

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -191,13 +191,13 @@ endfunction
 
 function! s:_eat_em(str, pat) abort
   let pat = a:pat.'\C'
-  let match = matchstr(a:str, pat)
-  if match ==# ''
+  let m = matchlist(a:str, pat)
+  if empty(m)
     throw 'uri parse error: '
     \   . printf("can't parse '%s' with '%s'.", a:str, pat)
   endif
-  let rest = strpart(a:str, strlen(match))
-  return [match, rest]
+  let rest = strpart(a:str, strlen(m[0]))
+  return [m[0], rest]
 endfunction
 
 " NOTE: More s:_eat_*() functions are defined by s:_create_eat_functions().

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -84,6 +84,12 @@ decode({str} [, {char-enc}])		*Vital.Web.URI.decode()*
 ------------------------------------------------------------------------------
 URI OBJECT				*Vital.Web.URI-URI* *Vital.Web.URI-object*
 
+NOTE: See |Vital.Web.HTTP| for encoding/decoding functions.
+* |Vital.Web.HTTP.encodeURI()|
+* |Vital.Web.HTTP.encodeURIComponent()|
+* |Vital.Web.HTTP.decodeURI()|
+
+
 *Vital.Web.URI-URI.scheme()* *Vital.Web.URI-object.scheme()*
 *Vital.Web.URI-URI.host()* *Vital.Web.URI-object.host()*
 *Vital.Web.URI-URI.port()* *Vital.Web.URI-object.port()*
@@ -165,13 +171,12 @@ This code lets the parser ignore these characters. >
 
     " Ignore trailing string after URI.
     let NONE = []
-    let ret = URI.new_from_seq_string('http://example.com)', NONE, pattern_set)
+    let ret = URI.new_from_seq_string(
+    \               'http://example.com)', NONE, s:LoosePatternSet)
     if ret isnot NONE
         ...
     endif
 <
-------------------------------------------------------------------------------
-METHODS				*Vital.Web.URI-PatternSet-methods*
 
 get({component})			*Vital.Web.URI-PatternSet.get()*
 
@@ -231,7 +236,7 @@ needs to raise an error for him or herself.
 ==============================================================================
 TODO					*Vital.Web.URI-todo*
 
-* Punycode
+* Punycode (RFC3492)
 * IRI support (RFC3987)
 * |Vital.Web.URI-URI.opaque()| with an argument
 * |Vital.Web.URI-URI.authority()| with an argument

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -141,7 +141,7 @@ This example allows more tolerant URI parsing.
 The default PatternSet is very strict
 because it is completely RFC3986 based implementation.
 (_default_ means the object which
-*Vital.Web.URI.new_default_pattern_set()* returns)
+|Vital.Web.URI.new_default_pattern_set()| returns)
 
 According to RFC3986, URI allows
 * ' (single quote)

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -236,6 +236,8 @@ REFERENCES				*Vital.Web.URI-references*
   https://url.spec.whatwg.org/#informative
 * RFC3986
   http://tools.ietf.org/html/rfc3986
+* Errata
+  https://www.rfc-editor.org/errata_search.php?rfc=3987
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -10,6 +10,7 @@ INTERFACE				|Vital.Web.URI-interface|
   Functions				|Vital.Web.URI-functions|
   URI Object			|Vital.Web.URI-URI|
   PatternSet Object		|Vital.Web.URI-PatternSet|
+NOTES					|Vital.Web.URI-notes|
 TODO					|Vital.Web.URI-todo|
 REFERENCES				|Vital.Web.URI-references|
 
@@ -88,12 +89,15 @@ URI OBJECT				*Vital.Web.URI-URI* *Vital.Web.URI-object*
 *Vital.Web.URI-URI.port()* *Vital.Web.URI-object.port()*
 *Vital.Web.URI-URI.path()* *Vital.Web.URI-object.path()*
 *Vital.Web.URI-URI.opaque()* *Vital.Web.URI-object.opaque()*
+*Vital.Web.URI-URI.authority()* *Vital.Web.URI-object.authority()*
 *Vital.Web.URI-URI.query()* *Vital.Web.URI-object.query()*
 *Vital.Web.URI-URI.fragment()* *Vital.Web.URI-object.fragment()*
 scheme([{str}])
+userinfo([{str}])
 host([{str}])
 port([{str}])
 path([{str}])
+authority([{str}])
 opaque([{str}])
 query([{str}])
 fragment([{str}])
@@ -101,7 +105,8 @@ fragment([{str}])
 	Returns each part if no arguments are given.
 	Set {str} as each part if {str} is given.
 
-	NOTE: opaque() does not support {str} yet.
+	NOTE: path() always returns a string prefixed by "/".
+	NOTE: opaque(), authority() do not support {str} yet.
 
 to_iri()				*Vital.Web.URI-object.to_iri()*
 	Same as |Vital.Web.URI-object.to_string()|,
@@ -111,18 +116,19 @@ to_string()				*Vital.Web.URI-object.to_string()*
 	Returns URI representation of this object.
 
 *Vital.Web.URI-URI.is_scheme()*
+*Vital.Web.URI-URI.is_userinfo()*
 *Vital.Web.URI-URI.is_host()*
 *Vital.Web.URI-URI.is_port()*
 *Vital.Web.URI-URI.is_path()*
 *Vital.Web.URI-URI.is_query()*
 *Vital.Web.URI-URI.is_fragment()*
 is_scheme({str})
+is_userinfo({str})
 is_host({str})
 is_port({str})
 is_path({str})
 is_query({str})
 is_fragment({str})
-is_opaque({str}) (TODO)
 
     Returns non-zero value if {str} has right syntax
     for each component. Returns zero otherwise.
@@ -167,60 +173,69 @@ get({component})			*Vital.Web.URI-PatternSet.get()*
     let s:PatternSet = s:URI.new_default_pattern_set()
     echo s:PatternSet.get('scheme')
 <
-Listing all customizable components here.
+Listing all customizable components here (alphabetic order).
 NOTE: DON'T call these methods directly.
 These methods are used when defining custimized PatternSet.
 See how-to at |Vital.Web.URI-PatternSet|.
 
-hexdig()					*Vital.Web.URI-PatternSet.hexdig()*
-unreserved()				*Vital.Web.URI-PatternSet.unreserved()*
-pct_encoded()				*Vital.Web.URI-PatternSet.pct_encoded()*
-sub_delims()				*Vital.Web.URI-PatternSet.sub_delims()*
 dec_octet()					*Vital.Web.URI-PatternSet.dec_octet()*
-ipv4address()				*Vital.Web.URI-PatternSet.ipv4address()*
+fragment()					*Vital.Web.URI-PatternSet.fragment()*
+h16()						*Vital.Web.URI-PatternSet.h16()*
+hexdig()					*Vital.Web.URI-PatternSet.hexdig()*
+host()						*Vital.Web.URI-PatternSet.host()*
 ip_literal()				*Vital.Web.URI-PatternSet.ip_literal()*
-reg_name()					*Vital.Web.URI-PatternSet.reg_name()*
-pchar()						*Vital.Web.URI-PatternSet.pchar()*
-segment()					*Vital.Web.URI-PatternSet.segment()*
-segment_nz()				*Vital.Web.URI-PatternSet.segment_nz()*
-segment_nz_nc()				*Vital.Web.URI-PatternSet.segment_nz_nc()*
+ipv4address()				*Vital.Web.URI-PatternSet.ipv4address()*
+ipv6address()				*Vital.Web.URI-PatternSet.ipv6address()*
+ipv_future()				*Vital.Web.URI-PatternSet.ipv_future()*
+ls32()						*Vital.Web.URI-PatternSet.ls32()*
+path()						*Vital.Web.URI-PatternSet.path()*
 path_abempty()				*Vital.Web.URI-PatternSet.path_abempty()*
 path_absolute()				*Vital.Web.URI-PatternSet.path_absolute()*
 path_noscheme()				*Vital.Web.URI-PatternSet.path_noscheme()*
 path_rootless()				*Vital.Web.URI-PatternSet.path_rootless()*
-scheme()					*Vital.Web.URI-PatternSet.scheme()*
-userinfo()					*Vital.Web.URI-PatternSet.userinfo()*
-host()						*Vital.Web.URI-PatternSet.host()*
+pchar()						*Vital.Web.URI-PatternSet.pchar()*
+pct_encoded()				*Vital.Web.URI-PatternSet.pct_encoded()*
 port()						*Vital.Web.URI-PatternSet.port()*
-path()						*Vital.Web.URI-PatternSet.path()*
 query()						*Vital.Web.URI-PatternSet.query()*
-fragment()					*Vital.Web.URI-PatternSet.fragment()*
+reg_name()					*Vital.Web.URI-PatternSet.reg_name()*
+scheme()					*Vital.Web.URI-PatternSet.scheme()*
+segment()					*Vital.Web.URI-PatternSet.segment()*
+segment_nz()				*Vital.Web.URI-PatternSet.segment_nz()*
+segment_nz_nc()				*Vital.Web.URI-PatternSet.segment_nz_nc()*
+sub_delims()				*Vital.Web.URI-PatternSet.sub_delims()*
+unreserved()				*Vital.Web.URI-PatternSet.unreserved()*
+userinfo()					*Vital.Web.URI-PatternSet.userinfo()*
 
+
+==============================================================================
+NOTES					*Vital.Web.URI-notes*
+
+Empty authority
+-----------------
+
+Empty authority is allowed for "file" scheme,
+but not for almost schemes, for example, "http" scheme.
+However, Web.URI does not concern about
+authority handling for each scheme,
+because it is just a parser library for URI.
+If a user wants to raise an error for a such case,
+needs to raise an error for him or herself.
 
 ==============================================================================
 TODO					*Vital.Web.URI-todo*
 
 * Punycode
+* IRI support (RFC3987)
 * |Vital.Web.URI-URI.opaque()| with an argument
-* |Vital.Web.URI-URI.is_opaque()|
+* |Vital.Web.URI-URI.authority()| with an argument
 
 ==============================================================================
 REFERENCES				*Vital.Web.URI-references*
 
-Here are the referenced documents.
-
-* The main parts of URLs
-  http://tools.ietf.org/html/rfc1738#section-2.1
-
-* BNF for specific URL schemes
-  http://tools.ietf.org/html/rfc1738#section-5
-
-* Collected ABNF for URI
-  http://tools.ietf.org/html/rfc3986#appendix-A
-
-* Parsing a URI Reference with a Regular Expression
-  http://tools.ietf.org/html/rfc3986#appendix-B
-  * Using this regexp pattern in this library basically.
+* URL: Living Standard
+  https://url.spec.whatwg.org/#informative
+* RFC3986
+  http://tools.ietf.org/html/rfc3986
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -40,7 +40,7 @@ new_from_uri_like_string({str} [, {default} [, {patternset}]])
 new_from_seq_string({str} [, {default} [, {patternset}]])
 					*Vital.Web.URI.new_from_seq_string()*
 	This is same as |Vital.Web.URI.new()|, except
-	1. When {str} has illegal string.
+	1. When {str} contains illegal trailing string,
 	   then this function DOES NOT throw an exception.
 	2. Returns |List| of [{uri}, {origuri}, {rest}]
 	   {uri}

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -8,7 +8,8 @@ CONTENTS				*Vital.Web.URI-contents*
 INTRODUCTION			|Vital.Web.URI-introduction|
 INTERFACE				|Vital.Web.URI-interface|
   Functions				|Vital.Web.URI-functions|
-  URI Object			|Vital.Web.URI-object|
+  URI Object			|Vital.Web.URI-URI|
+  PatternSet Object		|Vital.Web.URI-PatternSet|
 TODO					|Vital.Web.URI-todo|
 REFERENCES				|Vital.Web.URI-references|
 
@@ -22,18 +23,31 @@ INTERFACE				*Vital.Web.URI-interface*
 ------------------------------------------------------------------------------
 FUNCTIONS				*Vital.Web.URI-functions*
 
-new({str} [, {default}])		*Vital.Web.URI.new()*
-	Returns a |Vital.Web.URI-object| constructed by {str}.
+new({str} [, {default} [, {patternset}]])		*Vital.Web.URI.new()*
+	Returns a |Vital.Web.URI-URI| object constructed by {str}.
 	If {default} is given and {str} is invalid,
 	returns {default}.
 	Otherwise, throws an exception.
+	See |Vital.Web.URI-PatternSet| for {patternset}.
 
-new_from_uri_like_string({str} [, {default}])
+new_from_uri_like_string({str} [, {default} [, {patternset}]])
 					*Vital.Web.URI.new_from_uri_like_string()*
 	This is same as |Vital.Web.URI.new()|
 	except when {str} has no scheme.
-	then this function prepends the string "http://" to {str}
-	and returns a |Vital.Web.URI-object|.
+	then this function prepends the string "http://" to {str}.
+
+new_from_seq_string({str} [, {default} [, {patternset}]])
+					*Vital.Web.URI.new_from_seq_string()*
+	This is same as |Vital.Web.URI.new()|, except
+	1. When {str} has illegal string.
+	   then this function DOES NOT throw an exception.
+	2. Returns |List| of [{uri}, {origuri}, {rest}]
+	   {uri}
+	      |Vital.Web.URI-URI| object constructed by {str}.
+	   {origuri}
+	      Original string which was used for constructing {uri}.
+	   {rest}
+	      Rest of string after parsing {str}.
 
 is_uri({str})				*Vital.Web.URI.is_uri()*
 	Returns non-zero value if {str} is URI.
@@ -51,6 +65,10 @@ like_uri({str})				*Vital.Web.URI.like_uri()*
 	(This uses |Vital.Web.URI.new_from_uri_like_string()|
 	 instead of |Vital.Web.URI.new()|)
 
+					*Vital.Web.URI.new_default_pattern_set()*
+new_default_pattern_set()
+	Returns |Vital.Web.URI-PatternSet|.
+
 encode({str} [, {char-enc}])		*Vital.Web.URI.encode()*
 	Encodes {str} to Percent-encoding string.
 	Converts {str} to {char-enc}(or "utf-8" when omitted) before encode.
@@ -63,15 +81,22 @@ decode({str} [, {char-enc}])		*Vital.Web.URI.decode()*
 	When {char-enc} is an empty string, result is not converted.
 
 ------------------------------------------------------------------------------
-URI OBJECT				*Vital.Web.URI-object*
+URI OBJECT				*Vital.Web.URI-URI* *Vital.Web.URI-object*
 
-scheme([{str}])				*Vital.Web.URI-object.scheme()*
-host([{str}])				*Vital.Web.URI-object.host()*
-port([{str}])				*Vital.Web.URI-object.port()*
-path([{str}])				*Vital.Web.URI-object.path()*
-opaque([{str}])				*Vital.Web.URI-object.opaque()*
-query([{str}])				*Vital.Web.URI-object.query()*
-fragment([{str}])			*Vital.Web.URI-object.fragment()*
+*Vital.Web.URI-URI.scheme()* *Vital.Web.URI-object.scheme()*
+*Vital.Web.URI-URI.host()* *Vital.Web.URI-object.host()*
+*Vital.Web.URI-URI.port()* *Vital.Web.URI-object.port()*
+*Vital.Web.URI-URI.path()* *Vital.Web.URI-object.path()*
+*Vital.Web.URI-URI.opaque()* *Vital.Web.URI-object.opaque()*
+*Vital.Web.URI-URI.query()* *Vital.Web.URI-object.query()*
+*Vital.Web.URI-URI.fragment()* *Vital.Web.URI-object.fragment()*
+scheme([{str}])
+host([{str}])
+port([{str}])
+path([{str}])
+opaque([{str}])
+query([{str}])
+fragment([{str}])
 
 	Returns each part if no arguments are given.
 	Set {str} as each part if {str} is given.
@@ -85,12 +110,99 @@ to_iri()				*Vital.Web.URI-object.to_iri()*
 to_string()				*Vital.Web.URI-object.to_string()*
 	Returns URI representation of this object.
 
+*Vital.Web.URI-URI.is_scheme()*
+*Vital.Web.URI-URI.is_host()*
+*Vital.Web.URI-URI.is_port()*
+*Vital.Web.URI-URI.is_path()*
+*Vital.Web.URI-URI.is_query()*
+*Vital.Web.URI-URI.is_fragment()*
+is_scheme({str})
+is_host({str})
+is_port({str})
+is_path({str})
+is_query({str})
+is_fragment({str})
+is_opaque({str}) (TODO)
+
+    Returns non-zero value if {str} has right syntax
+    for each component. Returns zero otherwise.
+
+------------------------------------------------------------------------------
+PATTERNSET OBJECT				*Vital.Web.URI-PatternSet*
+
+PatternSet object is the set of patterns for URI syntax.
+This object has each method for URI components based on RFC3986
+and all components are fully customizable.
+e.g.: scheme(), host(), path(), ...
+
+Below is the example how to customize URI component definition.
+This example allows more tolerant URI parsing.
+(This example is from https://github.com/tyru/open-browser.vim/issues/72)
+The default PatternSet is very strict
+because it is completely RFC3986 based implementation.
+(_default_ means the object which
+*Vital.Web.URI.new_default_pattern_set()* returns)
+
+According to RFC3986, URI allows
+* ' (single quote)
+* ( (left parenthesis)
+* ) (right parenthesis)
+but these characters often appears in ordinary text.
+This code lets the parser ignore these characters. >
+
+    let s:LoosePatternSet = s:URI.new_default_pattern_set()
+
+    " Remove "'", "(", ")".
+    function! s:LoosePatternSet.sub_delims() abort
+        return '[!$&*+,;=]'
+    endfunction
+<
+------------------------------------------------------------------------------
+METHODS				*Vital.Web.URI-PatternSet-methods*
+
+get({component})			*Vital.Web.URI-PatternSet.get()*
+
+    Returns each component definition.
+>
+    let s:PatternSet = s:URI.new_default_pattern_set()
+    echo s:PatternSet.get('scheme')
+<
+Listing all customizable components here.
+NOTE: DON'T call these methods directly.
+These methods are used when defining custimized PatternSet.
+See how-to at |Vital.Web.URI-PatternSet|.
+
+hexdig()					*Vital.Web.URI-PatternSet.hexdig()*
+unreserved()				*Vital.Web.URI-PatternSet.unreserved()*
+pct_encoded()				*Vital.Web.URI-PatternSet.pct_encoded()*
+sub_delims()				*Vital.Web.URI-PatternSet.sub_delims()*
+dec_octet()					*Vital.Web.URI-PatternSet.dec_octet()*
+ipv4address()				*Vital.Web.URI-PatternSet.ipv4address()*
+ip_literal()				*Vital.Web.URI-PatternSet.ip_literal()*
+reg_name()					*Vital.Web.URI-PatternSet.reg_name()*
+pchar()						*Vital.Web.URI-PatternSet.pchar()*
+segment()					*Vital.Web.URI-PatternSet.segment()*
+segment_nz()				*Vital.Web.URI-PatternSet.segment_nz()*
+segment_nz_nc()				*Vital.Web.URI-PatternSet.segment_nz_nc()*
+path_abempty()				*Vital.Web.URI-PatternSet.path_abempty()*
+path_absolute()				*Vital.Web.URI-PatternSet.path_absolute()*
+path_noscheme()				*Vital.Web.URI-PatternSet.path_noscheme()*
+path_rootless()				*Vital.Web.URI-PatternSet.path_rootless()*
+scheme()					*Vital.Web.URI-PatternSet.scheme()*
+userinfo()					*Vital.Web.URI-PatternSet.userinfo()*
+host()						*Vital.Web.URI-PatternSet.host()*
+port()						*Vital.Web.URI-PatternSet.port()*
+path()						*Vital.Web.URI-PatternSet.path()*
+query()						*Vital.Web.URI-PatternSet.query()*
+fragment()					*Vital.Web.URI-PatternSet.fragment()*
+
+
 ==============================================================================
 TODO					*Vital.Web.URI-todo*
 
 * Punycode
-* Vital.Web.URI-object.userinfo()
-* |Vital.Web.URI-object.opaque()| with an argument
+* |Vital.Web.URI-URI.opaque()| with an argument
+* |Vital.Web.URI-URI.is_opaque()|
 
 ==============================================================================
 REFERENCES				*Vital.Web.URI-references*

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -158,10 +158,17 @@ This code lets the parser ignore these characters. >
 
     let s:LoosePatternSet = s:URI.new_default_pattern_set()
 
-    " Remove "'", "(", ")" from default set.
+    " Remove "'", "(", ")" from default sub_delims().
     function! s:LoosePatternSet.sub_delims() abort
         return '[!$&*+,;=]'
     endfunction
+
+    " Ignore trailing string after URI.
+    let NONE = []
+    let ret = URI.new_from_seq_string('http://example.com)', NONE, pattern_set)
+    if ret isnot NONE
+        ...
+    endif
 <
 ------------------------------------------------------------------------------
 METHODS				*Vital.Web.URI-PatternSet-methods*

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -236,7 +236,7 @@ REFERENCES				*Vital.Web.URI-references*
   https://url.spec.whatwg.org/#informative
 * RFC3986
   http://tools.ietf.org/html/rfc3986
-* Errata
+* RFC3986 Errata
   https://www.rfc-editor.org/errata_search.php?rfc=3987
 
 ==============================================================================

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -158,7 +158,7 @@ This code lets the parser ignore these characters. >
 
     let s:LoosePatternSet = s:URI.new_default_pattern_set()
 
-    " Remove "'", "(", ")".
+    " Remove "'", "(", ")" from default set.
     function! s:LoosePatternSet.sub_delims() abort
         return '[!$&*+,;=]'
     endfunction

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -137,6 +137,47 @@ Describe Web.URI
     End
   End
 
+  Describe .new_default_pattern_set()
+    Before each
+      " Define loose pattern set.
+      let pattern_set = URI.new_default_pattern_set()
+
+      " Remove "'", "(", ")" from default sub_delims().
+      function! pattern_set.sub_delims() abort
+          return '[!$&*+,;=]'
+      endfunction
+
+      let NONE = []
+    End
+
+    It allows to ignore some characters (:help Vital.Web.URI-PatternSet)
+      for [input, expected] in [
+      \  ['http://example.com)',
+      \    ['http://example.com/', 'http://example.com', ')']],
+      \  ['https://en.wikipedia.org/wiki/Markdown)',
+      \    ['https://en.wikipedia.org/wiki/Markdown', 'https://en.wikipedia.org/wiki/Markdown', ')']],
+      \  ['http://example.com/?q=query)',
+      \    ['http://example.com/?q=query', 'http://example.com/?q=query', ')']],
+      \  ['http://example.com/#fragment)',
+      \    ['http://example.com/#fragment', 'http://example.com/#fragment', ')']],
+      \
+      \  ["http://example.com'",
+      \    ['http://example.com/', 'http://example.com', "'"]],
+      \  ["https://github.com/Lokaltog/vim-easymotion'",
+      \    ['https://github.com/Lokaltog/vim-easymotion', 'https://github.com/Lokaltog/vim-easymotion', "'"]],
+      \  ["http://example.com/?q=query'",
+      \    ['http://example.com/?q=query', 'http://example.com/?q=query', "'"]],
+      \  ["http://example.com/#fragment'",
+      \    ['http://example.com/#fragment', 'http://example.com/#fragment', "'"]],
+      \]
+        let ret = URI.new_from_seq_string(input, NONE, pattern_set)
+        " Stringify URI object.
+        let [uri, origuri, rest] = [ret[0].to_string()] + ret[1:2]
+        Assert Equals([uri, origuri, rest], expected)
+      endfor
+    End
+  End
+
   Describe .is_uri()
     It checks valid URI
       Assert True(URI.is_uri('http://example.com/'))

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -95,6 +95,48 @@ Describe Web.URI
     End
   End
 
+  Describe .new_from_uri_like_string()
+    It parses valid URIs
+      Throws URI.new_from_uri_like_string('local[host]')
+      Assert Equals(URI.new_from_uri_like_string('local[host]', 'Error!'), 'Error!')
+
+      Assert NotEquals(URI.new_from_uri_like_string('localhost', 'Error!'), 'Error!')
+      Assert Equals(URI.new_from_uri_like_string('example.com/').to_string(), 'http://example.com/')
+      Assert Equals(URI.new_from_uri_like_string('example.com').to_string(), 'http://example.com/')
+      Assert Equals(URI.new_from_uri_like_string('/home/tyru').to_string(), 'http:///home/tyru')
+      Assert Equals(URI.new_from_uri_like_string('user:password@example.com:8080/path/for/test?q=query#fragment').to_string(), 'http://user:password@example.com:8080/path/for/test?q=query#fragment')
+    End
+  End
+
+  Describe .new_from_seq_string()
+    It parses valid URIs with trailing string
+      Throws URI.new_from_seq_string('[http://example.com]')
+      Assert Equals(URI.new_from_seq_string('[http://example.com]', 'Error!'), 'Error!')
+
+      for [input, expected] in [
+      \  ['http://example.com/ blah blah',
+      \    ['http://example.com/', 'http://example.com/', ' blah blah']],
+      \  ['http://example.com gera gera',
+      \    ['http://example.com/', 'http://example.com', ' gera gera']],
+      \  ['file:///home/tyru   # My home directory',
+      \    ['file:///home/tyru', 'file:///home/tyru',
+      \     '   # My home directory']],
+      \  ['http:///home/tyru   # Hmm...',
+      \    ['http:///home/tyru', 'http:///home/tyru',
+      \     '   # Hmm...']],
+      \  ['http://user:password@example.com:8080/path/for/test?q=query#fragment[Whoa!What Complex URL]',
+      \    ['http://user:password@example.com:8080/path/for/test?q=query#fragment',
+      \     'http://user:password@example.com:8080/path/for/test?q=query#fragment',
+      \     '[Whoa!What Complex URL]']]
+      \]
+        let ret = URI.new_from_seq_string(input)
+        " Stringify URI object.
+        let [uri, origuri, rest] = [ret[0].to_string()] + ret[1:2]
+        Assert Equals([uri, origuri, rest], expected)
+      endfor
+    End
+  End
+
   Describe .is_uri()
     It checks valid URI
       Assert True(URI.is_uri('http://example.com/'))

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -6,72 +6,102 @@ Describe Web.URI
   End
 
   Describe .new()
-    It parses @tyru's twitter URL
-      let uri = URI.new('http://twitter.com/tyru')
+    It parses a simple URL
+      let uri = URI.new('http://example.com/')
       Assert Equals(uri.scheme(), 'http')
-      Assert Equals(uri.host(), 'twitter.com')
-      Assert Equals(uri.path(), '/tyru')
-      Assert Equals(uri.opaque(), '//twitter.com/tyru')
+      Assert Equals(uri.userinfo(), '')
+      Assert Equals(uri.host(), 'example.com')
+      Assert Equals(uri.port(), '')
+      Assert Equals(uri.path(), '/')
+      Assert Equals(uri.authority(), 'example.com')
+      Assert Equals(uri.opaque(), '//example.com/')
+      Assert Equals(uri.query(), '')
       Assert Equals(uri.fragment(), '')
-      Assert Equals(uri.to_string(), 'http://twitter.com/tyru')
+      Assert Equals(uri.to_string(), 'http://example.com/')
     End
 
-    It parses tyru's blog URL
-      let uri = URI.new('http://d.hatena.ne.jp/tyru/20100619/git_push_vim_plugins_to_github#c')
+    It parses a URL without slash
+      let uri = URI.new('http://example.com')
       Assert Equals(uri.scheme(), 'http')
-      Assert Equals(uri.host(), 'd.hatena.ne.jp')
-      Assert Equals(uri.path(), '/tyru/20100619/git_push_vim_plugins_to_github')
-      Assert Equals(uri.opaque(), '//d.hatena.ne.jp/tyru/20100619/git_push_vim_plugins_to_github')
-      Assert Equals(uri.fragment(), 'c')
-      Assert Equals(uri.to_string(), 'http://d.hatena.ne.jp/tyru/20100619/git_push_vim_plugins_to_github#c')
+      Assert Equals(uri.userinfo(), '')
+      Assert Equals(uri.host(), 'example.com')
+      Assert Equals(uri.port(), '')
+      Assert Equals(uri.path(), '/')
+      Assert Equals(uri.authority(), 'example.com')
+      Assert Equals(uri.opaque(), '//example.com/')
+      Assert Equals(uri.query(), '')
+      Assert Equals(uri.fragment(), '')
+      Assert Equals(uri.to_string(), 'http://example.com/')
+    End
+
+    It allows empty authority (:help Vital.Web.URI-notes)
+      let uri = URI.new('file:///home/tyru/')
+      Assert Equals(uri.scheme(), 'file')
+      Assert Equals(uri.userinfo(), '')
+      Assert Equals(uri.host(), '')
+      Assert Equals(uri.port(), '')
+      Assert Equals(uri.path(), '/home/tyru/')
+      Assert Equals(uri.authority(), '')
+      Assert Equals(uri.opaque(), '///home/tyru/')
+      Assert Equals(uri.query(), '')
+      Assert Equals(uri.fragment(), '')
+      Assert Equals(uri.to_string(), 'file:///home/tyru/')
+    End
+
+    It also allows empty authority for http scheme (:help Vital.Web.URI-notes)
+      let uri = URI.new('http:///home/tyru/')
+      Assert Equals(uri.scheme(), 'http')
+      Assert Equals(uri.userinfo(), '')
+      Assert Equals(uri.host(), '')
+      Assert Equals(uri.port(), '')
+      Assert Equals(uri.path(), '/home/tyru/')
+      Assert Equals(uri.authority(), '')
+      Assert Equals(uri.opaque(), '///home/tyru/')
+      Assert Equals(uri.query(), '')
+      Assert Equals(uri.fragment(), '')
+      Assert Equals(uri.to_string(), 'http:///home/tyru/')
+    End
+
+    It parses a complex URL
+      let uri = URI.new('http://user:password@example.com:8080/path/for/test?q=query#fragment')
+      Assert Equals(uri.scheme(), 'http')
+      Assert Equals(uri.userinfo(), 'user:password')
+      Assert Equals(uri.host(), 'example.com')
+      Assert Equals(uri.port(), '8080')
+      Assert Equals(uri.path(), '/path/for/test')
+      Assert Equals(uri.authority(), 'user:password@example.com:8080')
+      Assert Equals(uri.opaque(), '//user:password@example.com:8080/path/for/test')
+      Assert Equals(uri.query(), 'q=query')
+      Assert Equals(uri.fragment(), 'fragment')
+      Assert Equals(uri.to_string(), 'http://user:password@example.com:8080/path/for/test?q=query#fragment')
     End
 
     It builds URI with given parts
-      let uri = URI.new('http://twitter.com/tyru')
+      let uri = URI.new('http://example.com/')
       call uri.scheme('ftp')
       Assert Equals(uri.scheme(), 'ftp')
-      Assert Equals(uri.to_string(), 'ftp://twitter.com/tyru')
+      Assert Equals(uri.to_string(), 'ftp://example.com/')
       call uri.host('ftp.vim.org')
       Assert Equals(uri.host(), 'ftp.vim.org')
-      Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/tyru')
+      Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/')
+      " uri.path({str}) prepends '/' if {str} doesn't have it.
       call uri.path('pub/vim/unix/vim-7.3.tar.bz2')
       Assert Equals(uri.path(), '/pub/vim/unix/vim-7.3.tar.bz2')
       Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/pub/vim/unix/vim-7.3.tar.bz2')
-      call uri.path('/pub/vim/unix/vim-7.3.tar.bz2')
-      " uri.path() ignores head slashes.
-      Assert Equals(uri.path(), '/pub/vim/unix/vim-7.3.tar.bz2')
-      Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/pub/vim/unix/vim-7.3.tar.bz2')
-    End
-
-    It modifies URI with given parts
-      let uri = URI.new('http://d.hatena.ne.jp/tyru/20100619/git_push_vim_plugins_to_github#c')
-      call uri.scheme('https')
-      Assert Equals(uri.scheme(), 'https')
-      Assert Equals(uri.to_string(), 'https://d.hatena.ne.jp/tyru/20100619/git_push_vim_plugins_to_github#c')
-      call uri.host('github.com')
-      Assert Equals(uri.host(), 'github.com')
-      Assert Equals(uri.to_string(), 'https://github.com/tyru/20100619/git_push_vim_plugins_to_github#c')
-      call uri.path('tyru/urilib.vim/blob/master/autoload/urilib.vim')
-      Assert Equals(uri.path(), '/tyru/urilib.vim/blob/master/autoload/urilib.vim')
-      Assert Equals(uri.to_string(), 'https://github.com/tyru/urilib.vim/blob/master/autoload/urilib.vim#c')
-      call uri.fragment('L32')
-      Assert Equals(uri.fragment(), 'L32')
-      Assert Equals(uri.to_string(), 'https://github.com/tyru/urilib.vim/blob/master/autoload/urilib.vim#L32')
-      call uri.fragment('#L32')
-      " uri.fragment({fragment}) ignores head # characters.
-      Assert Equals(uri.fragment(), 'L32')
-      Assert Equals(uri.to_string(), 'https://github.com/tyru/urilib.vim/blob/master/autoload/urilib.vim#L32')
+      " uri.path({str}) doesn't prepend '/' if {str} has it.
+      call uri.path('/pub/vim/unix/vim-7.4.tar.bz2')
+      Assert Equals(uri.path(), '/pub/vim/unix/vim-7.4.tar.bz2')
+      Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/pub/vim/unix/vim-7.4.tar.bz2')
     End
   End
 
   Describe .is_uri()
     It checks valid URI
-      Assert True(URI.is_uri('http://twitter.com/tyru'))
-      Assert True(URI.is_uri('http://d.hatena.ne.jp/tyru/20100619/git_push_vim_plugins_to_github#c'))
-      Assert True(URI.is_uri('file://baz/'))
-      Assert True(URI.is_uri('file:///home/tyru/'))
+      Assert True(URI.is_uri('http://example.com/'))
+      Assert True(URI.is_uri('http://example.com'))
       Assert True(URI.is_uri('file:///home/tyru'))
-      Assert True(URI.is_uri('ftp://withoutslash.com'))
+      Assert True(URI.is_uri('http:///home/tyru'))
+      Assert True(URI.is_uri('http://user:password@example.com:8080/path/for/test?q=query#fragment'))
     End
 
     It checks invalid URI


### PR DESCRIPTION
## Description

This pull requests allows each URI component configurable.
Each component is represented by PatternSet object.
(Below is the quote from help document)

PatternSet object is the set of patterns for URI syntax.
This object has each method for URI components based on RFC3986
and all components are fully customizable.
e.g.: scheme(), host(), path(), ...

Below is the example how to customize URI component definition.
This example allows more tolerant URI parsing.
(This example is from https://github.com/tyru/open-browser.vim/issues/72)
The default PatternSet is very strict
because it is completely RFC3986 based implementation.
(_default_ means the object which
*Vital.Web.URI.new_default_pattern_set()* returns)

According to RFC3986, URI allows

* ' (single quote)
* ( (left parenthesis)
* ) (right parenthesis)

but these characters often appears in ordinary text.
The following code lets the parser ignore these characters.

```viml
    let s:LoosePatternSet = s:URI.new_default_pattern_set()

    " Remove "'", "(", ")" from default set.
    function! s:LoosePatternSet.sub_delims() abort
        return '[!$&*+,;=]'
    endfunction
```

## Tasks

- [x] Implement code IP-Literal (including IPv6) support
- [x] Update document
- [x] Fix broken tests
- [x] Write tests
  - [x] ~~List missing tests for methods, functions~~
  - [x]  .new_from_uri_like_string()
  - [x]  .new_from_seq_string()
  - [x]  new_default_pattern_set()
- [x] Add ABNF comments for all methods of `s:DefaultPatternSet`
- [x] Check the differences between ABNF and implementation of `s:DefaultPatternSet`