### PR TITLE
Vim.Gurad: A module to store/restore option/variable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Module						 | Description
 [Vim.Search](doc/vital-vim-search.txt)		 | Vim's [I like function
 [Vim.ScriptLocal](doc/vital-vim-script_local.txt) | Get script-local things
 [Vim.ViewTracer](doc/vital-vim-view_tracer.txt) | Trace window and tabpage
+[Vim.Guard](doc/vital-vim-guard.txt)		 | Guard options/variables
 [Web.HTML](doc/vital-web-html.txt)		 | HTML parser written in pure Vim script
 [Web.HTTP](doc/vital-web-http.txt)		 | simple HTTP client library
 [Web.JSON](doc/vital-web-json.txt)		 | JSON parser written in pure Vim script

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -7,6 +7,14 @@ function! s:undefined() abort
 endfunction
 let s:UNDEFINED = function('s:undefined')
 
+function! s:_vital_created(module) abort
+  " define constant variables
+  let s:const = {}
+  let s:const.is_local_variable_supported =
+      \ v:version > 703 || (v:version == 703 && has('patch560'))
+  lockvar s:const
+  call extend(a:module, s:const)
+endfunction
 function! s:_throw(msg) abort
   throw printf('vital: Vim.Guard: %s', a:msg)
 endfunction

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -92,7 +92,10 @@ function! s:store(...) abort
       elseif meta =~# '^&'
         call add(resources, s:_new_option(meta))
       else
-        call add(resources, s:_new_option('&' . meta))
+        call s:_throw(printf(
+              \ 'Unknown option or variable "%s" was specified',
+              \ meta
+              \))
       endif
     endif
     unlet meta

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -77,7 +77,7 @@ function! s:variable.restore() abort
 endfunction
 
 let s:guard = {}
-function! s:new(...) abort
+function! s:store(...) abort
   let resources = []
   for meta in a:000
     if type(meta) == type([])

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -86,6 +86,8 @@ function! s:store(...) abort
       call add(resources, call('s:_new_variable', meta))
     elseif type(meta) == type('')
       if meta =~# '^[bwtgls]:'
+        " Note:
+        " To improve an error message, handle l:XXX or s:XXX as well
         call add(resources, s:_new_variable(meta))
       elseif meta =~# '^&'
         call add(resources, s:_new_option(meta))

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -7,12 +7,6 @@ function! s:undefined() abort
 endfunction
 let s:UNDEFINED = function('s:undefined')
 
-function! s:_vital_loaded(V) abort
-endfunction
-function! s:_vital_depends() abort
-  return []
-endfunction
-
 function! s:_throw(msg) abort
   throw printf('vital: Vim.Guard: %s', a:msg)
 endfunction

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -31,8 +31,6 @@ function! s:_new_option(name) abort
   let option = copy(s:option)
   let option.name = a:name
   let option.value = eval(a:name)
-  lockvar 1 option.name
-  lockvar 1 option.value
   return option
 endfunction
 function! s:option.restore() abort
@@ -66,8 +64,6 @@ function! s:_new_variable(name, ...) abort
         \   ? deepcopy(variable.value)
         \   : variable.value
   let variable._namespace = namespace
-  lockvar 1 variable.name
-  lockvar 1 variable.value
   return variable
 endfunction
 function! s:variable.restore() abort
@@ -76,7 +72,6 @@ function! s:variable.restore() abort
   if type(self.value) == type(s:UNDEFINED) && self.value == s:UNDEFINED
     " do nothing, leave the variable as undefined
   else
-    unlockvar 1 self.value
     let self._namespace[self.name] = self.value
   endif
 endfunction

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -1,0 +1,113 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+" Use a Funcref as a special term UNDEFINED
+function! s:undefined() abort
+  return 'undefined'
+endfunction
+let s:UNDEFINED = function('s:undefined')
+
+function! s:_vital_loaded(V) abort
+endfunction
+function! s:_vital_depends() abort
+  return []
+endfunction
+
+function! s:_throw(msg) abort
+  throw printf('vital: Vim.Guard: %s', a:msg)
+endfunction
+
+let s:option = {}
+function! s:_new_option(name) abort
+  if a:name !~# '^&'
+    call s:_throw(printf(
+          \'An option name "%s" requires to be started from "&"', a:name
+          \))
+  elseif !exists(a:name)
+    call s:_throw(printf(
+          \'An option name "%s" does not exist', a:name
+          \))
+  endif
+  let option = copy(s:option)
+  let option.name = a:name
+  let option.value = eval(a:name)
+  lockvar 1 option.name
+  lockvar 1 option.value
+  return option
+endfunction
+function! s:option.restore() abort
+  execute printf('let %s = %s', self.name, string(self.value))
+endfunction
+
+let s:variable = {}
+function! s:_new_variable(name, ...) abort
+  if a:0 == 0
+    let m = matchlist(a:name, '^\([bwtg]:\)\(.*\)$')
+    if empty(m)
+      call s:_throw(printf(
+            \ join([
+            \   'An variable name "%s" requires to start from b:, w:, t:, or g:',
+            \   'while no {namespace} is specified',
+            \ ]),
+            \ a:name,
+            \))
+    endif
+    let [prefix, name] = m[1 : 2]
+    let namespace = eval(prefix)
+  else
+    let name = a:name
+    let namespace = a:1
+  endif
+  let variable = copy(s:variable)
+  let variable.name = name
+  let variable.value = get(namespace, name, s:UNDEFINED)
+  let variable.value =
+        \ type(variable.value) == type({}) || type(variable.value) == type([])
+        \   ? deepcopy(variable.value)
+        \   : variable.value
+  let variable._namespace = namespace
+  lockvar 1 variable.name
+  lockvar 1 variable.value
+  return variable
+endfunction
+function! s:variable.restore() abort
+  " unlet the variable to prevent variable type mis-match in case
+  silent! unlet! self._namespace[self.name]
+  if type(self.value) == type(s:UNDEFINED) && self.value == s:UNDEFINED
+    " do nothing, leave the variable as undefined
+  else
+    unlockvar 1 self.value
+    let self._namespace[self.name] = self.value
+  endif
+endfunction
+
+let s:guard = {}
+function! s:new(...) abort
+  let resources = []
+  for meta in a:000
+    if type(meta) == type([])
+      call add(resources, call('s:_new_variable', meta))
+    elseif type(meta) == type('')
+      if meta =~# '^[bwtgls]:'
+        call add(resources, s:_new_variable(meta))
+      elseif meta =~# '^&'
+        call add(resources, s:_new_option(meta))
+      else
+        call add(resources, s:_new_option('&' . meta))
+      endif
+    endif
+    unlet meta
+  endfor
+  let guard = copy(s:guard)
+  let guard._resources = resources
+  return guard
+endfunction
+function! s:guard.restore() abort
+  for resource in self._resources
+    call resource.restore()
+  endfor
+endfunction
+
+let &cpo = s:save_cpo
+unlet! s:save_cpo
+" vim:set et ts=2 sts=2 sw=2 tw=0 fdm=marker:

