### PR TITLE
Vim.Buffer: Fix read_content()/edit_content() for a terminal empty line

### DIFF
--- a/autoload/vital/__latest__/Vim/Buffer.vim
+++ b/autoload/vital/__latest__/Vim/Buffer.vim
@@ -111,7 +111,7 @@ function! s:read_content(content, ...) abort
         \]
   let optname = join(filter(optnames, '!empty(v:val)'))
   try
-    call writefile(a:content, tempfile, 'b')
+    call writefile(a:content, tempfile)
     execute printf('keepalt keepjumps read %s%s',
           \ empty(optname) ? '' : optname . ' ',
           \ fnameescape(tempfile),


### PR DESCRIPTION
writefile({content}, {filename}, 'b') eliminates a terminal empty line so 'b' should not be used.

https://gist.github.com/lambdalisue/930d46ba2a9a969c4e93#file-test-vim

Before: The script above show "no difference"
After : The script above correctly show the difference

Close #384