### PR TITLE
System.Filepath: Add contains({path}, {base})

### DIFF
--- a/autoload/vital/__latest__/System/Filepath.vim
+++ b/autoload/vital/__latest__/System/Filepath.vim
@@ -12,6 +12,7 @@ let s:is_cygwin = has('win32unix')
 let s:is_mac = !s:is_windows && !s:is_cygwin
       \ && (has('mac') || has('macunix') || has('gui_macvim') ||
       \   (!isdirectory('/proc') && executable('sw_vers')))
+let s:is_case_tolerant = filereadable(expand('<sfile>:r') . '.VIM')
 
 " Get the directory separator.
 function! s:separator() abort
@@ -167,7 +168,6 @@ endfunction
 
 " Return true if filesystem ignores alphabetic case of a filename.
 " Return false otherwise.
-let s:is_case_tolerant = filereadable(expand('<sfile>:r') . '.VIM')
 function! s:is_case_tolerant() abort
   return s:is_case_tolerant
 endfunction
@@ -226,12 +226,19 @@ function! s:contains(path, base) abort
   endif
   let pathlist = s:split(a:path)
   let baselist = s:split(a:base)
-  let min = min([len(pathlist), len(baselist)]) - 1
-  if len(pathlist) >=# len(baselist)
-    return min <# 0 ? 1 : (pathlist[: min] ==# baselist[: min])
-  else
+  let pathlistlen = len(pathlist)
+  let baselistlen = len(baselist)
+  if pathlistlen < baselistlen
     return 0
   endif
+  if baselistlen == 0
+    return 1
+  endif
+  if s:is_case_tolerant
+    call map(pathlist, 'tolower(v:val)')
+    call map(baselist, 'tolower(v:val)')
+  endif
+  return pathlist[: baselistlen - 1] ==# baselist
 endfunction
 
 let &cpo = s:save_cpo

--- a/autoload/vital/__latest__/System/Filepath.vim
+++ b/autoload/vital/__latest__/System/Filepath.vim
@@ -220,6 +220,16 @@ function! s:is_root_directory(path) abort
   return (has('win32') || has('win64')) && a:path =~# '^[a-zA-Z]:[/\\]$'
 endfunction
 
+function! s:contains(path, base) abort
+  let pathlist = s:split(a:path)
+  let baselist = s:split(a:base)
+  let min = min([len(pathlist), len(baselist)]) - 1
+  if min <# 0
+    return 0
+  endif
+  return pathlist[: min] ==# baselist[: min]
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 

--- a/autoload/vital/__latest__/System/Filepath.vim
+++ b/autoload/vital/__latest__/System/Filepath.vim
@@ -221,13 +221,17 @@ function! s:is_root_directory(path) abort
 endfunction
 
 function! s:contains(path, base) abort
+  if a:path ==# '' || a:base ==# ''
+    return 0
+  endif
   let pathlist = s:split(a:path)
   let baselist = s:split(a:base)
   let min = min([len(pathlist), len(baselist)]) - 1
-  if min <# 0
+  if len(pathlist) >=# len(baselist)
+    return min <# 0 ? 1 : (pathlist[: min] ==# baselist[: min])
+  else
     return 0
   endif
-  return pathlist[: min] ==# baselist[: min]
 endfunction
 
 let &cpo = s:save_cpo

--- a/doc/vital-system-filepath.txt
+++ b/doc/vital-system-filepath.txt
@@ -97,6 +97,14 @@ is_root_directory({path})	*Vital.System.Filepath.is_root_directory()*
 	is_root_directory('/aaa/..') == 0 " It doesn't resolve.
 	is_root_directory('C:/') == 1     " If it's on Windows.
 <
+contains({path}, {base})	*Vital.System.Filepath.contains()*
+	Return 1 if {path} contains {base}, otherwise 0.
+	{path} and {base} must be a full path.
+>
+	contains('/foo/bar/buz', '/foo/bar') == 1
+	contains('/foo/hoge/buz', '/foo/bar') == 0
+<
+
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -202,6 +202,17 @@ Describe System.Filepath
         let ret = s:FP.contains('', '/')
         Assert !ret
       End
+      It should ignore the last directory separator in {base} (Non Windows)
+        let ret = s:FP.contains('/foo', '/foo/')
+        Assert ret
+      End
+
+      Context in case-sensitive system
+        It should not ignore case
+          let ret = s:FP.contains('/etc/x11/xinit', '/etc/X11')
+          Assert !ret
+        End
+      End
     else
       It should return non-zero if C:\foo\bar contains C:\foo\bar (Windows)
         let ret = s:FP.contains('C:\foo\bar', 'C:\foo\bar')
