### PR TITLE
Improve vital loader (fix #137)

### DIFF
--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -1,5 +1,6 @@
 let s:self_version = expand('<sfile>:t:r')
 let s:self_file = expand('<sfile>')
+let s:base_dir = expand('<sfile>:h')
 
 let s:loaded = {}
 let s:cache_module_path = {}
@@ -9,6 +10,11 @@ let s:_unify_path_cache = {}
 
 function! s:_vital_created(module) abort
   let a:module.vital_files = s:_vital_files()
+endfunction
+
+function! s:plugin_name() abort
+  let info_file = get(split(glob(s:base_dir . '/*.vital', 1), "\n"), 0, '')
+  return fnamemodify(info_file, ':t:r')
 endfunction
 
 function! s:import(name, ...) dict abort

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -13,6 +13,10 @@ function! s:plugin_name() abort
   return fnamemodify(info_file, ':t:r')
 endfunction
 
+function! s:vital_files() abort
+  return copy(s:vital_files)
+endfunction
+
 function! s:import(name, ...) abort
   let target = {}
   let functions = []

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -168,9 +168,7 @@ endif
 
 function! s:_self_vital_files() abort
   let base = fnamemodify(s:self_file, ':h') . '/*/**/*.vim'
-  let files = split(glob(base, 1), "\n")
-  let mod = ':p:gs?[\\/]\+?/?'
-  return map(files, 'fnamemodify(v:val, mod)')
+  return split(glob(base, 1), "\n")
 endfunction
 
 function! s:_global_vital_files() abort
@@ -179,9 +177,11 @@ function! s:_global_vital_files() abort
 endfunction
 
 let s:vital_files =
-\   s:plugin_name() ==# 'vital'
-\     ? s:_global_vital_files()
-\     : s:_self_vital_files()
+\   map(
+\     s:plugin_name() ==# 'vital'
+\       ? s:_global_vital_files()
+\       : s:_self_vital_files(),
+\     'fnamemodify(v:val, ":p:gs?[\\\\/]?/?")')
 
 function! s:_extract_files(pattern, files) abort
   let tr = {'.': '/', '*': '[^/]*', '**': '.*'}

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -171,7 +171,7 @@ else
 endif
 
 function! s:_self_vital_files() abort
-  let base = fnamemodify(s:self_file, ':h') . '/*/**/*.vim'
+  let base = s:base_dir . '/*/**/*.vim'
   return split(glob(base, 1), "\n")
 endfunction
 

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -111,9 +111,7 @@ function! s:_get_module_path(name) abort
   if s:_is_absolute_path(a:name) && filereadable(a:name)
     return a:name
   endif
-  if a:name ==# ''
-    let paths = [s:self_file]
-  elseif a:name =~# '\v^\u\w*%(\.\u\w*)*$'
+  if a:name =~# '\v^\u\w*%(\.\u\w*)*$'
     let paths = s:_extract_files(a:name, s:vital_files)
   else
     throw 'vital: Invalid module name: ' . a:name
@@ -278,5 +276,6 @@ function! s:_redir(cmd) abort
 endfunction
 
 function! vital#{s:self_version}#new() abort
-  return s:_import('')
+  let sid = s:_get_sid_by_script(s:self_file)
+  return s:_build_module(sid)
 endfunction

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -167,14 +167,10 @@ else
 endif
 
 function! s:_self_vital_files() abort
-  if exists('s:_vital_files_cache')
-    return copy(s:_vital_files_cache)
-  endif
   let base = fnamemodify(s:self_file, ':h') . '/*/**/*.vim'
   let files = split(glob(base, 1), "\n")
   let mod = ':p:gs?[\\/]\+?/?'
-  let s:_vital_files_cache = map(files, 'fnamemodify(v:val, mod)')
-  return copy(s:_vital_files_cache)
+  return map(files, 'fnamemodify(v:val, mod)')
 endfunction
 
 function! s:_global_vital_files() abort

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -79,30 +79,6 @@ function! s:search(pattern) abort
   return s:_uniq(modules)
 endfunction
 
-function! s:expand_modules(entry, all) abort
-  if type(a:entry) == type([])
-    let candidates = s:_concat(map(copy(a:entry), 's:search(v:val)'))
-    if empty(candidates)
-      throw printf('vital: Any of module %s is not found', string(a:entry))
-    endif
-    if eval(join(map(copy(candidates), 'has_key(a:all, v:val)'), '+'))
-      let modules = []
-    else
-      let modules = [candidates[0]]
-    endif
-  else
-    let modules = s:search(a:entry)
-    if empty(modules)
-      throw printf('vital: Module %s is not found', a:entry)
-    endif
-  endif
-  call filter(modules, '!has_key(a:all, v:val)')
-  for module in modules
-    let a:all[module] = 1
-  endfor
-  return modules
-endfunction
-
 function! s:_import(name) abort
   if type(a:name) == type(0)
     return s:_build_module(a:name)
@@ -285,14 +261,6 @@ else
     return a:list
   endfunction
 endif
-
-function! s:_concat(lists) abort
-  let result_list = []
-  for list in a:lists
-    let result_list += list
-  endfor
-  return result_list
-endfunction
 
 function! s:_redir(cmd) abort
   let [save_verbose, save_verbosefile] = [&verbose, &verbosefile]

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -9,7 +9,7 @@ let s:cache_sid = {}
 let s:_unify_path_cache = {}
 
 function! s:_vital_created(module) abort
-  let a:module.vital_files = s:_vital_files()
+  let a:module.vital_files = copy(s:vital_files)
 endfunction
 
 function! s:plugin_name() abort
@@ -172,7 +172,7 @@ else
   endfunction
 endif
 
-function! s:_vital_files() abort
+function! s:_self_vital_files() abort
   if exists('s:_vital_files_cache')
     return copy(s:_vital_files_cache)
   endif
@@ -182,6 +182,16 @@ function! s:_vital_files() abort
   let s:_vital_files_cache = map(files, 'fnamemodify(v:val, mod)')
   return copy(s:_vital_files_cache)
 endfunction
+
+function! s:_global_vital_files() abort
+  let pattern = 'autoload/vital/__latest__/**/*.vim'
+  return split(globpath(&runtimepath, pattern, 1), "\n")
+endfunction
+
+let s:vital_files =
+\   s:plugin_name() ==# 'vital'
+\     ? s:_global_vital_files()
+\     : s:_self_vital_files()
 
 function! s:_extract_files(pattern, files) abort
   let tr = {'.': '/', '*': '[^/]*', '**': '.*'}

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -8,16 +8,12 @@ let s:cache_sid = {}
 
 let s:_unify_path_cache = {}
 
-function! s:_vital_created(module) abort
-  let a:module.vital_files = copy(s:vital_files)
-endfunction
-
 function! s:plugin_name() abort
   let info_file = get(split(glob(s:base_dir . '/*.vital', 1), "\n"), 0, '')
   return fnamemodify(info_file, ':t:r')
 endfunction
 
-function! s:import(name, ...) dict abort
+function! s:import(name, ...) abort
   let target = {}
   let functions = []
   for a in a:000
@@ -28,7 +24,7 @@ function! s:import(name, ...) dict abort
     endif
     unlet a
   endfor
-  let module = s:_import(a:name, self.vital_files)
+  let module = s:_import(a:name)
   if empty(functions)
     call extend(target, module, 'keep')
   else
@@ -61,7 +57,7 @@ function! s:load(...) dict abort
     endwhile
 
     if exists('dict')
-      call extend(dict, s:_import(name, self.vital_files))
+      call extend(dict, s:_import(name))
     endif
     unlet arg
   endfor
@@ -74,21 +70,21 @@ function! s:unload() abort
   let s:cache_module_path = {}
 endfunction
 
-function! s:exists(name) dict abort
-  return s:_get_module_path(a:name, self.vital_files) !=# ''
+function! s:exists(name) abort
+  return s:_get_module_path(a:name) !=# ''
 endfunction
 
-function! s:search(pattern) dict abort
-  let paths = s:_extract_files(a:pattern, self.vital_files)
+function! s:search(pattern) abort
+  let paths = s:_extract_files(a:pattern, s:vital_files)
   let modules = sort(map(paths, 's:_file2module(v:val)'))
   return s:_uniq(modules)
 endfunction
 
-function! s:_import(name, vital_files) abort
+function! s:_import(name) abort
   if type(a:name) == type(0)
     return s:_build_module(a:name)
   endif
-  let path = s:_get_module_path(a:name, a:vital_files)
+  let path = s:_get_module_path(a:name)
   if path ==# ''
     throw 'vital: module not found: ' . a:name
   endif
@@ -107,7 +103,7 @@ function! s:_import(name, vital_files) abort
   return s:_build_module(sid)
 endfunction
 
-function! s:_get_module_path(name, vital_files) abort
+function! s:_get_module_path(name) abort
   let key = a:name . '_'
   if has_key(s:cache_module_path, key)
     return s:cache_module_path[key]
@@ -118,7 +114,7 @@ function! s:_get_module_path(name, vital_files) abort
   if a:name ==# ''
     let paths = [s:self_file]
   elseif a:name =~# '\v^\u\w*%(\.\u\w*)*$'
-    let paths = s:_extract_files(a:name, a:vital_files)
+    let paths = s:_extract_files(a:name, s:vital_files)
   else
     throw 'vital: Invalid module name: ' . a:name
   endif
@@ -282,5 +278,5 @@ function! s:_redir(cmd) abort
 endfunction
 
 function! vital#{s:self_version}#new() abort
-  return s:_import('', [s:self_file])
+  return s:_import('')
 endfunction

--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -209,8 +209,8 @@ function! s:_vital_files(pattern) abort
     call map(s:_vital_files_cache, 'fnamemodify(v:val, mod)')
     let s:_vital_files_cache_runtimepath = &runtimepath
   endif
-  let target = substitute(a:pattern, '\.', '/', 'g')
-  let target = substitute(target, '\*', '[^/]*', 'g')
+  let tr = {'.': '/', '*': '[^/]*', '**': '.*'}
+  let target = substitute(a:pattern, '\.\|\*\*\?', '\=tr[submatch(0)]', 'g')
   let regexp = printf('autoload/vital/%s/%s.vim', s:self_version, target)
   return filter(copy(s:_vital_files_cache), 'v:val =~# regexp')
 endfunction

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -9,10 +9,12 @@ let s:UNDEFINED = function('s:undefined')
 
 function! s:_vital_created(module) abort
   " define constant variables
-  let s:const = {}
-  let s:const.is_local_variable_supported =
-      \ v:version > 703 || (v:version == 703 && has('patch560'))
-  lockvar s:const
+  if !exists('s:const')
+    let s:const = {}
+    let s:const.is_local_variable_supported =
+        \ v:version > 703 || (v:version == 703 && has('patch560'))
+    lockvar s:const
+  endif
   call extend(a:module, s:const)
 endfunction
 function! s:_throw(msg) abort

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -93,7 +93,6 @@ function! s:search_dependence(depends_info) abort
   let g:vital_debug = 1
   let V = vital#of('vital')
   call V.unload()
-  let V.vital_files = s:available_module_files()
   let all = {}
   let data_files = []
   let entries = copy(a:depends_info)

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -337,19 +337,11 @@ function! vitalizer#vitalize(name, to, modules, hash) abort
         endif
       endfor
     endif
+    let action = 'install'  " TODO: We need --uninstall option
     let initial_install = !isdirectory(s:FP.join(a:to, 'autoload', 'vital'))
     if empty(installing_modules) && !initial_install
-      if confirm('vitalizer: Are you sure you want to uninstall vital?', "&Yes\n&No") == 2
-        return {
-        \ 'action': 'canceled',
-        \ 'prev_hash': '',
-        \ 'installed_hash': '',
-        \}
-      endif
-      let action = 'uninstall'
       let files = []
     else
-      let action = 'install'
       let installing_modules = s:L.uniq(installing_modules)
       let files = s:search_dependence(installing_modules)
     endif

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -91,8 +91,7 @@ function! s:search_dependence(depends_info) abort
     let vital_debug = g:vital_debug
   endif
   let g:vital_debug = 1
-  let V = vital#of('vital')
-  call V.unload()
+  call s:V.unload()
   let all = {}
   let data_files = []
   let entries = copy(a:depends_info)
@@ -101,10 +100,10 @@ function! s:search_dependence(depends_info) abort
     unlet! entry
     let entry = remove(entries, 0)
 
-    let modules = s:expand_modules(V, entry, all)
+    let modules = s:expand_modules(s:V, entry, all)
 
     for module in modules
-      let M = V.import(module)
+      let M = s:V.import(module)
       if has_key(M, '_vital_depends')
         let depends = M._vital_depends()
         if s:P.is_dict(depends)

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -70,7 +70,9 @@ function! s:search_dependence(depends_info) abort
     let vital_debug = g:vital_debug
   endif
   let g:vital_debug = 1
-  call s:V.unload()
+  let V = vital#of('vital')
+  call V.unload()
+  let V.vital_files = s:available_module_files()
   let all = {}
   let data_files = []
   let entries = copy(a:depends_info)
@@ -79,10 +81,10 @@ function! s:search_dependence(depends_info) abort
     unlet! entry
     let entry = remove(entries, 0)
 
-    let modules = s:expand_modules(entry, all)
+    let modules = s:expand_modules(V, entry, all)
 
     for module in modules
-      let M = s:V.import(module)
+      let M = V.import(module)
       if has_key(M, '_vital_depends')
         let depends = M._vital_depends()
         if s:P.is_dict(depends)
@@ -112,7 +114,7 @@ function! s:search_dependence(depends_info) abort
   return sort(map(keys(all), 's:module2file(v:val)') + data_files)
 endfunction
 
-function! s:expand_modules(entry, all) abort
+function! s:expand_modules(V, entry, all) abort
   if type(a:entry) == type([])
     let candidates = s:L.concat(map(copy(a:entry), 's:search(v:val)'))
     if empty(candidates)
@@ -124,7 +126,7 @@ function! s:expand_modules(entry, all) abort
       let modules = [candidates[0]]
     endif
   else
-    let modules = s:V.search(a:entry)
+    let modules = a:V.search(a:entry)
     if empty(modules)
       throw printf('vital: Module %s is not found', a:entry)
     endif

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -82,7 +82,7 @@ function! s:search_dependence(depends_info) abort
     let modules = s:expand_modules(entry, all)
 
     for module in modules
-      let M = s:V.import(module, 1)
+      let M = s:V.import(module)
       if has_key(M, '_vital_depends')
         let depends = M._vital_depends()
         if s:P.is_dict(depends)

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -79,7 +79,7 @@ function! s:search_dependence(depends_info) abort
     unlet! entry
     let entry = remove(entries, 0)
 
-    let modules = s:V.expand_modules(entry, all)
+    let modules = s:expand_modules(entry, all)
 
     for module in modules
       let M = s:V.import(module, 1)
@@ -110,6 +110,30 @@ function! s:search_dependence(depends_info) abort
     let g:vital_debug = vital_debug
   endif
   return sort(map(keys(all), 's:module2file(v:val)') + data_files)
+endfunction
+
+function! s:expand_modules(entry, all) abort
+  if type(a:entry) == type([])
+    let candidates = s:L.concat(map(copy(a:entry), 's:search(v:val)'))
+    if empty(candidates)
+      throw printf('vital: Any of module %s is not found', string(a:entry))
+    endif
+    if eval(join(map(copy(candidates), 'has_key(a:all, v:val)'), '+'))
+      let modules = []
+    else
+      let modules = [candidates[0]]
+    endif
+  else
+    let modules = s:V.search(a:entry)
+    if empty(modules)
+      throw printf('vital: Module %s is not found', a:entry)
+    endif
+  endif
+  call filter(modules, '!has_key(a:all, v:val)')
+  for module in modules
+    let a:all[module] = 1
+  endfor
+  return modules
 endfunction
 
 function! s:is_camel_case(str) abort

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -177,13 +177,8 @@ function! s:file2module(file) abort
   return join(split(tail, '[\\/]\+'), '.')
 endfunction
 
-function! s:available_module_files() abort
-  let pattern = 'autoload/vital/__latest__/**/*.vim'
-  return split(globpath(&runtimepath, pattern, 1), "\n")
-endfunction
-
 function! s:available_module_names() abort
-  return sort(s:L.uniq(filter(map(s:available_module_files(),
+  return sort(s:L.uniq(filter(map(s:V.vital_files(),
   \          's:file2module(v:val)'), 's:is_module_name(v:val)')))
 endfunction
 

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -155,9 +155,13 @@ function! s:file2module(file) abort
   return join(split(tail, '[\\/]\+'), '.')
 endfunction
 
+function! s:available_module_files() abort
+  let pattern = 'autoload/vital/__latest__/**/*.vim'
+  return split(globpath(&runtimepath, pattern, 1), "\n")
+endfunction
+
 function! s:available_module_names() abort
-  return sort(s:L.uniq(filter(map(split(globpath(&runtimepath,
-  \          'autoload/vital/__latest__/**/*.vim', 1), "\n"),
+  return sort(s:L.uniq(filter(map(s:available_module_files(),
   \          's:file2module(v:val)'), 's:is_module_name(v:val)')))
 endfunction
 

--- a/doc/vital.txt
+++ b/doc/vital.txt
@@ -96,10 +96,14 @@ Vital.exists({module-name})		*Vital-Vital.exists()*
 
 Vital.search({pattern})			*Vital-Vital.search()*
 	Searches available modules.  Returns module names by |List|.
-	Wildcard '*' is available in {pattern}.
+	Wildcard '*' is available in {pattern}.  This matches to any strings
+	in the part of module name that excludes ".".
+	Wildcard '**' is available in {pattern}.  This is similar to '*' but
+	also matches to ".".
 >
 	echo s:V.search('Data.*')
 	echo s:V.search('Data.*List')
+	echo s:V.search('**')  " returns all available module names
 
 
 


### PR DESCRIPTION
vital のローダーの改善です。かなりあちこちいじりましたが、大きな変更点は 3 つあります。

1. #137 の解決

  プラグイン内に `autoload/vital/__latest__` を置いておけば、この中身は `:Vitalize` しなくても使えるようになります。(ローダー自体を入れるため、`:Vitalize` 自体は必要になります。)

2. ロードの高速化

  昔の vital は、`runtimepath` 中の同じバージョンの vital を共有するために、`runtimepath` 内の全てのファイルを探していました。
  今は事情が変わっていて、各プラグインは自分用にファイルを持っていて、それだけを使うようになっています。
  もはやロード時に `runtimepath` を捜査するのは無駄であるので、自分自身が持っているファイルのみを探すようにしました。
  計測はしていないので申し訳ないんですが、`runtimepath` が大きい人ほど相対的にロード処理が速くなるはずです。

3. vital のモジュール一覧の保存位置の変更

  上記2つを解決するために、プラグインが普段使う vital のモジュールファイルの一覧と、vitalizer が使うモジュールファイルの一覧を変える必要がありました。vitalizer は相変わらず `runtimepath` からファイルの一覧を探すからです。
  そこで、ちょっとトリッキーな構造になってしまいましたが、`vital#of()` で得られる vital loader のオブジェクト自体にファイルの一覧を置き、`vitalizer` は使用時にこの一覧を置き換える形にしました。
  各モジュール関数が `dict` 関数になってしまうので正直微妙な感じもするのですが、とりあえず困ることはないだろうという妥協案です。

軽く動作確認はしましたが、十分ではないと思うので、できれば色々試してみて欲しいです。
速度に関しても、逆に遅くなっていないかなど検証結果募集中です。