--- a/doc/vital-vim-gurad.txt
+++ b/doc/vital-vim-gurad.txt
@@ -97,7 +97,8 @@ new([{name}, ...])	*Vital.Vim.Guard.new()*
 	An option name or variable name. If the {name} starts from b:, w:, t:,
 	or g:, a named |buffer-variable|, |window-variable|, |tabpage-variable|, or
 	|global-variable| would be guarded, otherwise the named option would
-	be guarded. To specify global or local option, use &g: or &l: prefix.
+	be guarded. To specify global or local option, use &g: or &l: prefix
+	in Vim 7.4 (individual assignment does not work on Vim 7.3).
 
 ------------------------------------------------------------------------------
 INSTANCE				*Vital.Vim.Guard-instance*

--- a/doc/vital-vim-gurad.txt
+++ b/doc/vital-vim-gurad.txt
@@ -27,7 +27,7 @@ The followings are supported
   - |tabpage-variable| (t:)
   - |global-variable| (g:)
 - Restoring values in a dictionary
-  - |local-variable| (l:)
+  - |local-variable| (l:), in Vim 7.3.560 or later
   - |script-variable| (s:)
   - |dict|
 
@@ -76,6 +76,18 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 INTERFACE				*Vital.Vim.Guard-interface*
 
 ------------------------------------------------------------------------------
+CONSTANTS				*Vital.Vim.Guard-constants*
+
+			*Vital.Vim.Guard.is_local_variable_supported*
+is_local_variable_supported
+	1 or 0 to indicate whether the |local-variable| is supported.
+	A |lockvar| flag of |local-variable| in Vim 7.3.559 or earlier is not
+	initialized and the value of the flag is undetermined. That mean the
+	method |Vital.Vim.Guard-instance.restore()| may fail due to |E741|.
+	Developers should not use this module to store/restore |local-variable|
+	when this constant is 0.
+
+------------------------------------------------------------------------------
 FUNCTIONS				*Vital.Vim.Guard-functions*
 
 store([{name}, ...])	*Vital.Vim.Guard.store()*
@@ -92,6 +104,8 @@ store([{name}, ...])	*Vital.Vim.Guard.store()*
 	when .restore() method of the guard instance is called.
 	Use this type to guard |local-variable| (|l:|), |script-variable| (|s:|), or
 	attributes in |dict|.
+	See |Vital.Vim.Guard.is_local_variable_supported| if you would like to
+	store/restore |local-variable| in Vim 7.3.559 or earlier.
 
 	|String|
 	An option name or variable name. If the {name} starts from b:, w:, t:,

--- a/doc/vital-vim-gurad.txt
+++ b/doc/vital-vim-gurad.txt
@@ -35,7 +35,7 @@ The followings are supported
 ==============================================================================
 USAGE					*Vital.Vim.Guard-usage*
 
-Specify options/variables to |Vital.Vim.Guard.new()| and restore previous
+Specify options/variables to |Vital.Vim.Guard.store()| and restore previous
 values with |Vital.Vim.Guard-instance.restore()| like:
 
 >
@@ -46,7 +46,7 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	  let foo = 'foo'
 
 	  " Guard options/variables