@@ -238,6 +249,21 @@ Describe System.Filepath
         Assert !ret
         let ret = s:FP.contains('', 'C:\')
         Assert !ret
+      End
+      It should return non-zero if C:\ contains C:\ (Windows)
+        let ret = s:FP.contains('C:\', 'C:\')
+        Assert ret
+      End
+      It should ignore the last directory separator in {base} (Windows)
+        let ret = s:FP.contains('C:\foo', 'C:\foo\')
+        Assert ret
+      End
+
+      Context in case-insensitive system
+        It should ignore case
+          let ret = s:FP.contains('c:\program files\Vim', 'C:\Program Files')
+          Assert ret
+        End
       End
     endif
   End

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -165,41 +165,80 @@ Describe System.Filepath
   End
 
   Describe .contains()
-    It should return non-zero if /foo/bar contains /foo/bar
-      let ret = s:FP.contains('/foo/bar', '/foo/bar')
-      Assert ret
-    End
-    It should return non-zero if /foo/bar contains /foo
-      let ret = s:FP.contains('/foo/bar', '/foo')
-      Assert ret
-    End
-    It should return zero if /foo contains /foo/bar
-      let ret = s:FP.contains('/foo', '/foo/bar')
-      Assert !ret
-    End
-    It should return non-zero if /foo contains /foo
-      let ret = s:FP.contains('/foo', '/foo')
-      Assert ret
-    End
-    It should return non-zero if /foo contains /
-      let ret = s:FP.contains('/foo', '/')
-      Assert ret
-    End
-    It should return zero if / contains /foo
-      let ret = s:FP.contains('/', '/foo')
-      Assert !ret
-    End
-    It should return non-zero if / contains /
-      let ret = s:FP.contains('/', '/')
-      Assert ret
-    End
-    It should return zero for empty paths
-      let ret = s:FP.contains('', '')
-      Assert !ret
-      let ret = s:FP.contains('/', '')
-      Assert !ret
-      let ret = s:FP.contains('', '/')
-      Assert !ret
-    End
+    if !s:is_windows
+      It should return non-zero if /foo/bar contains /foo/bar (Non Windows)
+        let ret = s:FP.contains('/foo/bar', '/foo/bar')
+        Assert ret
+      End
+      It should return non-zero if /foo/bar contains /foo (Non Windows)
+        let ret = s:FP.contains('/foo/bar', '/foo')
+        Assert ret
+      End
+      It should return zero if /foo contains /foo/bar (Non Windows)
+        let ret = s:FP.contains('/foo', '/foo/bar')
+        Assert !ret
+      End
+      It should return non-zero if /foo contains /foo (Non Windows)
+        let ret = s:FP.contains('/foo', '/foo')
+        Assert ret
+      End
+      It should return non-zero if /foo contains / (Non Windows)
+        let ret = s:FP.contains('/foo', '/')
+        Assert ret
+      End
+      It should return zero if / contains /foo (Non Windows)
+        let ret = s:FP.contains('/', '/foo')
+        Assert !ret
+      End
+      It should return non-zero if / contains / (Non Windows)
+        let ret = s:FP.contains('/', '/')
+        Assert ret
+      End
+      It should return zero for empty paths (Non Windows)
+        let ret = s:FP.contains('', '')
+        Assert !ret
+        let ret = s:FP.contains('/', '')
+        Assert !ret
+        let ret = s:FP.contains('', '/')
+        Assert !ret
+      End
+    else
+      It should return non-zero if C:\foo\bar contains C:\foo\bar (Windows)
+        let ret = s:FP.contains('C:\foo\bar', 'C:\foo\bar')
+        Assert ret
+      End
+      It should return non-zero if C:\foo\bar contains C:\foo (Windows)
+        let ret = s:FP.contains('C:\foo\bar', 'C:\foo')
+        Assert ret
+      End
+      It should return zero if C:\foo contains C:\foo\bar (Windows)
+        let ret = s:FP.contains('C:\foo', 'C:\foo\bar')
+        Assert !ret
+      End
+      It should return non-zero if C:\foo contains C:\foo (Windows)
+        let ret = s:FP.contains('C:\foo', 'C:\foo')
+        Assert ret
+      End
+      It should return non-zero if C:\foo contains C:\ (Windows)
+        let ret = s:FP.contains('C:\foo', 'C:\')
+        Assert ret
+      End
+      It should return zero if C:\ contains C:\foo (Windows)
+        let ret = s:FP.contains('C:\', 'C:\foo')
+        Assert !ret
+      End
+      It should return non-zero if C:\ contains C:\ (Windows)
+        let ret = s:FP.contains('C:\', 'C:\')
+        Assert ret
+      End
+      It should return zero for empty paths (Windows)
+        let ret = s:FP.contains('', '')
+        Assert !ret
+        let ret = s:FP.contains('C:\', '')
+        Assert !ret
+        let ret = s:FP.contains('', 'C:\')
+        Assert !ret
+      End
+    endif
   End
 End

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -163,4 +163,43 @@ Describe System.Filepath
       End
     endif
   End
+
+  Describe .contains()
+    It should return non-zero if /foo/bar contains /foo/bar
+      let ret = s:FP.contains('/foo/bar', '/foo/bar')
+      Assert ret
+    End
+    It should return non-zero if /foo/bar contains /foo
+      let ret = s:FP.contains('/foo/bar', '/foo')
+      Assert ret
+    End
+    It should return zero if /foo contains /foo/bar
+      let ret = s:FP.contains('/foo', '/foo/bar')
+      Assert !ret
+    End
+    It should return non-zero if /foo contains /foo
+      let ret = s:FP.contains('/foo', '/foo')
+      Assert ret
+    End
+    It should return non-zero if /foo contains /
+      let ret = s:FP.contains('/foo', '/')
+      Assert ret
+    End
+    It should return zero if / contains /foo
+      let ret = s:FP.contains('/', '/foo')
+      Assert !ret
+    End
+    It should return non-zero if / contains /
+      let ret = s:FP.contains('/', '/')
+      Assert ret
+    End
+    It should return zero for empty paths
+      let ret = s:FP.contains('', '')
+      Assert !ret
+      let ret = s:FP.contains('/', '')
+      Assert !ret
+      let ret = s:FP.contains('', '/')
+      Assert !ret
+    End
+  End
 End


### PR DESCRIPTION
http://lingr.com/room/vim/archives/2016/02/02#message-23010490

> ところで話が変わるのだけど、vitalizer の関係で、特定のパスが特定のパスを含んでいるか、みたいな判定をする機能が System.Filepath 辺りに欲しい