### PR TITLE
Pull Request: Web.URI で相対 URI を扱いたい

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,14 @@
+6703d4694c3bc0f23d7eb01b1bf79f85902a5edf
+	Modules: Web.URI
+	URI.path() behavior is changed to not prepend '/' for empty path.
+	e.g.: http://example.com
+	But URI.canonicalize() does this.
+b2fd058b94361ca0a9b982f2ba8976dd4f8cda20
+	Modules: Web.URI
+	All URI object methods behavior with arguments(setter) are changed to return URI object itself.
+b96e772738125ad23b9a396761ab2e37be3b0b2e
+	Modules: Web.URI
+	All URI object methods behavior are changed to throw an exception for invalid arguments.
 3ba9447aef5b2a2ffc9899f0d240333bc075afa5
 	Modules: System.Cache
 	System.Cache is replaced with a new version.

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -247,6 +247,7 @@ function! s:_uri_scheme(...) dict abort
   if a:0
     if self.is_scheme(a:1)
       let self.__scheme = a:1
+      return self
     else
       throw 'vital: Web.URI: scheme(): '
       \   . 'invalid argument (' . string(a:1) . ')'
@@ -259,6 +260,7 @@ function! s:_uri_userinfo(...) dict abort
   if a:0
     if self.is_userinfo(a:1)
       let self.__userinfo = a:1
+      return self
     else
       throw 'vital: Web.URI: userinfo(): '
       \   . 'invalid argument (' . string(a:1) . ')'
@@ -271,6 +273,7 @@ function! s:_uri_host(...) dict abort
   if a:0
     if self.is_host(a:1)
       let self.__host = a:1
+      return self
     else
       throw 'vital: Web.URI: host(): '
       \   . 'invalid argument (' . string(a:1) . ')'
@@ -283,6 +286,7 @@ function! s:_uri_port(...) dict abort
   if a:0
     if self.is_port(a:1)
       let self.__port = a:1
+      return self
     else
       throw 'vital: Web.URI: port(): '
       \   . 'invalid argument (' . string(a:1) . ')'
@@ -297,6 +301,7 @@ function! s:_uri_path(...) dict abort
     let path = substitute(a:1, '^/\+', '', '')
     if self.is_path(path)
       let self.__path = path
+      return self
     else
       throw 'vital: Web.URI: path(): '
       \   . 'invalid argument (' . string(a:1) . ')'
@@ -332,6 +337,7 @@ function! s:_uri_query(...) dict abort
     let query = substitute(a:1, '^?', '', '')
     if self.is_query(query)
       let self.__query = query
+      return self
     else
       throw 'vital: Web.URI: query(): '
       \   . 'invalid argument (' . string(a:1) . ')'
@@ -346,6 +352,7 @@ function! s:_uri_fragment(...) dict abort
     let fragment = substitute(a:1, '^#', '', '')
     if self.is_fragment(fragment)
       let self.__fragment = fragment
+      return self
     else
       throw 'vital: Web.URI: fragment(): '
       \   . 'invalid argument (' . string(a:1) . ')'

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -160,8 +160,7 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
   let obj.__userinfo = hier_part.userinfo
   let obj.__host = hier_part.host
   let obj.__port = hier_part.port
-  " NOTE: obj.__path must not have "/" as prefix.
-  let obj.__path = substitute(hier_part.path, '^/\+', '', '')
+  let obj.__path = hier_part.path
   " NOTE: obj.__query must not have "?" as prefix.
   let obj.__query = substitute(query, '^?', '', '')
   " NOTE: obj.__fragment must not have "#" as prefix.
@@ -303,17 +302,15 @@ endfunction
 
 function! s:_uri_path(...) dict abort
   if a:0
-    " NOTE: self.__path must not have "/" as prefix.
-    let path = substitute(a:1, '^/\+', '', '')
-    if self.is_path(path)
-      let self.__path = path
+    if self.is_path(a:1)
+      let self.__path = a:1
       return self
     else
       throw 'vital: Web.URI: path(): '
       \   . 'invalid argument (' . string(a:1) . ')'
     endif
   endif
-  return "/" . self.__path
+  return self.__path
 endfunction
 
 function! s:_uri_authority(...) dict abort
@@ -332,7 +329,7 @@ function! s:_uri_opaque(...) dict abort
     " TODO
     throw 'vital: Web.URI: uri.opaque(value) does not support yet.'
   endif