-	  let guard = s:G.new(
+	  let guard = s:G.store(
 	    \ '&backup',
 	    \ 'g:foo',
 	    \ ['foo', l:],
@@ -78,7 +78,7 @@ INTERFACE				*Vital.Vim.Guard-interface*
 ------------------------------------------------------------------------------
 FUNCTIONS				*Vital.Vim.Guard-functions*
 
-new([{name}, ...])	*Vital.Vim.Guard.new()*
+store([{name}, ...])	*Vital.Vim.Guard.store()*
 	Create a new guard instance. Values of {name} options/variables will
 	be stored in the instance and can be restored by calling .restore()
 	method of the instance.

--- a/doc/vital-vim-gurad.txt
+++ b/doc/vital-vim-gurad.txt
@@ -1,4 +1,4 @@
-*vital-vim-gurad.txt*		Vim options/variables guard utility
+*vital-vim-guard.txt*		Vim options/variables guard utility
 
 Maintainer: lambdalisue <lambdalisue@hashnote.net>
 
@@ -45,8 +45,8 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	function! s:foobar() abort
 	  let foo = 'foo'
 
-	  " Gurad options/variables
-	  let gurad = s:G.new(
+	  " Guard options/variables
+	  let guard = s:G.new(
 	    \ '&backup',
 	    \ 'g:foo',
 	    \ ['foo', l:],
@@ -60,7 +60,7 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	  let foo = []
 
 	  " restore previous values
-	  call gurad.restore()
+	  call guard.restore()
 
 	  " Check if the value is restored
 	  echo &backup
@@ -79,7 +79,7 @@ INTERFACE				*Vital.Vim.Guard-interface*
 FUNCTIONS				*Vital.Vim.Guard-functions*
 
 new([{name}, ...])	*Vital.Vim.Guard.new()*
-	Create a new gurad instance. Values of {name} options/variables will
+	Create a new guard instance. Values of {name} options/variables will
 	be stored in the instance and can be restored by calling .restore()
 	method of the instance.
 
@@ -90,7 +90,7 @@ new([{name}, ...])	*Vital.Vim.Guard.new()*
 	of attribute in {namespace}. If {attr} does not exist in {namespace},
 	The {attr} in {namespace} will be removed from {namespace} if exists
 	when .restore() method of the guard instance is called.
-	Use this type to gurad |local-variable| (|l:|), |script-variable| (|s:|), or
+	Use this type to guard |local-variable| (|l:|), |script-variable| (|s:|), or
 	attributes in |dict|.
 
 	|String|

--- a/doc/vital-vim-gurad.txt
+++ b/doc/vital-vim-gurad.txt
@@ -1,0 +1,110 @@
+*vital-vim-gurad.txt*		Vim options/variables guard utility
+
+Maintainer: lambdalisue <lambdalisue@hashnote.net>
+
+==============================================================================
+CONTENTS				*Vital.Vim.Guard-contents*
+
+INTRODUCTION			|Vital.Vim.Guard-introduction|
+USAGE				|Vital.Vim.Guard-usage|
+INTERFACE			|Vital.Vim.Guard-interface|
+  FUNCTIONS			  |Vital.Vim.Guard-functions|
+
+
+==============================================================================
+INTRODUCTION				*Vital.Vim.Guard-introduction*
+
+*Vital.Vim.Guard* is used to restore previous values of options/variables.
+The followings are supported
+
+- Restoring values of options
+  - |options|
+  - |global-local|
+  - |local-options|
+- Restoring values of variable
+  - |buffer-variable| (b:)
+  - |window-variable| (w:)
+  - |tabpage-variable| (t:)
+  - |global-variable| (g:)
+- Restoring values in a dictionary
+  - |local-variable| (l:)
+  - |script-variable| (s:)
+  - |dict|
+
+
+==============================================================================
+USAGE					*Vital.Vim.Guard-usage*
+
+Specify options/variables to |Vital.Vim.Guard.new()| and restore previous
+values with |Vital.Vim.Guard-instance.restore()| like:
+
+>
+	let s:G = s:V.import('Vim.Guard')
+	let g:foo = 'foo'
+
+	function! s:foobar() abort
+	  let foo = 'foo'
+
+	  " Gurad options/variables
+	  let gurad = s:G.new(
+	    \ '&backup',
+	    \ 'g:foo',
+	    \ ['foo', l:],
+	    \)
+
+	  " Assign temporary values
+	  set nobackup
+	  unlet g:foo
+	  let g:foo = 1
+	  unlet foo
+	  let foo = []
+
+	  " restore previous values
+	  call gurad.restore()
+
+	  " Check if the value is restored
+	  echo &backup
+	  " => 1
+	  echo g:foo
+	  " => 'foo'
+	  echo foo
+	  " => foo
+	endfunction
+<
+
+==============================================================================
+INTERFACE				*Vital.Vim.Guard-interface*
+
+------------------------------------------------------------------------------
+FUNCTIONS				*Vital.Vim.Guard-functions*
+
+new([{name}, ...])	*Vital.Vim.Guard.new()*
+	Create a new gurad instance. Values of {name} options/variables will
+	be stored in the instance and can be restored by calling .restore()
+	method of the instance.
+
+	The following type of value is allowed for {name}
+
+	|List|
+	Components of the list is [{attr}, {namespace}] where {attr} is a name
+	of attribute in {namespace}. If {attr} does not exist in {namespace},
+	The {attr} in {namespace} will be removed from {namespace} if exists
+	when .restore() method of the guard instance is called.
+	Use this type to gurad |local-variable| (|l:|), |script-variable| (|s:|), or
+	attributes in |dict|.
+
+	|String|
+	An option name or variable name. If the {name} starts from b:, w:, t:,
+	or g:, a named |buffer-variable|, |window-variable|, |tabpage-variable|, or
+	|global-variable| would be guarded, otherwise the named option would
+	be guarded. To specify global or local option, use &g: or &l: prefix.
+
+------------------------------------------------------------------------------
+INSTANCE				*Vital.Vim.Guard-instance*
+
+restore()		*Vital.Vim.Guard-instance.restore()*
+	Restore guarded options/variables.
+
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-vim-gurad.txt
+++ b/doc/vital-vim-gurad.txt
@@ -113,6 +113,10 @@ store([{name}, ...])	*Vital.Vim.Guard.store()*
 	|global-variable| would be guarded, otherwise the named option would
 	be guarded. To specify global or local option, use &g: or &l: prefix
 	in Vim 7.4 (individual assignment does not work on Vim 7.3).
+	Note that the guard instance is insensible of the change of the 
+	current buffer, mean that |buffer-variable|, |window-variable|, or
+	|tabpage-variable| would not be correctly re-stored when users move the
+	buffer to the other before |Vital.Vim.Guard-instance.restore()|.
 
 ------------------------------------------------------------------------------
 INSTANCE				*Vital.Vim.Guard-instance*

--- a/doc/vital.txt
+++ b/doc/vital.txt
@@ -184,6 +184,7 @@ LINKS					*Vital-links*
   |vital-vim-search.txt|	  Vim's [I like function
   |vital-vim-script_local.txt|	  Get script-local things
   |vital-vim-view_tracer.txt|	  Trace |window| and |tabpage|
+  |vital-vim-guard.txt|		  Guard options/variables
   |vital-web-html.txt|		  HTML parser written in pure Vim script
   |vital-web-http.txt|		  simple HTTP client library
   |vital-web-json.txt|		  JSON parser written in pure Vim script

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -31,8 +31,6 @@ Describe Vim.Guard
       Assert KeyExists(option, 'restore')
       Assert Equals(option.name, '&backup')
       Assert Equals(option.value, &backup)
-      Throw /E741: Value is locked/ :let option.name = 'hello'
-      Throw /E741: Value is locked/ :let option.value = 'hello'
     End
     Context An option instance
       Before
@@ -131,8 +129,6 @@ Describe Vim.Guard
       Assert KeyExists(variable, 'restore')
       Assert Equals(variable.name, 'foo')
       Assert Equals(variable.value, namespace.foo)
-      Throw /E741: Value is locked/ :let variable.name = 'hello'
-      Throw /E741: Value is locked/ :let variable.value = 'hello'
 
       let VitalVimGuardTest = 1
       let variable = sf._new_variable('VitalVimGuardTest', l:)
@@ -141,8 +137,6 @@ Describe Vim.Guard
       Assert KeyExists(variable, 'restore')
       Assert Equals(variable.name, 'VitalVimGuardTest')
       Assert Equals(variable.value, VitalVimGuardTest)
-      Throw /E741: Value is locked/ :let variable.name = 'hello'
-      Throw /E741: Value is locked/ :let variable.value = 'hello'
 
       let variable = sf._new_variable('VitalVimGuardTest', s:)
       Assert KeyExists(variable, 'name')
@@ -151,8 +145,6 @@ Describe Vim.Guard
       Assert Equals(variable.name, 'VitalVimGuardTest')
       let s = s:VitalVimGuardTest
       Assert Equals(variable.value, s)
-      Throw /E741: Value is locked/ :let variable.name = 'hello'
-      Throw /E741: Value is locked/ :let variable.value = 'hello'
     End
     It returns an variable instance of {name} in a {namespace} specified as a prefix of {name}
       let variable = sf._new_variable('b:VitalVimGuardTest')
@@ -161,8 +153,6 @@ Describe Vim.Guard
       Assert KeyExists(variable, 'restore')
       Assert Equals(variable.name, 'VitalVimGuardTest')
       Assert Equals(variable.value, b:VitalVimGuardTest)
-      Throw /E741: Value is locked/ :let variable.name = 'hello'
-      Throw /E741: Value is locked/ :let variable.value = 'hello'
 
       let variable = sf._new_variable('w:VitalVimGuardTest')
       Assert KeyExists(variable, 'name')
@@ -170,8 +160,6 @@ Describe Vim.Guard
       Assert KeyExists(variable, 'restore')
       Assert Equals(variable.name, 'VitalVimGuardTest')
       Assert Equals(variable.value, w:VitalVimGuardTest)
-      Throw /E741: Value is locked/ :let variable.name = 'hello'
-      Throw /E741: Value is locked/ :let variable.value = 'hello'
 
       let variable = sf._new_variable('t:VitalVimGuardTest')
       Assert KeyExists(variable, 'name')
@@ -179,8 +167,6 @@ Describe Vim.Guard
       Assert KeyExists(variable, 'restore')
       Assert Equals(variable.name, 'VitalVimGuardTest')
       Assert Equals(variable.value, t:VitalVimGuardTest)
-      Throw /E741: Value is locked/ :let variable.name = 'hello'
-      Throw /E741: Value is locked/ :let variable.value = 'hello'
 
       let variable = sf._new_variable('g:VitalVimGuardTest')
       Assert KeyExists(variable, 'name')
@@ -188,8 +174,6 @@ Describe Vim.Guard
       Assert KeyExists(variable, 'restore')
       Assert Equals(variable.name, 'VitalVimGuardTest')
       Assert Equals(variable.value, g:VitalVimGuardTest)
-      Throw /E741: Value is locked/ :let variable.name = 'hello'
-      Throw /E741: Value is locked/ :let variable.value = 'hello'
     End
     Context A variable instance
       It restore a value of the variable when assigned

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -10,7 +10,7 @@ Describe Vim.Guard
           \)
     let sf = s:S.sfuncs(sfile)
   End
-  Context [PRIVATE] s:_new_option({name})
+  Describe [PRIVATE] s:_new_option({name})
     " NOTE:
     "   backup      - glocal
     "   backupcopy  - global or local to buffer
@@ -32,7 +32,7 @@ Describe Vim.Guard
       Assert Equals(option.name, '&backup')
       Assert Equals(option.value, &backup)
     End
-    Context An option instance
+    Describe An option instance
       Before
         let previous_backup = &backup
         let previous_g_backupcopy = &g:backupcopy
@@ -96,7 +96,7 @@ Describe Vim.Guard
       End
     End
   End
-  Context [PRIVATE] s:_new_variable({name}[, {namespace}])
+  Describe [PRIVATE] s:_new_variable({name}[, {namespace}])
     Before
       let g:VitalVimGuardTest = 1
       let b:VitalVimGuardTest = 1
@@ -175,7 +175,7 @@ Describe Vim.Guard
       Assert Equals(variable.name, 'VitalVimGuardTest')
       Assert Equals(variable.value, g:VitalVimGuardTest)
     End
-    Context A variable instance
+    Describe A variable instance
       It restore a value of the variable when assigned
         let variable = sf._new_variable('b:VitalVimGuardTest')
         let previous = b:VitalVimGuardTest
@@ -241,7 +241,7 @@ Describe Vim.Guard
     End
   End
 
-  Context .new({option_or_variable}...)
+  Describe .new({option_or_variable}...)
     Before
       let previous_backup = &backup
       let previous_g_backupcopy = &g:backupcopy
@@ -313,7 +313,7 @@ Describe Vim.Guard
             \)
       Assert KeyExists(guard, 'restore')
     End
-    Context A guard instance
+    Describe A guard instance
       It restore options and variables assigned
         let namespace = { 'VitalVimGuardTest': 1 }
         let VitalVimGuardTest = 1

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -275,20 +275,16 @@ Describe Vim.Guard
       unlet g:VitalVimGuardTest
       unlet s:VitalVimGuardTest
     End
+    It throws an exception when unknown {option_or_variable} is specified
+      Throws /Unknown option or variable "backup" was specified/
+            \ Guard.store('backup')
+    End
     It returns a guard instance for options
       let guard = Guard.store(
             \ '&backup',
             \ '&backupcopy',
             \ '&binary',
             \ '&list',
-            \)
-      Assert KeyExists(guard, 'restore')
-      " NOTE: first character & of names are omittable
-      let guard = Guard.store(
-            \ 'backup',
-            \ 'backupcopy',
-            \ 'binary',
-            \ 'list',
             \)
       Assert KeyExists(guard, 'restore')
     End
@@ -318,10 +314,10 @@ Describe Vim.Guard
       It restore options and variables assigned
         let namespace = { 'VitalVimGuardTest': 1 }
         let guard = Guard.store(
-              \ 'backup',
-              \ 'backupcopy',
-              \ 'binary',
-              \ 'list',
+              \ '&backup',
+              \ '&backupcopy',
+              \ '&binary',
+              \ '&list',
               \ 'b:VitalVimGuardTest',
               \ 'w:VitalVimGuardTest',
               \ 't:VitalVimGuardTest',

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -294,14 +294,12 @@ Describe Vim.Guard
     End
     It returns a guard instance for variables
       let namespace = { 'VitalVimGuardTest': 1 }
-      let VitalVimGuardTest = 1
       let guard = Guard.store(
             \ ['VitalVimGuardTest', b:],
             \ ['VitalVimGuardTest', w:],
             \ ['VitalVimGuardTest', t:],
             \ ['VitalVimGuardTest', g:],
             \ ['VitalVimGuardTest', s:],
-            \ ['VitalVimGuardTest', l:],
             \ ['VitalVimGuardTest', namespace],
             \)
       Assert KeyExists(guard, 'restore')
@@ -312,7 +310,6 @@ Describe Vim.Guard
             \ 't:VitalVimGuardTest',
             \ 'g:VitalVimGuardTest',
             \ ['VitalVimGuardTest', s:],
-            \ ['VitalVimGuardTest', l:],
             \ ['VitalVimGuardTest', namespace],
             \)
       Assert KeyExists(guard, 'restore')
@@ -320,7 +317,6 @@ Describe Vim.Guard
     Describe A guard instance
       It restore options and variables assigned
         let namespace = { 'VitalVimGuardTest': 1 }
-        let VitalVimGuardTest = 1
         let guard = Guard.store(
               \ 'backup',
               \ 'backupcopy',
@@ -331,7 +327,6 @@ Describe Vim.Guard
               \ 't:VitalVimGuardTest',
               \ 'g:VitalVimGuardTest',
               \ ['VitalVimGuardTest', s:],
-              \ ['VitalVimGuardTest', l:],
               \ ['VitalVimGuardTest', namespace],
               \)
         set nobackup
@@ -342,7 +337,6 @@ Describe Vim.Guard
         let w:VitalVimGuardTest = 2
         let t:VitalVimGuardTest = 2
         let g:VitalVimGuardTest = 2
-        let VitalVimGuardTest = 2
         let s:VitalVimGuardTest = 2
         let namespace.VitalVimGuardTest = 2
         call guard.restore()
@@ -354,7 +348,6 @@ Describe Vim.Guard
         Assert Equals(w:VitalVimGuardTest, 1)
         Assert Equals(t:VitalVimGuardTest, 1)
         Assert Equals(g:VitalVimGuardTest, 1)
-        Assert Equals(VitalVimGuardTest, 1)
         let s = s:VitalVimGuardTest
         Assert Equals(s, 1)
         Assert Equals(namespace.VitalVimGuardTest, 1)

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -231,7 +231,7 @@ Describe Vim.Guard
         let s = s:VitalVimGuardTest
         Assert Equals(s, previous)
       End
-      It deepcopy List or Dictionary to prevent E741: Value is locked
+      It deepcopy List or Dictionary
         let namespace = {
               \ 'list': ['a', 'b', 'c'],
               \ 'dict': {

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -130,13 +130,15 @@ Describe Vim.Guard
       Assert Equals(variable.name, 'foo')
       Assert Equals(variable.value, namespace.foo)
 
-      let VitalVimGuardTest = 1
-      let variable = sf._new_variable('VitalVimGuardTest', l:)
-      Assert KeyExists(variable, 'name')
-      Assert KeyExists(variable, 'value')
-      Assert KeyExists(variable, 'restore')
-      Assert Equals(variable.name, 'VitalVimGuardTest')
-      Assert Equals(variable.value, VitalVimGuardTest)
+      if Guard.is_local_variable_supported
+        let VitalVimGuardTest = 1
+        let variable = sf._new_variable('VitalVimGuardTest', l:)
+        Assert KeyExists(variable, 'name')
+        Assert KeyExists(variable, 'value')
+        Assert KeyExists(variable, 'restore')
+        Assert Equals(variable.name, 'VitalVimGuardTest')
+        Assert Equals(variable.value, VitalVimGuardTest)
+      endif
 
       let variable = sf._new_variable('VitalVimGuardTest', s:)
       Assert KeyExists(variable, 'name')
@@ -201,12 +203,14 @@ Describe Vim.Guard
         call variable.restore()
         Assert Equals(g:VitalVimGuardTest, previous)
 
-        let VitalVimGuardTest = 1
-        let variable = sf._new_variable('VitalVimGuardTest', l:)
-        let previous = VitalVimGuardTest
-        let VitalVimGuardTest = 2
-        call variable.restore()
-        Assert Equals(VitalVimGuardTest, previous)
+        if Guard.is_local_variable_supported
+          let VitalVimGuardTest = 1
+          let variable = sf._new_variable('VitalVimGuardTest', l:)
+          let previous = VitalVimGuardTest
+          let VitalVimGuardTest = 2
+          call variable.restore()
+          Assert Equals(VitalVimGuardTest, previous)
+        endif
 
         let variable = sf._new_variable('VitalVimGuardTest', s:)
         let previous = s:VitalVimGuardTest

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -66,7 +66,7 @@ Describe Vim.Guard
         setl backupcopy=no
         call option.restore()
         Assert Equals(&g:backupcopy, 'yes')
-        Assert Equals(&l:backupcopy, '')
+        Assert Equals(&l:backupcopy, v:version >= 704 ? '' : 'yes')
       End
       It restore a value of the option when assigned [global-local with &g:]
         let option = sf._new_option('&g:backupcopy')
@@ -74,14 +74,14 @@ Describe Vim.Guard
         setl backupcopy=no
         call option.restore()
         Assert Equals(&g:backupcopy, 'yes')
-        Assert Equals(&l:backupcopy, 'no')
+        Assert Equals(&l:backupcopy, v:version >= 704 ? 'no' : 'yes')
       End
       It restore a value of the option when assigned [global-local with &l:]
         let option = sf._new_option('&l:backupcopy')
         setg backupcopy=no
         setl backupcopy=no
         call option.restore()
-        Assert Equals(&g:backupcopy, 'no')
+        Assert Equals(&g:backupcopy, v:version >= 704 ? 'no' : 'yes')
         Assert Equals(&l:backupcopy, 'yes')
       End
       It restore a value of the option when assigned [local to buffer]

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -1,0 +1,376 @@
+let s:V = vital#of('vital')
+let s:P = s:V.import('System.Filepath')
+let s:S = s:V.import('Vim.ScriptLocal')
+
+Describe Vim.Guard
+  Before
+    let Guard = s:V.import('Vim.Guard')
+    let sfile = s:P.realpath(
+          \ 'autoload/vital/__latest__/Vim/Guard.vim'
+          \)
+    let sf = s:S.sfuncs(sfile)
+  End
+  Context [PRIVATE] s:_new_option({name})
+    " NOTE:
+    "   backup      - glocal
+    "   backupcopy  - global or local to buffer
+    "   binary      - local to buffer
+    "   list        - local to window
+    It throws an exception if {name} does not start from "&"
+      Throw /An option name "foo" requires to be started from "&"/
+            \ sf._new_option('foo')
+    End
+    It throws an exception if {name} does not exist as an option
+      Throw /An option name "&foo" does not exist/
+            \ sf._new_option('&foo')
+    End
+    It returns an option instance of {name}
+      let option = sf._new_option('&backup')
+      Assert KeyExists(option, 'name')
+      Assert KeyExists(option, 'value')
+      Assert KeyExists(option, 'restore')
+      Assert Equals(option.name, '&backup')
+      Assert Equals(option.value, &backup)
+      Throw /E741: Value is locked/ :let option.name = 'hello'
+      Throw /E741: Value is locked/ :let option.value = 'hello'
+    End
+    Context An option instance
+      Before
+        let previous_backup = &backup
+        let previous_g_backupcopy = &g:backupcopy
+        let previous_l_backupcopy = &l:backupcopy
+        let previous_b_binary = &binary
+        let previous_w_list = &list
+        set backup
+        setg backupcopy=yes
+        setl backupcopy=yes
+        set binary
+        set list
+      End
+      After
+        let &backup = previous_backup
+        let &g:backupcopy = previous_g_backupcopy
+        let &l:backupcopy = previous_l_backupcopy
+        let &binary = previous_b_binary
+        let &list = previous_w_list
+      End
+      It restore a value of the option when assigned [global]
+        let option = sf._new_option('&backup')
+        set nobackup
+        call option.restore()
+        Assert Equals(&backup, 1)
+      End
+      It restore a value of the option when assigned [global-local with &]
+        let option = sf._new_option('&backupcopy')
+        setg backupcopy=no
+        setl backupcopy=no
+        call option.restore()
+        Assert Equals(&g:backupcopy, 'yes')
+        Assert Equals(&l:backupcopy, '')
+      End
+      It restore a value of the option when assigned [global-local with &g:]
+        let option = sf._new_option('&g:backupcopy')
+        setg backupcopy=no
+        setl backupcopy=no
+        call option.restore()
+        Assert Equals(&g:backupcopy, 'yes')
+        Assert Equals(&l:backupcopy, 'no')
+      End
+      It restore a value of the option when assigned [global-local with &l:]
+        let option = sf._new_option('&l:backupcopy')
+        setg backupcopy=no
+        setl backupcopy=no
+        call option.restore()
+        Assert Equals(&g:backupcopy, 'no')
+        Assert Equals(&l:backupcopy, 'yes')
+      End
+      It restore a value of the option when assigned [local to buffer]
+        let option = sf._new_option('&binary')
+        set nobinary
+        call option.restore()
+        Assert Equals(&binary, 1)
+      End
+      It restore a value of the option when assigned [local to window]
+        let option = sf._new_option('&list')
+        set nolist
+        call option.restore()
+        Assert Equals(&list, 1)
+      End
+    End
+  End
+  Context [PRIVATE] s:_new_variable({name}[, {namespace}])
+    Before
+      let g:VitalVimGuardTest = 1
+      let b:VitalVimGuardTest = 1
+      let w:VitalVimGuardTest = 1
+      let t:VitalVimGuardTest = 1
+      let s:VitalVimGuardTest = 1
+    End
+    After
+      unlet g:VitalVimGuardTest
+      unlet b:VitalVimGuardTest
+      unlet w:VitalVimGuardTest
+      unlet t:VitalVimGuardTest
+      unlet s:VitalVimGuardTest
+    End
+    It throws an exception when no {namespace} is specified and {name} does not start from b:, w:, t:, or g:
+      Throw /An variable name "foo" requires to start from b:, w:, t:, or g:/
+            \ sf._new_variable('foo')
+      Throw /An variable name "l:foo" requires to start from b:, w:, t:, or g:/
+            \ sf._new_variable('l:foo')
+      Throw /An variable name "s:foo" requires to start from b:, w:, t:, or g:/
+            \ sf._new_variable('s:foo')
+    End
+    It returns an variable instance of {name} in a {namespace}
+      let namespace = {
+            \ 'foo': 'bar',
+            \}
+      let variable = sf._new_variable('foo', namespace)
+      Assert KeyExists(variable, 'name')
+      Assert KeyExists(variable, 'value')
+      Assert KeyExists(variable, 'restore')
+      Assert Equals(variable.name, 'foo')
+      Assert Equals(variable.value, namespace.foo)
+      Throw /E741: Value is locked/ :let variable.name = 'hello'
+      Throw /E741: Value is locked/ :let variable.value = 'hello'
+
+      let VitalVimGuardTest = 1
+      let variable = sf._new_variable('VitalVimGuardTest', l:)
+      Assert KeyExists(variable, 'name')
+      Assert KeyExists(variable, 'value')
+      Assert KeyExists(variable, 'restore')
+      Assert Equals(variable.name, 'VitalVimGuardTest')
+      Assert Equals(variable.value, VitalVimGuardTest)
+      Throw /E741: Value is locked/ :let variable.name = 'hello'
+      Throw /E741: Value is locked/ :let variable.value = 'hello'
+
+      let variable = sf._new_variable('VitalVimGuardTest', s:)
+      Assert KeyExists(variable, 'name')
+      Assert KeyExists(variable, 'value')
+      Assert KeyExists(variable, 'restore')
+      Assert Equals(variable.name, 'VitalVimGuardTest')
+      let s = s:VitalVimGuardTest
+      Assert Equals(variable.value, s)
+      Throw /E741: Value is locked/ :let variable.name = 'hello'
+      Throw /E741: Value is locked/ :let variable.value = 'hello'
+    End
+    It returns an variable instance of {name} in a {namespace} specified as a prefix of {name}
+      let variable = sf._new_variable('b:VitalVimGuardTest')
+      Assert KeyExists(variable, 'name')
+      Assert KeyExists(variable, 'value')
+      Assert KeyExists(variable, 'restore')
+      Assert Equals(variable.name, 'VitalVimGuardTest')
+      Assert Equals(variable.value, b:VitalVimGuardTest)
+      Throw /E741: Value is locked/ :let variable.name = 'hello'
+      Throw /E741: Value is locked/ :let variable.value = 'hello'
+
+      let variable = sf._new_variable('w:VitalVimGuardTest')
+      Assert KeyExists(variable, 'name')
+      Assert KeyExists(variable, 'value')
+      Assert KeyExists(variable, 'restore')
+      Assert Equals(variable.name, 'VitalVimGuardTest')
+      Assert Equals(variable.value, w:VitalVimGuardTest)
+      Throw /E741: Value is locked/ :let variable.name = 'hello'
+      Throw /E741: Value is locked/ :let variable.value = 'hello'
+
+      let variable = sf._new_variable('t:VitalVimGuardTest')
+      Assert KeyExists(variable, 'name')
+      Assert KeyExists(variable, 'value')
+      Assert KeyExists(variable, 'restore')
+      Assert Equals(variable.name, 'VitalVimGuardTest')
+      Assert Equals(variable.value, t:VitalVimGuardTest)
+      Throw /E741: Value is locked/ :let variable.name = 'hello'
+      Throw /E741: Value is locked/ :let variable.value = 'hello'
+
+      let variable = sf._new_variable('g:VitalVimGuardTest')
+      Assert KeyExists(variable, 'name')
+      Assert KeyExists(variable, 'value')
+      Assert KeyExists(variable, 'restore')
+      Assert Equals(variable.name, 'VitalVimGuardTest')
+      Assert Equals(variable.value, g:VitalVimGuardTest)
+      Throw /E741: Value is locked/ :let variable.name = 'hello'
+      Throw /E741: Value is locked/ :let variable.value = 'hello'
+    End
+    Context A variable instance
+      It restore a value of the variable when assigned
+        let variable = sf._new_variable('b:VitalVimGuardTest')
+        let previous = b:VitalVimGuardTest
+        let b:VitalVimGuardTest = 2
+        call variable.restore()
+        Assert Equals(b:VitalVimGuardTest, previous)
+
+        let variable = sf._new_variable('w:VitalVimGuardTest')
+        let previous = w:VitalVimGuardTest
+        let w:VitalVimGuardTest = 2
+        call variable.restore()
+        Assert Equals(w:VitalVimGuardTest, previous)
+
+        let variable = sf._new_variable('t:VitalVimGuardTest')
+        let previous = t:VitalVimGuardTest
+        let t:VitalVimGuardTest = 2
+        call variable.restore()
+        Assert Equals(t:VitalVimGuardTest, previous)
+
+        let variable = sf._new_variable('g:VitalVimGuardTest')
+        let previous = g:VitalVimGuardTest
+        let g:VitalVimGuardTest = 2
+        call variable.restore()
+        Assert Equals(g:VitalVimGuardTest, previous)
+
+        let VitalVimGuardTest = 1
+        let variable = sf._new_variable('VitalVimGuardTest', l:)
+        let previous = VitalVimGuardTest
+        let VitalVimGuardTest = 2
+        call variable.restore()
+        Assert Equals(VitalVimGuardTest, previous)
+
+        let variable = sf._new_variable('VitalVimGuardTest', s:)
+        let previous = s:VitalVimGuardTest
+        let s:VitalVimGuardTest = 2
+        call variable.restore()
+        let s = s:VitalVimGuardTest
+        Assert Equals(s, previous)
+      End
+      It deepcopy List or Dictionary to prevent E741: Value is locked
+        let namespace = {
+              \ 'list': ['a', 'b', 'c'],
+              \ 'dict': {
+              \   'a': 'a',
+              \   'b': 'b',
+              \   'c': 'c',
+              \ },
+              \}
+        let variable = sf._new_variable('list', namespace)
+        let namespace.list = ['foo', 'bar', 'hoge']
+        call variable.restore()
+        Assert Equals(namespace.list, ['a', 'b', 'c'])
+
+        let variable = sf._new_variable('dict', namespace)
+        let namespace.dict = { 'foo': 'foo', 'bar': 'bar' }
+        call variable.restore()
+        Assert Equals(namespace.dict, {
+              \ 'a': 'a',
+              \ 'b': 'b',
+              \ 'c': 'c',
+              \})
+      End
+    End
+  End
+
+  Context .new({option_or_variable}...)
+    Before
+      let previous_backup = &backup
+      let previous_g_backupcopy = &g:backupcopy
+      let previous_l_backupcopy = &l:backupcopy
+      let previous_b_binary = &binary
+      let previous_w_list = &list
+      set backup
+      setg backupcopy=yes
+      setl backupcopy=yes
+      set binary
+      set list
+      let b:VitalVimGuardTest = 1
+      let w:VitalVimGuardTest = 1
+      let t:VitalVimGuardTest = 1
+      let g:VitalVimGuardTest = 1
+      let s:VitalVimGuardTest = 1
+    End
+    After
+      let &backup = previous_backup
+      let &g:backupcopy = previous_g_backupcopy
+      let &l:backupcopy = previous_l_backupcopy
+      let &binary = previous_b_binary
+      let &list = previous_w_list
+      unlet b:VitalVimGuardTest
+      unlet w:VitalVimGuardTest
+      unlet t:VitalVimGuardTest
+      unlet g:VitalVimGuardTest
+      unlet s:VitalVimGuardTest
+    End
+    It returns a guard instance for options
+      let guard = Guard.new(
+            \ '&backup',
+            \ '&backupcopy',
+            \ '&binary',
+            \ '&list',
+            \)
+      Assert KeyExists(guard, 'restore')
+      " NOTE: first character & of names are omittable
+      let guard = Guard.new(
+            \ 'backup',
+            \ 'backupcopy',
+            \ 'binary',
+            \ 'list',
+            \)
+      Assert KeyExists(guard, 'restore')
+    End
+    It returns a guard instance for variables
+      let namespace = { 'VitalVimGuardTest': 1 }
+      let VitalVimGuardTest = 1
+      let guard = Guard.new(
+            \ ['VitalVimGuardTest', b:],
+            \ ['VitalVimGuardTest', w:],
+            \ ['VitalVimGuardTest', t:],
+            \ ['VitalVimGuardTest', g:],
+            \ ['VitalVimGuardTest', s:],
+            \ ['VitalVimGuardTest', l:],
+            \ ['VitalVimGuardTest', namespace],
+            \)
+      Assert KeyExists(guard, 'restore')
+      " NOTE: namespace variables of b:, w:, t:, g: are omittable
+      let guard = Guard.new(
+            \ 'b:VitalVimGuardTest',
+            \ 'w:VitalVimGuardTest',
+            \ 't:VitalVimGuardTest',
+            \ 'g:VitalVimGuardTest',
+            \ ['VitalVimGuardTest', s:],
+            \ ['VitalVimGuardTest', l:],
+            \ ['VitalVimGuardTest', namespace],
+            \)
+      Assert KeyExists(guard, 'restore')
+    End
+    Context A guard instance
+      It restore options and variables assigned
+        let namespace = { 'VitalVimGuardTest': 1 }
+        let VitalVimGuardTest = 1
+        let guard = Guard.new(
+              \ 'backup',
+              \ 'backupcopy',
+              \ 'binary',
+              \ 'list',
+              \ 'b:VitalVimGuardTest',
+              \ 'w:VitalVimGuardTest',
+              \ 't:VitalVimGuardTest',
+              \ 'g:VitalVimGuardTest',
+              \ ['VitalVimGuardTest', s:],
+              \ ['VitalVimGuardTest', l:],
+              \ ['VitalVimGuardTest', namespace],
+              \)
+        set nobackup
+        set backupcopy=no
+        set nobinary
+        set nolist
+        let b:VitalVimGuardTest = 2
+        let w:VitalVimGuardTest = 2
+        let t:VitalVimGuardTest = 2
+        let g:VitalVimGuardTest = 2
+        let VitalVimGuardTest = 2
+        let s:VitalVimGuardTest = 2
+        let namespace.VitalVimGuardTest = 2
+        call guard.restore()
+        Assert Equals(&backup, 1)
+        Assert Equals(&backupcopy, 'yes')
+        Assert Equals(&binary, 1)
+        Assert Equals(&list, 1)
+        Assert Equals(b:VitalVimGuardTest, 1)
+        Assert Equals(w:VitalVimGuardTest, 1)
+        Assert Equals(t:VitalVimGuardTest, 1)
+        Assert Equals(g:VitalVimGuardTest, 1)
+        Assert Equals(VitalVimGuardTest, 1)
+        let s = s:VitalVimGuardTest
+        Assert Equals(s, 1)
+        Assert Equals(namespace.VitalVimGuardTest, 1)
+      End
+    End
+  End
+End

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -241,7 +241,7 @@ Describe Vim.Guard
     End
   End
 
-  Describe .new({option_or_variable}...)
+  Describe .store({option_or_variable}...)
     Before
       let previous_backup = &backup
       let previous_g_backupcopy = &g:backupcopy
@@ -272,7 +272,7 @@ Describe Vim.Guard
       unlet s:VitalVimGuardTest
     End
     It returns a guard instance for options
-      let guard = Guard.new(
+      let guard = Guard.store(
             \ '&backup',
             \ '&backupcopy',
             \ '&binary',
@@ -280,7 +280,7 @@ Describe Vim.Guard
             \)
       Assert KeyExists(guard, 'restore')
       " NOTE: first character & of names are omittable
-      let guard = Guard.new(
+      let guard = Guard.store(
             \ 'backup',
             \ 'backupcopy',
             \ 'binary',
@@ -291,7 +291,7 @@ Describe Vim.Guard
     It returns a guard instance for variables
       let namespace = { 'VitalVimGuardTest': 1 }
       let VitalVimGuardTest = 1
-      let guard = Guard.new(
+      let guard = Guard.store(
             \ ['VitalVimGuardTest', b:],
             \ ['VitalVimGuardTest', w:],
             \ ['VitalVimGuardTest', t:],
@@ -302,7 +302,7 @@ Describe Vim.Guard
             \)
       Assert KeyExists(guard, 'restore')
       " NOTE: namespace variables of b:, w:, t:, g: are omittable
-      let guard = Guard.new(
+      let guard = Guard.store(
             \ 'b:VitalVimGuardTest',
             \ 'w:VitalVimGuardTest',
             \ 't:VitalVimGuardTest',
@@ -317,7 +317,7 @@ Describe Vim.Guard
       It restore options and variables assigned
         let namespace = { 'VitalVimGuardTest': 1 }
         let VitalVimGuardTest = 1
-        let guard = Guard.new(
+        let guard = Guard.store(
               \ 'backup',
               \ 'backupcopy',
               \ 'binary',


### PR DESCRIPTION
Example

```vim
let s:G = s:V.import('Vim.Guard')
let guard = s:G.store('&backup', 'g:foo', ['foo', s:])
" do something
call guard.restore()
```