-  return printf('//%s/%s',
+  return printf('//%s%s',
   \           self.authority(),
   \           self.__path)
 endfunction
@@ -370,7 +367,7 @@ endfunction
 function! s:_uri_to_iri() dict abort
   " Same as uri.to_string(), but do unescape for self.__path.
   return printf(
-  \   '%s://%s/%s%s%s',
+  \   '%s://%s%s%s%s',
   \   self.__scheme,
   \   self.authority(),
   \   s:HTTP.decodeURI(self.__path),
@@ -381,7 +378,7 @@ endfunction
 
 function! s:_uri_to_string() dict abort
   return printf(
-  \   '%s://%s/%s%s%s',
+  \   '%s://%s%s%s%s',
   \   self.__scheme,
   \   self.authority(),
   \   self.__path,

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -10,13 +10,17 @@ function! s:_vital_depends() abort
   return ['Web.HTTP']
 endfunction
 
+" NOTE: See s:DefaultPatternSet about the reason
+" why s:DefaultPatternSet is not deepcopy()ed here.
 function! s:new(uri, ...) abort
   let NothrowValue = get(a:000, 0, s:NONE)
-  let pattern_set = get(a:000, 1, s:DefaultPatternSet)
+  let pattern_set  = get(a:000, 1, s:DefaultPatternSet)
   return s:_uri_new_sandbox(
   \   a:uri, 0, pattern_set, 0, NothrowValue)
 endfunction
 
+" NOTE: See s:DefaultPatternSet about the reason
+" why s:DefaultPatternSet is not deepcopy()ed here.
 function! s:new_from_uri_like_string(str, ...) abort
   let NothrowValue = get(a:000, 0, s:NONE)
   let pattern_set  = get(a:000, 1, s:DefaultPatternSet)
@@ -31,6 +35,8 @@ function! s:new_from_uri_like_string(str, ...) abort
   \   str, 0, pattern_set, 0, NothrowValue)
 endfunction
 
+" NOTE: See s:DefaultPatternSet about the reason
+" why s:DefaultPatternSet is not deepcopy()ed here.
 function! s:new_from_seq_string(uri, ...) abort
   let NothrowValue = get(a:000, 0, s:NONE)
   let pattern_set  = get(a:000, 1, s:DefaultPatternSet)
@@ -467,19 +473,17 @@ let s:URI = {
 " ===================== s:URI =====================
 
 
-" ================= s:PatternSet ==================
-" s:PatternSet: Patterns for URI syntax
+" ================= s:DefaultPatternSet ==================
+" s:DefaultPatternSet: Default patterns for URI syntax
 "
-" The main parts of URLs
-"   http://tools.ietf.org/html/rfc1738#section-2.1
-" BNF for specific URL schemes
-"   http://tools.ietf.org/html/rfc1738#section-5
-" Collected ABNF for URI
-"   http://tools.ietf.org/html/rfc3986#appendix-A
-" Parsing a URI Reference with a Regular Expression
-" NOTE: Using this regexp pattern in urilib.vim
-"   http://tools.ietf.org/html/rfc3986#appendix-B
+" @seealso http://tools.ietf.org/html/rfc3986
 
+" s:new*() methods do not create new copy of s:DefaultPatternSet
+" Thus it shares this instance also cache.
+" But it is no problem because of the following reasons.
+" 1. Each component's return value doesn't change
+"    unless it is overriden by a user. but...
+" 2. s:DefaultPatternSet can't be accessed by a user.
 let s:DefaultPatternSet = {'_cache': {}}
 
 function! s:new_default_pattern_set() abort
@@ -653,6 +657,6 @@ function! s:DefaultPatternSet.fragment() abort
   return '\%(' . join([self.pchar(), '/', '?'], '\|') . '\)*'
 endfunction
 
-" ================= s:PatternSet ==================
+" ================= s:DefaultPatternSet ==================
 
 " vim:set et ts=2 sts=2 sw=2 tw=0:fen:

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -673,7 +673,7 @@ function! s:DefaultPatternSet.host() abort
 endfunction
 " port = *DIGIT
 function! s:DefaultPatternSet.port() abort
-  return '[0-9]\+'
+  return '[0-9]*'
 endfunction
 " path = path-abempty    ; begins with "/" or is empty
 "      / path-absolute   ; begins with "/" but not "//"

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -150,15 +150,16 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
 
   let obj = deepcopy(s:URI)
   let obj.__pattern_set = a:pattern_set
-  " TODO: No need to use setter?
-  " Just set the values to each property directly.
-  call obj.scheme(scheme)
-  call obj.userinfo(hier_part.userinfo)
-  call obj.host(hier_part.host)
-  call obj.port(hier_part.port)
-  call obj.path(hier_part.path)
-  call obj.query(query)
-  call obj.fragment(fragment)
+  let obj.__scheme = scheme
+  let obj.__userinfo = hier_part.userinfo
+  let obj.__host = hier_part.host
+  let obj.__port = hier_part.port
+  " NOTE: obj.__path must not have "/" as prefix.
+  let obj.__path = substitute(hier_part.path, '^/\+', '', '')
+  " NOTE: obj.__query must not have "?" as prefix.
+  let obj.__query = substitute(query, '^?', '', '')
+  " NOTE: obj.__fragment must not have "#" as prefix.
+  let obj.__fragment = substitute(fragment, '^#', '', '')
   return [obj, rest]
 endfunction
 
@@ -243,29 +244,49 @@ function! s:_uri_new(str, ignore_rest, pattern_set) abort
 endfunction
 
 function! s:_uri_scheme(...) dict abort
-  if a:0 && self.is_scheme(a:1)
-    let self.__scheme = a:1
+  if a:0
+    if self.is_scheme(a:1)
+      let self.__scheme = a:1
+    else
+      throw 'vital: Web.URI: scheme(): '
+      \   . 'invalid argument (' . string(a:1) . ')'
+    endif
   endif
   return self.__scheme
 endfunction
 
 function! s:_uri_userinfo(...) dict abort
-  if a:0 && self.is_userinfo(a:1)
-    let self.__userinfo = a:1
+  if a:0
+    if self.is_userinfo(a:1)
+      let self.__userinfo = a:1
+    else
+      throw 'vital: Web.URI: userinfo(): '
+      \   . 'invalid argument (' . string(a:1) . ')'
+    endif
   endif
   return self.__userinfo
 endfunction
 
 function! s:_uri_host(...) dict abort
-  if a:0 && self.is_host(a:1)
-    let self.__host = a:1
+  if a:0
+    if self.is_host(a:1)
+      let self.__host = a:1
+    else
+      throw 'vital: Web.URI: host(): '
+      \   . 'invalid argument (' . string(a:1) . ')'
+    endif
   endif
   return self.__host
 endfunction
 
 function! s:_uri_port(...) dict abort
-  if a:0 && self.is_port(a:1)
-    let self.__port = a:1
+  if a:0
+    if self.is_port(a:1)
+      let self.__port = a:1
+    else
+      throw 'vital: Web.URI: port(): '
+      \   . 'invalid argument (' . string(a:1) . ')'
+    endif
   endif
   return self.__port
 endfunction
@@ -276,6 +297,9 @@ function! s:_uri_path(...) dict abort
     let path = substitute(a:1, '^/\+', '', '')
     if self.is_path(path)
       let self.__path = path
+    else
+      throw 'vital: Web.URI: path(): '
+      \   . 'invalid argument (' . string(a:1) . ')'
     endif
   endif
   return "/" . self.__path
@@ -308,6 +332,9 @@ function! s:_uri_query(...) dict abort
     let query = substitute(a:1, '^?', '', '')
     if self.is_query(query)
       let self.__query = query
+    else
+      throw 'vital: Web.URI: query(): '
+      \   . 'invalid argument (' . string(a:1) . ')'
     endif
   endif
   return self.__query
@@ -319,6 +346,9 @@ function! s:_uri_fragment(...) dict abort
     let fragment = substitute(a:1, '^#', '', '')
     if self.is_fragment(fragment)
       let self.__fragment = fragment
+    else
+      throw 'vital: Web.URI: fragment(): '
+      \   . 'invalid argument (' . string(a:1) . ')'
     endif
   endif
   return self.__fragment

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -413,6 +413,10 @@ function! s:_call_handler_method(this, name, args) abort
   return a:this
 endfunction
 
+function! s:_uri_clone() dict abort
+  return deepcopy(self)
+endfunction
+
 function! s:_uri_relative(relstr) dict abort
   call self.canonicalize()
   let relobj = s:_parse_relative_ref(a:relstr, self.__pattern_set)
@@ -674,6 +678,7 @@ let s:URI = {
 \ 'query': s:_local_func('_uri_query'),
 \ 'fragment': s:_local_func('_uri_fragment'),
 \
+\ 'clone': s:_local_func('_uri_clone'),
 \ 'relative': s:_local_func('_uri_relative'),
 \ 'canonicalize': s:_local_func('_uri_canonicalize'),
 \ 'default_port': s:_local_func('_uri_default_port'),

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -118,11 +118,6 @@ endfunction
 " RFC3986: http://tools.ietf.org/html/rfc3986
 "
 " URI = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
-" hier-part = "//" authority path-abempty
-"           / path-absolute
-"           / path-noscheme
-"           / path-rootless
-"           / path-empty
 " authority = [ userinfo "@" ] host [ ":" port ]
 function! s:_parse_uri(str, ignore_rest, pattern_set) abort
   let rest = a:str
@@ -197,6 +192,11 @@ function! s:_eat_em(str, pat, ...) abort
   return [m[0], rest]
 endfunction
 
+" hier-part = "//" authority path-abempty
+"           / path-absolute
+"           / path-noscheme
+"           / path-rootless
+"           / path-empty
 function! s:_eat_hier_part(rest, pattern_set) abort
   let rest = a:rest
   if rest =~# '^://'

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -392,7 +392,8 @@ function! s:_uri_fragment(...) dict abort
 endfunction
 
 function! s:_uri_canonicalize() dict abort
-  return s:_call_handler_method(self, 'canonicalize', [])
+  call s:_call_handler_method(self, 'canonicalize', [])
+  return self
 endfunction
 
 function! s:_uri_default_port() dict abort
@@ -404,8 +405,7 @@ function! s:_call_handler_method(this, name, args) abort
     throw 'vital: Web.URI: ' . a:name . '(): '
     \   . "Handler was not found for scheme '" . a:this.__scheme . "'."
   endif
-  call call(a:this.__handler[a:name], [a:this] + a:args, a:this.__handler)
-  return a:this
+  return call(a:this.__handler[a:name], [a:this] + a:args)
 endfunction
 
 function! s:_uri_clone() dict abort

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -289,7 +289,10 @@ endfunction
 
 function! s:_uri_port(...) dict abort
   if a:0
-    if self.is_port(a:1)
+    if type(a:1) ==# type(0)
+      let self.__port = "" . a:1
+      return self
+    elseif type(a:1) ==# type("") && self.is_port(a:1)
       let self.__port = a:1
       return self
     else

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -8,7 +8,7 @@ function! s:_vital_loaded(V) abort
 endfunction
 
 function! s:_vital_depends() abort
-  return ['Web.HTTP', 'Web.URI.HTTP']
+  return ['Web.HTTP', 'Web.URI.HTTP', 'Web.URI.HTTPS']
 endfunction
 
 " NOTE: See s:DefaultPatternSet about the reason

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -161,6 +161,9 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
   let obj.__fragment = substitute(fragment, '^#', '', '')
   let obj.__pattern_set = a:pattern_set
   let obj.__handler = s:_get_handler_module(scheme, obj)
+  if !empty(obj.__handler)
+    call extend(obj.__handler, obj.__handler.new(obj))
+  endif
   return [obj, rest]
 endfunction
 
@@ -172,11 +175,7 @@ function! s:_get_handler_module(scheme, uriobj) abort
   if !s:V.exists(name)
     return {}
   endif
-  let m = s:V.import(name)
-  if has_key(m, 'on_loaded')
-    call m.on_loaded(a:uriobj)
-  endif
-  return m
+  return s:V.import(name)
 endfunction
 
 function! s:_eat_em(str, pat, ...) abort

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -4,11 +4,10 @@ set cpo&vim
 let s:V = {}
 function! s:_vital_loaded(V) abort
   let s:V = a:V
-  let s:HTTP = s:V.import('Web.HTTP')
 endfunction
 
 function! s:_vital_depends() abort
-  return ['Web.HTTP', 'Web.URI.HTTP', 'Web.URI.HTTPS']
+  return ['Web.URI.HTTP', 'Web.URI.HTTPS']
 endfunction
 
 " NOTE: See s:DefaultPatternSet about the reason
@@ -584,13 +583,13 @@ function! s:_remove_dot_segments(path) abort
   return join(paths, '/')
 endfunction
 
-function! s:_uri_to_iri() dict abort
+function! s:_uri_to_iri(...) dict abort
   " Same as uri.to_string(), but do unescape for self.__path.
   return printf(
   \   '%s://%s%s%s%s',
   \   self.__scheme,
   \   self.authority(),
-  \   s:HTTP.decodeURI(self.__path),
+  \   call('s:decode', [self.__path] + (a:0 ? [a:1] : [])),
   \   (self.__query !=# '' ? '?' . self.__query : ''),
   \   (self.__fragment !=# '' ? '#' . self.__fragment : ''),
   \)

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -319,9 +319,9 @@ endfunction
 function! s:_uri_port(...) dict abort
   if a:0
     if type(a:1) ==# type(0)
-      let self.__port = "" . a:1
+      let self.__port = '' . a:1
       return self
-    elseif type(a:1) ==# type("") && self.is_port(a:1)
+    elseif type(a:1) ==# type('') && self.is_port(a:1)
       let self.__port = a:1
       return self
     else

--- a/autoload/vital/__latest__/Web/URI.vim
+++ b/autoload/vital/__latest__/Web/URI.vim
@@ -1,7 +1,6 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:V = {}
 function! s:_vital_loaded(V) abort
   let s:V = a:V
 endfunction
@@ -161,9 +160,6 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
   let obj.__fragment = substitute(fragment, '^#', '', '')
   let obj.__pattern_set = a:pattern_set
   let obj.__handler = s:_get_handler_module(scheme, obj)
-  if !empty(obj.__handler)
-    call extend(obj.__handler, obj.__handler.new(obj))
-  endif
   return [obj, rest]
 endfunction
 
@@ -408,7 +404,7 @@ function! s:_call_handler_method(this, name, args) abort
     throw 'vital: Web.URI: ' . a:name . '(): '
     \   . "Handler was not found for scheme '" . a:this.__scheme . "'."
   endif
-  call call(a:this.__handler[a:name], a:args, a:this.__handler)
+  call call(a:this.__handler[a:name], [a:this] + a:args, a:this.__handler)
   return a:this
 endfunction
 

--- a/autoload/vital/__latest__/Web/URI/HTTP.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTP.vim
@@ -8,16 +8,16 @@ set cpo&vim
 " * http://example.com:80/
 "
 " https://tools.ietf.org/html/rfc3986#section-6.2.3
-function! s:canonicalize(uriobj) dict abort
+function! s:canonicalize(uriobj) abort
   if a:uriobj.path() ==# ''
     call a:uriobj.path('/')
   endif
-  if a:uriobj.port() ==# self.default_port(a:uriobj)
+  if a:uriobj.port() ==# a:uriobj.default_port()
     call a:uriobj.port('')
   endif
 endfunction
 
-function! s:default_port(uriobj) dict abort
+function! s:default_port(uriobj) abort
   return '80'
 endfunction
 

--- a/autoload/vital/__latest__/Web/URI/HTTP.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTP.vim
@@ -1,11 +1,6 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-
-function! s:new(super) abort
-  return {'super': a:super}
-endfunction
-
 " The following four URIs are equivalent:
 " * http://example.com
 " * http://example.com/
@@ -13,16 +8,16 @@ endfunction
 " * http://example.com:80/
 "
 " https://tools.ietf.org/html/rfc3986#section-6.2.3
-function! s:canonicalize() dict abort
-  if self.super.path() ==# ''
-    call self.super.path('/')
+function! s:canonicalize(uriobj) dict abort
+  if a:uriobj.path() ==# ''
+    call a:uriobj.path('/')
   endif
-  if self.super.port() ==# self.default_port()
-    call self.super.port('')
+  if a:uriobj.port() ==# self.default_port(a:uriobj)
+    call a:uriobj.port('')
   endif
 endfunction
 
-function! s:default_port() dict abort
+function! s:default_port(uriobj) dict abort
   return '80'
 endfunction
 

--- a/autoload/vital/__latest__/Web/URI/HTTP.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTP.vim
@@ -11,6 +11,8 @@ endfunction
 " * http://example.com/
 " * http://example.com:/
 " * http://example.com:80/
+"
+" https://tools.ietf.org/html/rfc3986#section-6.2.3
 function! s:canonicalize() dict abort
   if s:super.path() ==# ''
     call s:super.path('/')

--- a/autoload/vital/__latest__/Web/URI/HTTP.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTP.vim
@@ -1,9 +1,9 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-let s:super = {}
-function! s:on_loaded(super) abort
-  let s:super = a:super
+
+function! s:new(super) abort
+  return {'super': a:super}
 endfunction
 
 " The following four URIs are equivalent:
@@ -14,11 +14,11 @@ endfunction
 "
 " https://tools.ietf.org/html/rfc3986#section-6.2.3
 function! s:canonicalize() dict abort
-  if s:super.path() ==# ''
-    call s:super.path('/')
+  if self.super.path() ==# ''
+    call self.super.path('/')
   endif
-  if s:super.port() ==# self.default_port()
-    call s:super.port('')
+  if self.super.port() ==# self.default_port()
+    call self.super.port('')
   endif
 endfunction
 

--- a/autoload/vital/__latest__/Web/URI/HTTP.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTP.vim
@@ -1,0 +1,27 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:super = {}
+function! s:on_loaded(super) abort
+  let s:super = a:super
+endfunction
+
+" The following four URIs are equivalent:
+" * http://example.com
+" * http://example.com/
+" * http://example.com:/
+" * http://example.com:80/
+function! s:canonicalize() dict abort
+  if s:super.path() ==# ''
+    call s:super.path('/')
+  endif
+  if s:super.port() ==# self.default_port()
+    call s:super.port('')
+  endif
+endfunction
+
+function! s:default_port() dict abort
+  return '80'
+endfunction
+
+" vim:set et ts=2 sts=2 sw=2 tw=0:fen:

--- a/autoload/vital/__latest__/Web/URI/HTTPS.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTPS.vim
@@ -10,18 +10,14 @@ function! s:_vital_depends() abort
   return ['Web.URI.HTTP']
 endfunction
 
-function! s:new(super) abort
-  return s:HTTP.new(a:super)
-endfunction
-
 
 " In order to let s:HTTP.canonicalize()
 " calls s:HTTPS.default_port(), pass self.
-function! s:canonicalize() dict abort
-  return call(s:HTTP.canonicalize, [], self)
+function! s:canonicalize(uriobj) dict abort
+  return call(s:HTTP.canonicalize, [a:uriobj], self)
 endfunction
 
-function! s:default_port() dict abort
+function! s:default_port(uriobj) dict abort
   return '443'
 endfunction
 

--- a/autoload/vital/__latest__/Web/URI/HTTPS.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTPS.vim
@@ -11,13 +11,11 @@ function! s:_vital_depends() abort
 endfunction
 
 
-" In order to let s:HTTP.canonicalize()
-" calls s:HTTPS.default_port(), pass self.
-function! s:canonicalize(uriobj) dict abort
-  return call(s:HTTP.canonicalize, [a:uriobj], self)
+function! s:canonicalize(uriobj) abort
+  return s:HTTP.canonicalize(a:uriobj)
 endfunction
 
-function! s:default_port(uriobj) dict abort
+function! s:default_port(uriobj) abort
   return '443'
 endfunction
 

--- a/autoload/vital/__latest__/Web/URI/HTTPS.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTPS.vim
@@ -10,8 +10,8 @@ function! s:_vital_depends() abort
   return ['Web.URI.HTTP']
 endfunction
 
-function! s:on_loaded(super) abort
-  call s:HTTP.on_loaded(a:super)
+function! s:new(super) abort
+  return s:HTTP.new(a:super)
 endfunction
 
 

--- a/autoload/vital/__latest__/Web/URI/HTTPS.vim
+++ b/autoload/vital/__latest__/Web/URI/HTTPS.vim
@@ -1,0 +1,28 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:HTTP = {}
+function! s:_vital_loaded(V) abort
+  let s:HTTP = a:V.import('Web.URI.HTTP')
+endfunction
+
+function! s:_vital_depends() abort
+  return ['Web.URI.HTTP']
+endfunction
+
+function! s:on_loaded(super) abort
+  call s:HTTP.on_loaded(a:super)
+endfunction
+
+
+" In order to let s:HTTP.canonicalize()
+" calls s:HTTPS.default_port(), pass self.
+function! s:canonicalize() dict abort
+  return call(s:HTTP.canonicalize, [], self)
+endfunction
+
+function! s:default_port() dict abort
+  return '443'
+endfunction
+
+" vim:set et ts=2 sts=2 sw=2 tw=0:fen:

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -113,6 +113,7 @@ fragment([{str}])
 	and returns URI object itself.
 
 	NOTE: opaque(), authority() do not support {str} yet.
+	NOTE: port({str}) allows both Number and String for {str}.
 
 to_iri()				*Vital.Web.URI-object.to_iri()*
 	Same as |Vital.Web.URI-object.to_string()|,

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -305,6 +305,25 @@ TODO					*Vital.Web.URI-todo*
 * IRI support (RFC3987)
 * |Vital.Web.URI-URI.opaque()| with an argument
 * |Vital.Web.URI-URI.authority()| with an argument
+* Perl's URI, URI::Find module
+  * `URI::eq()`
+  * `URI::query_form()`
+  * `URI::query_keywords()`
+  * `URI::ihost()`
+  * `URI::Find::find()`
+* RFC 5890: IDNA (Internationalized Domain Names for Applications)
+  * A Label
+  * U Label
+  * NR-LDH Label
+* `s:URI.to_string()` should recompose string by the algorithm
+  based on https://tools.ietf.org/html/rfc3986#section-5.3
+* `s:URI.to_iri()`: Write tests
+* `s:URI.to_iri()`: Write document
+* URN Support
+  * urn:isbn
+  * urn:uuid
+  * urn:ietf:rfc
+  * urn:oid
 
 ==============================================================================
 REFERENCES				*Vital.Web.URI-references*

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -115,9 +115,10 @@ fragment([{str}])
 	NOTE: opaque(), authority() do not support {str} yet.
 	NOTE: port({str}) allows both Number and String for {str}.
 
-to_iri()				*Vital.Web.URI-object.to_iri()*
+to_iri([{char-enc}])				*Vital.Web.URI-object.to_iri()*
 	Same as |Vital.Web.URI-object.to_string()|,
 	but do URI-unescape for |Vital.Web.URI-object.path()| part.
+	Passes {char-enc} to |Vital.Web.URI.decode()| if specified.
 
 to_string()				*Vital.Web.URI-object.to_string()*
 	Returns URI representation of this object.

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -112,8 +112,6 @@ fragment([{str}])
 	If {str} is given, sets {str} as each part value,
 	and returns URI object itself.
 
-	NOTE: path() with no arguments always returns
-	a string prefixed by "/".
 	NOTE: opaque(), authority() do not support {str} yet.
 
 to_iri()				*Vital.Web.URI-object.to_iri()*

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -110,7 +110,7 @@ fragment([{str}])
 
 	If no arguments are given, returns each part value.
 	If {str} is given, sets {str} as each part value,
-	and returns URI object itself.
+	and returns the URI object itself.
 
 	NOTE: opaque(), authority() do not support {str} yet.
 	NOTE: port({str}) allows both Number and String for {str}.
@@ -139,6 +139,51 @@ is_fragment({str})
 
     Returns non-zero value if {str} has right syntax
     for each component. Returns zero otherwise.
+
+*Vital.Web.URI-URI.relative()*
+relative({reluri})
+
+    This method ...
+    * Calculates a URI from
+    base URI and relative URI({reluri}).
+    * Changes the URI object itself (destructive).
+    * Returns the URI object itself.
+    * Calls |Vital.Web.URI-URI.relative()| implicitly.
+
+    Example: >
+    let s:URI = vital#of('vital').import('Web.URI')
+    let BASE_URI = 'http://example.com/foo/bar'
+    let RELATIVE_URI = '../baz'
+    echo s:URI.new(BASE_URI).relative(RELATIVE_URI).to_string()
+    " => http://example.com/foo/baz
+<
+*Vital.Web.URI-URI.canonicalize()*
+canonicalize()
+
+    This method ...
+    * Canonicalizes the URI.
+    * Changes the URI object itself (destructive).
+    * Returns the URI object itself.
+
+    See Web.URI.* modules for supported schemes.
+    For example, the following four URIs
+    becomes equivalent URI (http://example.com/).
+    * http://example.com
+    * http://example.com/
+    * http://example.com:/
+    * http://example.com:80/
+
+    Example: >
+    let s:URI = vital#of('vital').import('Web.URI')
+    echo s:URI.new('http://example.com:80/').to_string()
+    " => http://example.com/
+<
+*Vital.Web.URI-URI.default_port()*
+default_port()
+
+    This method returns the default port for current scheme.
+    (e.g.: 80 for "http" scheme)
+    See Web.URI.* modules for supported schemes.
 
 ------------------------------------------------------------------------------
 PATTERNSET OBJECT				*Vital.Web.URI-PatternSet*

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -80,6 +80,12 @@ decode({str} [, {char-enc}])		*Vital.Web.URI.decode()*
 	Converts result from {char-enc}(or "utf-8" when omitted) to 'encoding'
 	after decode.
 	When {char-enc} is an empty string, result is not converted.
+	Note that this function does not convert "+" to " ".
+	Because this function is based on percent-encoding in RFC3986.
+	http://tools.ietf.org/html/rfc3986#section-2.1
+	But "+" conversion is based on
+	application/x-www-form-urlencoded in RFC1866.
+	http://tools.ietf.org/html/rfc1866#section-8.2.1
 
 ------------------------------------------------------------------------------
 URI OBJECT				*Vital.Web.URI-URI* *Vital.Web.URI-object*

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -108,10 +108,12 @@ opaque([{str}])
 query([{str}])
 fragment([{str}])
 
-	Returns each part if no arguments are given.
-	Set {str} as each part if {str} is given.
+	If no arguments are given, returns each part value.
+	If {str} is given, sets {str} as each part value,
+	and returns URI object itself.
 
-	NOTE: path() always returns a string prefixed by "/".
+	NOTE: path() with no arguments always returns
+	a string prefixed by "/".
 	NOTE: opaque(), authority() do not support {str} yet.
 
 to_iri()				*Vital.Web.URI-object.to_iri()*

--- a/doc/vital-web-uri.txt
+++ b/doc/vital-web-uri.txt
@@ -147,6 +147,18 @@ is_fragment({str})
     Returns non-zero value if {str} has right syntax
     for each component. Returns zero otherwise.
 
+*Vital.Web.URI-URI.clone()*
+clone()
+
+    This method clones a URI object itself. >
+    let s:URI = vital#of('vital').import('Web.URI')
+    let uri = s:URI.new('http://example.com/')
+    let copyuri = uri.clone().relative('/a/b/c')
+    echo uri.to_string()
+    " => 'http://example.com/'
+    echo copyuri.to_string()
+    " => 'http://example.com/a/b/c'
+<
 *Vital.Web.URI-URI.relative()*
 relative({reluri})
 
@@ -162,7 +174,7 @@ relative({reluri})
     let BASE_URI = 'http://example.com/foo/bar'
     let RELATIVE_URI = '../baz'
     echo s:URI.new(BASE_URI).relative(RELATIVE_URI).to_string()
-    " => http://example.com/foo/baz
+    " => 'http://example.com/foo/baz'
 <
 *Vital.Web.URI-URI.canonicalize()*
 canonicalize()
@@ -183,7 +195,7 @@ canonicalize()
     Example: >
     let s:URI = vital#of('vital').import('Web.URI')
     echo s:URI.new('http://example.com:80/').to_string()
-    " => http://example.com/
+    " => 'http://example.com/'
 <
 *Vital.Web.URI-URI.default_port()*
 default_port()

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -109,7 +109,7 @@ Describe Web.URI
     " * http://example.com:/
     " * http://example.com:80/
     Describe .canonicalize()
-      It canonicalizes given URI
+      It canonicalizes given http URL
         for [input, expected] in [
         \ ['http://example.com', 'http://example.com/'],
         \ ['http://example.com/', 'http://example.com/'],
@@ -117,6 +117,20 @@ Describe Web.URI
         \ ['http://example.com:80/', 'http://example.com/'],
         \ ['http://example.com:80', 'http://example.com/'],
         \ ['http://example.com:8080/', 'http://example.com:8080/'],
+        \]
+            let got = URI.new(input).canonicalize().to_string()
+            Assert Equals(got, expected)
+        endfor
+      End
+
+      It canonicalizes given https URL
+        for [input, expected] in [
+        \ ['https://example.com', 'https://example.com/'],
+        \ ['https://example.com/', 'https://example.com/'],
+        \ ['https://example.com:/', 'https://example.com/'],
+        \ ['https://example.com:443/', 'https://example.com/'],
+        \ ['https://example.com:443', 'https://example.com/'],
+        \ ['https://example.com:8443/', 'https://example.com:8443/'],
         \]
             let got = URI.new(input).canonicalize().to_string()
             Assert Equals(got, expected)

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -167,6 +167,15 @@ Describe Web.URI
     End
   End
 
+  Describe .clone()
+    It clones self
+      let uri = URI.new('http://example.com/')
+      let copyuri = uri.clone().relative('/a/b/c')
+      Assert Equals(uri.to_string(), 'http://example.com/')
+      Assert Equals(copyuri.to_string(), 'http://example.com/a/b/c')
+    End
+  End
+
   " The following four URIs are equivalent:
   " * http://example.com
   " * http://example.com/

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -115,12 +115,58 @@ Describe Web.URI
         \ ['http://example.com/', 'http://example.com/'],
         \ ['http://example.com:/', 'http://example.com/'],
         \ ['http://example.com:80/', 'http://example.com/'],
+        \ ['http://example.com:80', 'http://example.com/'],
         \ ['http://example.com:8080/', 'http://example.com:8080/'],
         \]
             let got = URI.new(input).canonicalize().to_string()
             Assert Equals(got, expected)
         endfor
       End
+    End
+
+    It resolves relative URI
+      for [base, rel, expected] in [
+      \ ['http://example.com/', '/a/b/c', 'http://example.com/a/b/c'],
+      \ ['http://example.com', '/a/b/c', 'http://example.com/a/b/c'],
+      \ ['http://example.com/', 'a/b/c', 'http://example.com/a/b/c'],
+      \ ['http://example.com', 'a/b/c', 'http://example.com/a/b/c'],
+      \
+      \ ['http://example.com/', '../d', 'http://example.com/d'],
+      \ ['http://example.com/', '/../d', 'http://example.com/d'],
+      \ ['http://example.com/', 'd/../e', 'http://example.com/e'],
+      \ ['http://example.com/', 'd/e/../../f', 'http://example.com/f'],
+      \ ['http://example.com/', 'd/..', 'http://example.com/'],
+      \ ['http://example.com/', 'd/../', 'http://example.com/'],
+      \ ['http://example.com/', 'd/e/../..', 'http://example.com/'],
+      \
+      \ ['http://example.com/a/b/c', '../d', 'http://example.com/a/d'],
+      \ ['http://example.com/a/b/c', '/../d', 'http://example.com/d'],
+      \ ['http://example.com/a/b/c', 'd/../e', 'http://example.com/a/b/e'],
+      \ ['http://example.com/a/b/c', 'd/e/../../f', 'http://example.com/a/b/f'],
+      \ ['http://example.com/a/b/c', 'd/..', 'http://example.com/a/b/'],
+      \ ['http://example.com/a/b/c', 'd/../', 'http://example.com/a/b/'],
+      \ ['http://example.com/a/b/c', 'd/e/../..', 'http://example.com/a/b/'],
+      \
+      \ ['http://example.com/', './d', 'http://example.com/d'],
+      \ ['http://example.com/', '/./d', 'http://example.com/d'],
+      \ ['http://example.com/', 'd/./e', 'http://example.com/d/e'],
+      \ ['http://example.com/', 'd/././e', 'http://example.com/d/e'],
+      \ ['http://example.com/', 'd/.', 'http://example.com/d/'],
+      \ ['http://example.com/', 'd/./', 'http://example.com/d/'],
+      \ ['http://example.com/', 'd/./.', 'http://example.com/d/'],
+      \
+      \ ['http://example.com/a/b/c', './d', 'http://example.com/a/b/d'],
+      \ ['http://example.com/a/b/c', '/./d', 'http://example.com/d'],
+      \ ['http://example.com/a/b/c', 'd/./e', 'http://example.com/a/b/d/e'],
+      \ ['http://example.com/a/b/c', 'd/././e', 'http://example.com/a/b/d/e'],
+      \ ['http://example.com/a/b/c', 'd/.', 'http://example.com/a/b/d/'],
+      \ ['http://example.com/a/b/c', 'd/./', 'http://example.com/a/b/d/'],
+      \ ['http://example.com/a/b/c', 'd/./.', 'http://example.com/a/b/d/'],
+      \]
+        let got = URI.new(base).relative(rel).to_string()
+        let msg = printf('base:%s, rel:%s', base, rel)
+        Assert Equals(got, expected, msg)
+      endfor
     End
   End
 

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -102,6 +102,26 @@ Describe Web.URI
       Assert Equals(uri.path(), '/pub/vim/unix/vim-7.4.tar.bz2')
       Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/pub/vim/unix/vim-7.4.tar.bz2')
     End
+
+    " The following four URIs are equivalent:
+    " * http://example.com
+    " * http://example.com/
+    " * http://example.com:/
+    " * http://example.com:80/
+    Describe .canonicalize()
+      It canonicalizes given URI
+        for [input, expected] in [
+        \ ['http://example.com', 'http://example.com/'],
+        \ ['http://example.com/', 'http://example.com/'],
+        \ ['http://example.com:/', 'http://example.com/'],
+        \ ['http://example.com:80/', 'http://example.com/'],
+        \ ['http://example.com:8080/', 'http://example.com:8080/'],
+        \]
+            let got = URI.new(input).canonicalize().to_string()
+            Assert Equals(got, expected)
+        endfor
+      End
+    End
   End
 
   Describe .new_from_uri_like_string()

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -26,12 +26,12 @@ Describe Web.URI
       Assert Equals(uri.userinfo(), '')
       Assert Equals(uri.host(), 'example.com')
       Assert Equals(uri.port(), '')
-      Assert Equals(uri.path(), '/')
+      Assert Equals(uri.path(), '')
       Assert Equals(uri.authority(), 'example.com')
-      Assert Equals(uri.opaque(), '//example.com/')
+      Assert Equals(uri.opaque(), '//example.com')
       Assert Equals(uri.query(), '')
       Assert Equals(uri.fragment(), '')
-      Assert Equals(uri.to_string(), 'http://example.com/')
+      Assert Equals(uri.to_string(), 'http://example.com')
     End
 
     It allows empty authority (:help Vital.Web.URI-notes)
@@ -98,11 +98,6 @@ Describe Web.URI
       call uri.host('ftp.vim.org')
       Assert Equals(uri.host(), 'ftp.vim.org')
       Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/')
-      " uri.path({str}) prepends '/' if {str} doesn't have it.
-      call uri.path('pub/vim/unix/vim-7.3.tar.bz2')
-      Assert Equals(uri.path(), '/pub/vim/unix/vim-7.3.tar.bz2')
-      Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/pub/vim/unix/vim-7.3.tar.bz2')
-      " uri.path({str}) doesn't prepend '/' if {str} has it.
       call uri.path('/pub/vim/unix/vim-7.4.tar.bz2')
       Assert Equals(uri.path(), '/pub/vim/unix/vim-7.4.tar.bz2')
       Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/pub/vim/unix/vim-7.4.tar.bz2')
@@ -116,7 +111,7 @@ Describe Web.URI
 
       Assert NotEquals(URI.new_from_uri_like_string('localhost', 'Error!'), 'Error!')
       Assert Equals(URI.new_from_uri_like_string('example.com/').to_string(), 'http://example.com/')
-      Assert Equals(URI.new_from_uri_like_string('example.com').to_string(), 'http://example.com/')
+      Assert Equals(URI.new_from_uri_like_string('example.com').to_string(), 'http://example.com')
       Assert Equals(URI.new_from_uri_like_string('/home/tyru').to_string(), 'http:///home/tyru')
       Assert Equals(URI.new_from_uri_like_string('user:password@example.com:8080/path/for/test?q=query#fragment').to_string(), 'http://user:password@example.com:8080/path/for/test?q=query#fragment')
       Assert Equals(URI.new_from_uri_like_string('http://198.51.100.1/').to_string(), 'http://198.51.100.1/')
@@ -134,7 +129,7 @@ Describe Web.URI
       \  ['http://example.com/ blah blah',
       \    ['http://example.com/', 'http://example.com/', ' blah blah']],
       \  ['http://example.com gera gera',
-      \    ['http://example.com/', 'http://example.com', ' gera gera']],
+      \    ['http://example.com', 'http://example.com', ' gera gera']],
       \  ['file:///home/tyru   # My home directory',
       \    ['file:///home/tyru', 'file:///home/tyru',
       \     '   # My home directory']],
@@ -170,7 +165,7 @@ Describe Web.URI
     It allows to ignore some characters (:help Vital.Web.URI-PatternSet)
       for [input, expected] in [
       \  ['http://example.com)',
-      \    ['http://example.com/', 'http://example.com', ')']],
+      \    ['http://example.com', 'http://example.com', ')']],
       \  ['https://en.wikipedia.org/wiki/Markdown)',
       \    ['https://en.wikipedia.org/wiki/Markdown', 'https://en.wikipedia.org/wiki/Markdown', ')']],
       \  ['http://example.com/?q=query)',
@@ -179,7 +174,7 @@ Describe Web.URI
       \    ['http://example.com/#fragment', 'http://example.com/#fragment', ')']],
       \
       \  ["http://example.com'",
-      \    ['http://example.com/', 'http://example.com', "'"]],
+      \    ['http://example.com', 'http://example.com', "'"]],
       \  ["https://github.com/Lokaltog/vim-easymotion'",
       \    ['https://github.com/Lokaltog/vim-easymotion', 'https://github.com/Lokaltog/vim-easymotion', "'"]],
       \  ["http://example.com/?q=query'",

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -68,12 +68,12 @@ Describe Web.URI
       Assert Equals(uri.userinfo(), '')
       Assert Equals(uri.host(), '203.0.113.11')
       Assert Equals(uri.port(), '')
-      Assert Equals(uri.path(), '/')
+      Assert Equals(uri.path(), '')
       Assert Equals(uri.authority(), '203.0.113.11')
-      Assert Equals(uri.opaque(), '//203.0.113.11/')
+      Assert Equals(uri.opaque(), '//203.0.113.11')
       Assert Equals(uri.query(), '')
       Assert Equals(uri.fragment(), '')
-      Assert Equals(uri.to_string(), 'http://203.0.113.11/')
+      Assert Equals(uri.to_string(), 'http://203.0.113.11')
     End
 
     It parses a complex URL

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -102,42 +102,25 @@ Describe Web.URI
       Assert Equals(uri.path(), '/pub/vim/unix/vim-7.4.tar.bz2')
       Assert Equals(uri.to_string(), 'ftp://ftp.vim.org/pub/vim/unix/vim-7.4.tar.bz2')
     End
+  End
 
-    " The following four URIs are equivalent:
-    " * http://example.com
-    " * http://example.com/
-    " * http://example.com:/
-    " * http://example.com:80/
-    Describe .canonicalize()
-      It canonicalizes given http URL
-        for [input, expected] in [
-        \ ['http://example.com', 'http://example.com/'],
-        \ ['http://example.com/', 'http://example.com/'],
-        \ ['http://example.com:/', 'http://example.com/'],
-        \ ['http://example.com:80/', 'http://example.com/'],
-        \ ['http://example.com:80', 'http://example.com/'],
-        \ ['http://example.com:8080/', 'http://example.com:8080/'],
-        \]
-            let got = URI.new(input).canonicalize().to_string()
-            Assert Equals(got, expected)
-        endfor
-      End
+  Describe .new_from_uri_like_string()
+    It parses valid URIs
+      Throws URI.new_from_uri_like_string('local[host]')
+      Assert Equals(URI.new_from_uri_like_string('local[host]', 'Error!'), 'Error!')
 
-      It canonicalizes given https URL
-        for [input, expected] in [
-        \ ['https://example.com', 'https://example.com/'],
-        \ ['https://example.com/', 'https://example.com/'],
-        \ ['https://example.com:/', 'https://example.com/'],
-        \ ['https://example.com:443/', 'https://example.com/'],
-        \ ['https://example.com:443', 'https://example.com/'],
-        \ ['https://example.com:8443/', 'https://example.com:8443/'],
-        \]
-            let got = URI.new(input).canonicalize().to_string()
-            Assert Equals(got, expected)
-        endfor
-      End
+      Assert NotEquals(URI.new_from_uri_like_string('localhost', 'Error!'), 'Error!')
+      Assert Equals(URI.new_from_uri_like_string('example.com/').to_string(), 'http://example.com/')
+      Assert Equals(URI.new_from_uri_like_string('example.com').to_string(), 'http://example.com')
+      Assert Equals(URI.new_from_uri_like_string('/home/tyru').to_string(), 'http:///home/tyru')
+      Assert Equals(URI.new_from_uri_like_string('user:password@example.com:8080/path/for/test?q=query#fragment').to_string(), 'http://user:password@example.com:8080/path/for/test?q=query#fragment')
+      Assert Equals(URI.new_from_uri_like_string('http://198.51.100.1/').to_string(), 'http://198.51.100.1/')
+      Assert Equals(URI.new_from_uri_like_string('http://198.51.100.22/').to_string(), 'http://198.51.100.22/')
+      Assert Equals(URI.new_from_uri_like_string('http://198.51.100.199/').to_string(), 'http://198.51.100.199/')
     End
+  End
 
+  Describe .relative()
     It resolves relative URI
       for [base, rel, expected] in [
       \ ['http://example.com/', '/a/b/c', 'http://example.com/a/b/c'],
@@ -184,19 +167,38 @@ Describe Web.URI
     End
   End
 
-  Describe .new_from_uri_like_string()
-    It parses valid URIs
-      Throws URI.new_from_uri_like_string('local[host]')
-      Assert Equals(URI.new_from_uri_like_string('local[host]', 'Error!'), 'Error!')
+  " The following four URIs are equivalent:
+  " * http://example.com
+  " * http://example.com/
+  " * http://example.com:/
+  " * http://example.com:80/
+  Describe .canonicalize()
+    It canonicalizes given http URL
+      for [input, expected] in [
+      \ ['http://example.com', 'http://example.com/'],
+      \ ['http://example.com/', 'http://example.com/'],
+      \ ['http://example.com:/', 'http://example.com/'],
+      \ ['http://example.com:80/', 'http://example.com/'],
+      \ ['http://example.com:80', 'http://example.com/'],
+      \ ['http://example.com:8080/', 'http://example.com:8080/'],
+      \]
+          let got = URI.new(input).canonicalize().to_string()
+          Assert Equals(got, expected)
+      endfor
+    End
 
-      Assert NotEquals(URI.new_from_uri_like_string('localhost', 'Error!'), 'Error!')
-      Assert Equals(URI.new_from_uri_like_string('example.com/').to_string(), 'http://example.com/')
-      Assert Equals(URI.new_from_uri_like_string('example.com').to_string(), 'http://example.com')
-      Assert Equals(URI.new_from_uri_like_string('/home/tyru').to_string(), 'http:///home/tyru')
-      Assert Equals(URI.new_from_uri_like_string('user:password@example.com:8080/path/for/test?q=query#fragment').to_string(), 'http://user:password@example.com:8080/path/for/test?q=query#fragment')
-      Assert Equals(URI.new_from_uri_like_string('http://198.51.100.1/').to_string(), 'http://198.51.100.1/')
-      Assert Equals(URI.new_from_uri_like_string('http://198.51.100.22/').to_string(), 'http://198.51.100.22/')
-      Assert Equals(URI.new_from_uri_like_string('http://198.51.100.199/').to_string(), 'http://198.51.100.199/')
+    It canonicalizes given https URL
+      for [input, expected] in [
+      \ ['https://example.com', 'https://example.com/'],
+      \ ['https://example.com/', 'https://example.com/'],
+      \ ['https://example.com:/', 'https://example.com/'],
+      \ ['https://example.com:443/', 'https://example.com/'],
+      \ ['https://example.com:443', 'https://example.com/'],
+      \ ['https://example.com:8443/', 'https://example.com:8443/'],
+      \]
+          let got = URI.new(input).canonicalize().to_string()
+          Assert Equals(got, expected)
+      endfor
     End
   End
 

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -245,7 +245,7 @@ Describe Web.URI
       " Define loose pattern set.
       let pattern_set = URI.new_default_pattern_set()
 
-      " Remove "'", "(", ")" from default sub_delims().
+      " Remove "'", '(', ')' from default sub_delims().
       function! pattern_set.sub_delims() abort
           return '[!$&*+,;=]'
       endfunction


### PR DESCRIPTION
#364 を実装しました。

- `s:URI.clone()`
- `s:URI.relative({reluri})`

以下のコードはhelpより抜粋しました。

```viml
let s:URI = vital#of('vital').import('Web.URI')
let uri = s:URI.new('http://example.com/')
let copyuri = uri.clone().relative('/a/b/c')
echo uri.to_string()
" => 'http://example.com/'
echo copyuri.to_string()
" => 'http://example.com/a/b/c'
```
