### PR TITLE
Vim.Guard: Support registers, environment variables, values in list or dict

### DIFF
--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -7,6 +7,15 @@ function! s:undefined() abort
 endfunction
 let s:UNDEFINED = function('s:undefined')
 
+function! s:_vital_loaded(V) abort
+  let s:V = a:V
+  let s:Prelude = s:V.import('Prelude')
+  let s:List = s:V.import('Data.List')
+  let s:Dict = s:V.import('Data.Dict')
+endfunction
+function! s:_vital_depends() abort
+  return ['Prelude', 'Data.List', 'Data.Dict']
+endfunction
 function! s:_vital_created(module) abort
   " define constant variables
   if !exists('s:const')
@@ -38,6 +47,55 @@ function! s:_new_option(name) abort
   return option
 endfunction
 function! s:option.restore() abort
+  execute printf('let %s = %s', self.name, string(self.value))
+endfunction
+
+let s:register = {}
+function! s:_new_register(name) abort
+  if len(a:name) != 2
+    call s:_throw(printf(
+          \'A register name "%s" requires to be "@" + a single character', a:name
+          \))
+  elseif a:name !~# '^@'
+    call s:_throw(printf(
+          \'A register name "%s" requires to be started from "@"', a:name
+          \))
+  elseif a:name =~# '^@[:.%]$'
+    call s:_throw(printf(
+          \'A register name "%s" is read only', a:name
+          \))
+  elseif a:name !~# '^@[@0-9a-zA-Z#=*+~_/-]$'
+    call s:_throw(printf(
+          \'A register name "%s" does not exist. See ":help let-register"', a:name
+          \))
+  endif
+  let name = a:name ==# '@@' ? '' : a:name[1]
+  let register = copy(s:register)
+  let register.name = name
+  let register.value = getreg(name, 1)
+  return register
+endfunction
+function! s:register.restore() abort
+  call setreg(self.name, self.value)
+endfunction
+
+let s:environment = {}
+function! s:_new_environment(name) abort
+  if a:name !~# '^\$'
+    call s:_throw(printf(
+          \'An environment variable name "%s" requires to be started from "$"', a:name
+          \))
+  elseif !exists(a:name)
+    call s:_throw(printf(
+          \'An environment variable name "%s" does not exist. While Vim cannot unlet environment variable, it requires to exist', a:name
+          \))
+  endif
+  let environment = copy(s:environment)
+  let environment.name = a:name
+  let environment.value = eval(a:name)
+  return environment
+endfunction
+function! s:environment.restore() abort
   execute printf('let %s = %s', self.name, string(self.value))
 endfunction
 
@@ -80,12 +138,39 @@ function! s:variable.restore() abort
   endif
 endfunction
 
+let s:instance = {}
+function! s:_new_instance(instance) abort
+  if !s:Prelude.is_list(a:instance) && !s:Prelude.is_dict(a:instance)
+    call s:_throw(printf(
+          \'An instance "%s" requires to be List or Dictionary', string(a:instance)
+          \))
+  endif
+  let instance = copy(s:instance)
+  let instance.instance = a:instance
+  let instance.values = deepcopy(a:instance)
+  return instance
+endfunction
+function! s:instance.restore() abort
+  if s:Prelude.is_list(self.instance)
+    call s:List.clear(self.instance)
+  else
+    call s:Dict.clear(self.instance)
+  endif
+  call extend(self.instance, self.values)
+endfunction
+
 let s:guard = {}
 function! s:store(...) abort
   let resources = []
   for meta in a:000
-    if type(meta) == type([])
-      call add(resources, call('s:_new_variable', meta))
+    if s:Prelude.is_list(meta)
+      if len(meta) == 1
+        call add(resources, s:_new_instance(meta[0]))
+      elseif len(meta) == 2
+        call add(resources, call('s:_new_variable', meta))
+      else
+        call s:_throw('List assignment requires one or two elements')
+      endif
     elseif type(meta) == type('')
       if meta =~# '^[bwtgls]:'
         " Note:
@@ -93,9 +178,13 @@ function! s:store(...) abort
         call add(resources, s:_new_variable(meta))
       elseif meta =~# '^&'
         call add(resources, s:_new_option(meta))
+      elseif meta =~# '^@'
+        call add(resources, s:_new_register(meta))
+      elseif meta =~# '^\$'
+        call add(resources, s:_new_environment(meta))
       else
         call s:_throw(printf(
-              \ 'Unknown option or variable "%s" was specified',
+              \ 'Unknown value "%s" was specified',
               \ meta
               \))
       endif

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -22,6 +22,10 @@ function! s:_vital_created(module) abort
     let s:const = {}
     let s:const.is_local_variable_supported =
         \ v:version > 703 || (v:version == 703 && has('patch560'))
+    " NOTE:
+    " The third argument is available from 7.4.242 but it had bug and that
+    " bug was fixed from 7.4.513
+    let s:const.is_third_argument_of_getreg_supported = has('patch-7.4.513')
     lockvar s:const
   endif
   call extend(a:module, s:const)
@@ -72,11 +76,16 @@ function! s:_new_register(name) abort
   let name = a:name ==# '@@' ? '' : a:name[1]
   let register = copy(s:register)
   let register.name = name
-  let register.value = getreg(name, 1)
+  if s:const.is_third_argument_of_getreg_supported
+    let register.value = getreg(name, 1, 1)
+  else
+    let register.value = getreg(name, 1)
+  endif
+  let register.type = getregtype(name)
   return register
 endfunction
 function! s:register.restore() abort
-  call setreg(self.name, self.value)
+  call setreg(self.name, self.value, self.type)
 endfunction
 
 let s:environment = {}

--- a/autoload/vital/__latest__/Vim/Guard.vim
+++ b/autoload/vital/__latest__/Vim/Guard.vim
@@ -1,11 +1,11 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
-" Use a Funcref as a special term UNDEFINED
+" Use a Funcref as a special term _UNDEFINED
 function! s:undefined() abort
   return 'undefined'
 endfunction
-let s:UNDEFINED = function('s:undefined')
+let s:_UNDEFINED = function('s:undefined')
 
 function! s:_vital_loaded(V) abort
   let s:V = a:V
@@ -120,7 +120,7 @@ function! s:_new_variable(name, ...) abort
   endif
   let variable = copy(s:variable)
   let variable.name = name
-  let variable.value = get(namespace, name, s:UNDEFINED)
+  let variable.value = get(namespace, name, s:_UNDEFINED)
   let variable.value =
         \ type(variable.value) == type({}) || type(variable.value) == type([])
         \   ? deepcopy(variable.value)
@@ -131,7 +131,7 @@ endfunction
 function! s:variable.restore() abort
   " unlet the variable to prevent variable type mis-match in case
   silent! unlet! self._namespace[self.name]
-  if type(self.value) == type(s:UNDEFINED) && self.value == s:UNDEFINED
+  if type(self.value) == type(s:_UNDEFINED) && self.value == s:_UNDEFINED
     " do nothing, leave the variable as undefined
   else
     let self._namespace[self.name] = self.value

--- a/doc/vital-vim-guard.txt
+++ b/doc/vital-vim-guard.txt
@@ -53,8 +53,10 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	  call setreg('a', 'foo')
 	  let $EDITOR = 'vim'
 	  let foo = 'foo'
-	  let l:list = ['foo']
-	  let l:dict = {'foo': 'bar'}
+	  let l:list1 = ['foo']
+	  let l:dict1 = {'foo': 'bar'}
+	  let l:list2 = [['foo']
+	  let l:dict2 = {'foo': ['bar']}
 
 	  " Guard options/variables
 	  let guard = s:G.store(
@@ -63,8 +65,10 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	    \ '$EDITOR',
 	    \ 'g:foo',
 	    \ ['foo', l:],
-	    \ [l:list],
-	    \ [l:dict],
+	    \ [l:list1],
+	    \ [l:dict1],
+	    \ [l:list2, 1],
+	    \ [l:dict2, 1],
 	    \)
 
 	  " Assign temporary values
@@ -75,8 +79,10 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	  let g:foo = 1
 	  unlet foo
 	  let foo = []
-	  call remove(l:list, 0)
-	  unlet l:dict['foo']
+	  call remove(l:list1, 0)
+	  unlet l:dict1['foo']
+	  call remove(l:list2, 0)
+	  unlet l:dict2['foo']
 
 	  " restore previous values
 	  call guard.restore()
@@ -92,10 +98,14 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	  " => 'foo'
 	  echo foo
 	  " => foo
-	  echo l:list
+	  echo l:list1
 	  " => ['foo']
-	  echo l:dict
+	  echo l:dict1
 	  " => {'foo': 'bar'}
+	  echo l:list2
+	  " => [['foo']]
+	  echo l:dict2
+	  " => {'foo': ['bar']}
 	endfunction
 <
 
@@ -126,18 +136,27 @@ store([{name}, ...])	*Vital.Vim.Guard.store()*
 
 	|List|
 	If the {name} contains:
-	- One item, the item is assumed as an instance of |List| or
-	  |Dictionary| and the instance will be guarded. Note that if you assign
-	  a different instance after store, it won't restore the values.
-	- Two items, the list is assumed as [{attr}, {namespace}] where
-	  {attr} is a name of attribute in {namespace}.
+	- One item, the item is assumed as an instance of |List| or |Dictionary|
+	  and the instance will be guarded. Note that if you assign a
+	  different instance after store, it won't restore the values.
+	  It works equal to [{instance}, 0] explained below.
+	- Two items, the list is assumed as 1.) [{attr}, {namespace}] or 2.)
+	  [{instance}, {shallow}] described individually below:
+	  1.) Where {attr} is a name of attribute in {namespace} |Dictionary|.
 	  If {attr} does not exist in {namespace}, The {attr} in {namespace}
-	  will be removed from {namespace} if exists when .restore() method
-	  of the guard instance is called.
+	  will be removed from {namespace} if exists when
+	  .restore() method of the guard instance is called.
 	  Use this type to guard |local-variable| (|l:|), |script-variable| (|s:|),
 	  or attributes in |dict|.
 	  See |Vital.Vim.Guard.is_local_variable_supported| if you would like
 	  to store/restore |local-variable| in Vim 7.3.559 or earlier.
+	  2.) Where {instance} is an instance of |List| or |Dictionary| and
+	  {shallow} is a flag to use |copy| instead of |deepcopy| to store
+	  contents of the instance. When {shallow} is 1, the content of the
+	  instance is copied rather than deepcopied, indicating that values
+	  could not be restored when user changes the contents inside the
+	  contents of the instance. Use {shallow} when the reference of the
+	  each contents are prior to the content itself.
 	It will raise an exception when {name} contains less or more number
 	of items than expect.
 

--- a/doc/vital-vim-guard.txt
+++ b/doc/vital-vim-guard.txt
@@ -55,7 +55,7 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	  let foo = 'foo'
 	  let l:list1 = ['foo']
 	  let l:dict1 = {'foo': 'bar'}
-	  let l:list2 = [['foo']
+	  let l:list2 = [['foo']]
 	  let l:dict2 = {'foo': ['bar']}
 
 	  " Guard options/variables

--- a/doc/vital-vim-guard.txt
+++ b/doc/vital-vim-guard.txt
@@ -21,7 +21,11 @@ The followings are supported
   - |options|
   - |global-local|
   - |local-options|
-- Restoring values of variable
+- Restoring values of existing environmental variables
+  - |let-environment|
+- Restoring values of registers
+  - |let-register|
+- Restoring values of variables
   - |buffer-variable| (b:)
   - |window-variable| (w:)
   - |tabpage-variable| (t:)
@@ -30,6 +34,9 @@ The followings are supported
   - |local-variable| (l:), in Vim 7.3.560 or later
   - |script-variable| (s:)
   - |dict|
+- Restoring instance
+  - |List|
+  - |Dictionary|
 
 
 ==============================================================================
@@ -43,21 +50,33 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	let g:foo = 'foo'
 
 	function! s:foobar() abort
+	  call setreg('a', 'foo')
+	  let $EDITOR = 'vim'
 	  let foo = 'foo'
+	  let l:list = ['foo']
+	  let l:dict = {'foo': 'bar'}
 
 	  " Guard options/variables
 	  let guard = s:G.store(
 	    \ '&backup',
+	    \ '@a',
+	    \ '$EDITOR',
 	    \ 'g:foo',
 	    \ ['foo', l:],
+	    \ [l:list],
+	    \ [l:dict],
 	    \)
 
 	  " Assign temporary values
 	  set nobackup
+	  call setreg('a', 'bar')
+	  let $EDITOR = 'nvim'
 	  unlet g:foo
 	  let g:foo = 1
 	  unlet foo
 	  let foo = []
+	  call remove(l:list, 0)
+	  unlet l:dict['foo']
 
 	  " restore previous values
 	  call guard.restore()
@@ -65,10 +84,18 @@ values with |Vital.Vim.Guard-instance.restore()| like:
 	  " Check if the value is restored
 	  echo &backup
 	  " => 1
+	  echo getreg('a')
+	  " => foo
+	  echo $EDITOR
+	  " => vim
 	  echo g:foo
 	  " => 'foo'
 	  echo foo
 	  " => foo
+	  echo l:list
+	  " => ['foo']
+	  echo l:dict
+	  " => {'foo': 'bar'}
 	endfunction
 <
 
@@ -98,22 +125,35 @@ store([{name}, ...])	*Vital.Vim.Guard.store()*
 	The following type of value is allowed for {name}
 
 	|List|
-	Components of the list is [{attr}, {namespace}] where {attr} is a name
-	of attribute in {namespace}. If {attr} does not exist in {namespace},
-	The {attr} in {namespace} will be removed from {namespace} if exists
-	when .restore() method of the guard instance is called.
-	Use this type to guard |local-variable| (|l:|), |script-variable| (|s:|), or
-	attributes in |dict|.
-	See |Vital.Vim.Guard.is_local_variable_supported| if you would like to
-	store/restore |local-variable| in Vim 7.3.559 or earlier.
+	If the {name} contains:
+	- One item, the item is assumed as an instance of |List| or
+	  |Dictionary| and the instance will be garded. Note that if you assign
+	  a different instance after store, it won't restore the values.
+	- Two items, the list is assumed as [{attr}, {namespace}] where
+	  {attr} is a name of attribute in {namespace}.
+	  If {attr} does not exist in {namespace}, The {attr} in {namespace}
+	  will be removed from {namespace} if exists when .restore() method
+	  of the guard instance is called.
+	  Use this type to guard |local-variable| (|l:|), |script-variable| (|s:|),
+	  or attributes in |dict|.
+	  See |Vital.Vim.Guard.is_local_variable_supported| if you would like
+	  to store/restore |local-variable| in Vim 7.3.559 or earlier.
+	It will raise an exception when {name} contains less or more number
+	of items than expect.
 
 	|String|
-	An option name or variable name. If the {name} starts from b:, w:, t:,
-	or g:, a named |buffer-variable|, |window-variable|, |tabpage-variable|, or
-	|global-variable| would be guarded, otherwise the named option would
-	be guarded. To specify global or local option, use &g: or &l: prefix
-	in Vim 7.4 (individual assignment does not work on Vim 7.3).
-	Note that the guard instance is insensible of the change of the 
+	If the {name} starts from:
+	- &, &g:, or &l:, the named option would be guarded. Note that
+	  individual assignment of option does not work on Vim 7.3.
+	- @, the named register would be guarded. Note that unnamed register
+	  should use @@ instead of @, which is explained in |let-register|.
+	- $, the named environment variable would be guarded. Note that Vim
+	  does not allow to unlet environment variables so Vim.Guard cannot
+	  guard non existing environment variable and will throw an exception
+	  when the variable is going to be guarded.
+	- b:, w:, t:, or g:, a named |buffer-variable|, |window-variable|,
+	  |tabpage-variable|, or |global-variable| would be guarded
+	Note that the guard instance is insensible of the change of the
 	current buffer, mean that |buffer-variable|, |window-variable|, or
 	|tabpage-variable| would not be correctly re-stored when users move the
 	buffer to the other before |Vital.Vim.Guard-instance.restore()|.
@@ -122,7 +162,7 @@ store([{name}, ...])	*Vital.Vim.Guard.store()*
 INSTANCE				*Vital.Vim.Guard-instance*
 
 restore()		*Vital.Vim.Guard-instance.restore()*
-	Restore guarded options/variables.
+	Restore guarded values.
 
 
 ==============================================================================

--- a/doc/vital-vim-guard.txt
+++ b/doc/vital-vim-guard.txt
@@ -127,7 +127,7 @@ store([{name}, ...])	*Vital.Vim.Guard.store()*
 	|List|
 	If the {name} contains:
 	- One item, the item is assumed as an instance of |List| or
-	  |Dictionary| and the instance will be garded. Note that if you assign
+	  |Dictionary| and the instance will be guarded. Note that if you assign
 	  a different instance after store, it won't restore the values.
 	- Two items, the list is assumed as [{attr}, {namespace}] where
 	  {attr} is a name of attribute in {namespace}.

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -121,19 +121,28 @@ Describe Vim.Guard
             \ sf._new_register('@!')
     End
     It returns a register instace of {name}
+      call setreg('', 'foo')
       let register = sf._new_register('@@')
       Assert KeyExists(register, 'name')
       Assert KeyExists(register, 'value')
       Assert KeyExists(register, 'restore')
       Assert Equals(register.name, '')
-      Assert Equals(register.value, getreg('', 1))
+      if Guard.is_third_argument_of_getreg_supported
+        Assert Equals(register.value, getreg('', 1, 1))
+      else
+        Assert Equals(register.value, getreg('', 1))
+      endif
 
       let register = sf._new_register('@=')
       Assert KeyExists(register, 'name')
       Assert KeyExists(register, 'value')
       Assert KeyExists(register, 'restore')
       Assert Equals(register.name, '=')
-      Assert Equals(register.value, getreg('=', 1))
+      if Guard.is_third_argument_of_getreg_supported
+        Assert Equals(register.value, getreg('=', 1, 1))
+      else
+        Assert Equals(register.value, getreg('=', 1))
+      endif
     End
     Describe A register variable instace
       It restore a value of the register when assigned

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -388,7 +388,7 @@ Describe Vim.Guard
       End
     End
   End
-  Describe [PRIVATE] s:_new_instance({instance})
+  Describe [PRIVATE] s:_new_instance({instance}[, {shallow}])
     It throws an exception if {instance} is not a instance instance
       Throw /An instance "'foo'" requires to be List or Dictionary/
             \ sf._new_instance('foo')
@@ -397,7 +397,7 @@ Describe Vim.Guard
     End
     Context with List
       It returns a instance instance of {name}
-        let l:list = ['a', 'b', 'c']
+        let l:list = [['a'], ['b'], ['c']]
         let instance = sf._new_instance(l:list)
         Assert KeyExists(instance, 'instance')
         Assert KeyExists(instance, 'values')
@@ -406,6 +406,27 @@ Describe Vim.Guard
         Assert Same(instance.instance, l:list)
         Assert Equals(instance.values, l:list)
         Assert NotSame(instance.values, l:list)
+        " NOTE:
+        " {shallow} is not specified (0) so the content should NOT be SAME
+        Assert NotSame(instance.values[0], l:list[0])
+        Assert NotSame(instance.values[1], l:list[1])
+        Assert NotSame(instance.values[2], l:list[2])
+      End
+      It returns a instance instance of {name} with {shallow}
+        let l:list = [['a'], ['b'], ['c']]
+        let instance = sf._new_instance(l:list, 1)
+        Assert KeyExists(instance, 'instance')
+        Assert KeyExists(instance, 'values')
+        Assert KeyExists(instance, 'restore')
+        Assert Equals(instance.instance, l:list)
+        Assert Same(instance.instance, l:list)
+        Assert Equals(instance.values, l:list)
+        Assert NotSame(instance.values, l:list)
+        " NOTE:
+        " {shallow} is 1 so the content should be SAME
+        Assert Same(instance.values[0], l:list[0])
+        Assert Same(instance.values[1], l:list[1])
+        Assert Same(instance.values[2], l:list[2])
       End
       Describe A instance instance
         It restore values of the instance when assigned
@@ -426,7 +447,7 @@ Describe Vim.Guard
     End
     Context with Dictionary
       It returns a instance instance of {name}
-        let l:dict = {'foo': 'bar'}
+        let l:dict = {'foo': {}, 'bar': {}}
         let instance = sf._new_instance(l:dict)
         Assert KeyExists(instance, 'instance')
         Assert KeyExists(instance, 'values')
@@ -435,6 +456,25 @@ Describe Vim.Guard
         Assert Same(instance.instance, l:dict)
         Assert Equals(instance.values, l:dict)
         Assert NotSame(instance.values, l:dict)
+        " NOTE:
+        " {shallow} is not specified (0) so content should NOT be SAME
+        Assert NotSame(instance.values.foo, l:dict.foo)
+        Assert NotSame(instance.values.bar, l:dict.bar)
+      End
+      It returns a instance instance of {name} with {shallow}
+        let l:dict = {'foo': {}, 'bar': {}}
+        let instance = sf._new_instance(l:dict, 1)
+        Assert KeyExists(instance, 'instance')
+        Assert KeyExists(instance, 'values')
+        Assert KeyExists(instance, 'restore')
+        Assert Equals(instance.instance, l:dict)
+        Assert Same(instance.instance, l:dict)
+        Assert Equals(instance.values, l:dict)
+        Assert NotSame(instance.values, l:dict)
+        " NOTE:
+        " {shallow} is 1 so content should be SAME
+        Assert Same(instance.values.foo, l:dict.foo)
+        Assert Same(instance.values.bar, l:dict.bar)
       End
       Describe A instance instance
         It restore values of the instance when assigned
@@ -541,6 +581,10 @@ Describe Vim.Guard
       let guard = Guard.store(
             \ [[]],
             \ [{}],
+            \ [[], 0],
+            \ [{}, 0],
+            \ [[], 1],
+            \ [{}, 1],
             \)
       Assert KeyExists(guard, 'restore')
     End

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -96,6 +96,109 @@ Describe Vim.Guard
       End
     End
   End
+  Describe [PRIVATE] s:_new_register({name})
+    It throws a exception if {name} is longer or shorter tha two characters
+      Throw /A register name "f" requires to be "@" + a single character/
+            \ sf._new_register('f')
+      Throw /A register name "foo" requires to be "@" + a single character/
+            \ sf._new_register('foo')
+    End
+    It throws a exception if {name} does not start from "@"
+      Throw /A register name "ff" requires to be started from "@"/
+            \ sf._new_register('ff')
+    End
+    It throws a exception if {name} is a read-only register
+      Throw /A register name "@:" is read only/
+            \ sf._new_register('@:')
+      Throw /A register name "@." is read only/
+            \ sf._new_register('@.')
+      Throw /A register name "@%" is read only/
+            \ sf._new_register('@%')
+    End
+    It throws a exception if {name} does not exist as a register variable
+      Throw /A register name "@!" does not exist/
+            \ sf._new_register('@!')
+    End
+    It returns a register instace of {name}
+      let register = sf._new_register('@@')
+      Assert KeyExists(register, 'name')
+      Assert KeyExists(register, 'value')
+      Assert KeyExists(register, 'restore')
+      Assert Equals(register.name, '')
+      Assert Equals(register.value, getreg('', 1))
+
+      let register = sf._new_register('@=')
+      Assert KeyExists(register, 'name')
+      Assert KeyExists(register, 'value')
+      Assert KeyExists(register, 'restore')
+      Assert Equals(register.name, '=')
+      Assert Equals(register.value, getreg('=', 1))
+    End
+    Describe A register variable instace
+      It restore a value of the register when assigned
+        call setreg('a', 'foobar')
+        call setreg('b', 'foobar')
+        let register = sf._new_register('@a')
+        call setreg('a', 'hogehoge')
+        call setreg('b', 'hogehoge')
+        call register.restore()
+        Assert Equals(getreg('a'), 'foobar')
+        Assert Equals(getreg('b'), 'hogehoge')
+      End
+      It restore a RAW value of the expression register when assigned
+        call setreg('=', '100 + 100 + 100')
+        let register = sf._new_register('@=')
+        call setreg('=', '100 * 5')
+        call register.restore()
+        Assert Equals(getreg('='), '300')
+        Assert Equals(getreg('=', 1), '100 + 100 + 100')
+      End
+    End
+  End
+  Describe [PRIVATE] s:_new_environment({name})
+    " NOTE:
+    "   $PATH  : it should exist
+    "   $_EMPTY : it should exist and empty
+    "   $_INVALID : it should NOT exist
+    It throws an exception if {name} does not start from "$"
+      Throw /An environment variable name "foo" requires to be started from "$"/
+            \ sf._new_environment('foo')
+    End
+    It throws an exception if {name} does not exist as an environment variable
+      Throw /An environment variable name "$_INVALID" does not exist/
+            \ sf._new_environment('$_INVALID')
+    End
+    It returns an environment variable instance of {name}
+      let environment = sf._new_environment('$PATH')
+      Assert KeyExists(environment, 'name')
+      Assert KeyExists(environment, 'value')
+      Assert KeyExists(environment, 'restore')
+      Assert Equals(environment.name, '$PATH')
+      Assert Equals(environment.value, $PATH)
+    End
+    It returns an environment variable instance of {name} even it is an empty string
+      let $_VITAL_VIM_GUARD_EMPTY = ''
+      let environment = sf._new_environment('$_VITAL_VIM_GUARD_EMPTY')
+      Assert KeyExists(environment, 'name')
+      Assert KeyExists(environment, 'value')
+      Assert KeyExists(environment, 'restore')
+      Assert Equals(environment.name, '$_VITAL_VIM_GUARD_EMPTY')
+      Assert Equals(environment.value, $_VITAL_VIM_GUARD_EMPTY)
+      " there is no way to unlet environment variable so leave it
+    End
+    Describe An environment variable instance
+      It restore a value of the environment when assigned
+        let $_VITAL_VIM_GUARD_A = 'A'
+        let $_VITAL_VIM_GUARD_B = 'B'
+        let environment = sf._new_environment('$_VITAL_VIM_GUARD_A')
+        let $_VITAL_VIM_GUARD_A = 'B'
+        let $_VITAL_VIM_GUARD_B = 'A'
+        call environment.restore()
+        Assert Equals($_VITAL_VIM_GUARD_A, 'A')
+        Assert Equals($_VITAL_VIM_GUARD_B, 'A')
+      End
+    End
+  End
   Describe [PRIVATE] s:_new_variable({name}[, {namespace}])
     Before
       let g:VitalVimGuardTest = 1
@@ -244,6 +347,68 @@ Describe Vim.Guard
       End
     End
   End
+  Describe [PRIVATE] s:_new_instance({instance})
+    It throws an exception if {instance} is not a instance instance
+      Throw /An instance "'foo'" requires to be List or Dictionary/
+            \ sf._new_instance('foo')
+      Throw /An instance "100" requires to be List or Dictionary/
+            \ sf._new_instance(100)
+    End
+    Context with List
+      It returns a instance instance of {name}
+        let l:list = ['a', 'b', 'c']
+        let instance = sf._new_instance(l:list)
+        Assert KeyExists(instance, 'instance')
+        Assert KeyExists(instance, 'values')
+        Assert KeyExists(instance, 'restore')
+        Assert Equals(instance.instance, l:list)
+        Assert Same(instance.instance, l:list)
+        Assert Equals(instance.values, l:list)
+        Assert NotSame(instance.values, l:list)
+      End
+      Describe A instance instance
+        It restore values of the instance when assigned
+          let list1 = ['a', 'b', 'c']
+          let list2 = ['a', 'b', 'c']
+          let instance = sf._new_instance(list1)
+          let list1[0] = 'f'
+          let list1[1] = 'o'
+          let list1[2] = 'o'
+          let list2[0] = 'f'
+          let list2[1] = 'o'
+          let list2[2] = 'o'
+          call l:instance.restore()
+          Assert Equals(list1, ['a', 'b', 'c'])
+          Assert Equals(list2, ['f', 'o', 'o'])
+        End
+      End
+    End
+    Context with Dictionary
+      It returns a instance instance of {name}
+        let l:dict = {'foo': 'bar'}
+        let instance = sf._new_instance(l:dict)
+        Assert KeyExists(instance, 'instance')
+        Assert KeyExists(instance, 'values')
+        Assert KeyExists(instance, 'restore')
+        Assert Equals(instance.instance, l:dict)
+        Assert Same(instance.instance, l:dict)
+        Assert Equals(instance.values, l:dict)
+        Assert NotSame(instance.values, l:dict)
+      End
+      Describe A instance instance
+        It restore values of the instance when assigned
+          let dict1 = {'foo': 'bar'}
+          let dict2 = {'foo': 'bar'}
+          let instance = sf._new_instance(dict1)
+          let dict1['foo'] = 'hoge'
+          let dict2['foo'] = 'hoge'
+          call instance.restore()
+          Assert Equals(dict1, {'foo': 'bar'})
+          Assert Equals(dict2, {'foo': 'hoge'})
+        End
+      End
+    End
+  End
 
   Describe .store({option_or_variable}...)
     Before
@@ -257,6 +422,9 @@ Describe Vim.Guard
       setl backupcopy=yes
       set binary
       set list
+      let previous_a_register = getreg('a')
+      call setreg('a', 'foo')
+      let $_VITAL_VIM_GUARD_A = 'foo'
       let b:VitalVimGuardTest = 1
       let w:VitalVimGuardTest = 1
       let t:VitalVimGuardTest = 1
@@ -269,6 +437,8 @@ Describe Vim.Guard
       let &l:backupcopy = previous_l_backupcopy
       let &binary = previous_b_binary
       let &list = previous_w_list
+      call setreg('a', previous_a_register)
+      let $_VITAL_VIM_GUARD_A = ''
       unlet b:VitalVimGuardTest
       unlet w:VitalVimGuardTest
       unlet t:VitalVimGuardTest
@@ -276,7 +446,7 @@ Describe Vim.Guard
       unlet s:VitalVimGuardTest
     End
     It throws an exception when unknown {option_or_variable} is specified
-      Throws /Unknown option or variable "backup" was specified/
+      Throws /Unknown value "backup" was specified/
             \ Guard.store('backup')
     End
     It returns a guard instance for options
@@ -285,6 +455,22 @@ Describe Vim.Guard
             \ '&backupcopy',
             \ '&binary',
             \ '&list',
+            \)
+      Assert KeyExists(guard, 'restore')
+    End
+    It returns a guard instance for register
+      let guard = Guard.store(
+            \ '@@',
+            \ '@a',
+            \ '@b',
+            \ '@=',
+            \)
+      Assert KeyExists(guard, 'restore')
+    End
+    It returns a guard instance for environment variable
+      let guard = Guard.store(
+            \ '$PATH',
+            \ '$_VITAL_VIM_GUARD_A',
             \)
       Assert KeyExists(guard, 'restore')
     End
@@ -310,36 +496,57 @@ Describe Vim.Guard
             \)
       Assert KeyExists(guard, 'restore')
     End
+    It returns a guard instance for instance
+      let guard = Guard.store(
+            \ [[]],
+            \ [{}],
+            \)
+      Assert KeyExists(guard, 'restore')
+    End
     Describe A guard instance
       It restore options and variables assigned
         let namespace = { 'VitalVimGuardTest': 1 }
+        let l:list = ['foo', 'bar', 'hoge']
+        let l:dict = {'foo': 'bar', 'hoge': 'hoge'}
         let guard = Guard.store(
               \ '&backup',
               \ '&backupcopy',
               \ '&binary',
               \ '&list',
+              \ '@a',
+              \ '$_VITAL_VIM_GUARD_A',
               \ 'b:VitalVimGuardTest',
               \ 'w:VitalVimGuardTest',
               \ 't:VitalVimGuardTest',
               \ 'g:VitalVimGuardTest',
               \ ['VitalVimGuardTest', s:],
               \ ['VitalVimGuardTest', namespace],
+              \ [l:list],
+              \ [l:dict],
               \)
         set nobackup
         set backupcopy=no
         set nobinary
         set nolist
+        call setreg('a', 'hogehoge')
+        let $_VITAL_VIM_GUARD_A = 'hogehoge'
         let b:VitalVimGuardTest = 2
         let w:VitalVimGuardTest = 2
         let t:VitalVimGuardTest = 2
         let g:VitalVimGuardTest = 2
         let s:VitalVimGuardTest = 2
         let namespace.VitalVimGuardTest = 2
+        let l:list[0] = 'hello'
+        call remove(l:list, 1)
+        let l:dict['foo'] = 'hoge'
+        unlet l:dict['hoge']
         call guard.restore()
         Assert Equals(&backup, 1)
         Assert Equals(&backupcopy, 'yes')
         Assert Equals(&binary, 1)
         Assert Equals(&list, 1)
+        Assert Equals(getreg('a'), 'foo')
+        Assert Equals($_VITAL_VIM_GUARD_A, 'foo')
         Assert Equals(b:VitalVimGuardTest, 1)
         Assert Equals(w:VitalVimGuardTest, 1)
         Assert Equals(t:VitalVimGuardTest, 1)
@@ -347,6 +554,8 @@ Describe Vim.Guard
         let s = s:VitalVimGuardTest
         Assert Equals(s, 1)
         Assert Equals(namespace.VitalVimGuardTest, 1)
+        Assert Equals(l:list, ['foo', 'bar', 'hoge'])
+        Assert Equals(l:dict, {'foo': 'bar', 'hoge': 'hoge'})
       End
     End
   End

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -1,6 +1,7 @@
 let s:V = vital#of('vital')
 let s:P = s:V.import('System.Filepath')
 let s:S = s:V.import('Vim.ScriptLocal')
+let s:is_windows = has('win16') || has('win32') || has('win64')
 
 Describe Vim.Guard
   Before
@@ -145,20 +146,31 @@ Describe Vim.Guard
         Assert Equals(getreg('a'), 'foobar')
         Assert Equals(getreg('b'), 'hogehoge')
       End
-      It restore a RAW value of the expression register when assigned
-        call setreg('=', '100 + 100 + 100')
-        let register = sf._new_register('@=')
-        call setreg('=', '100 * 5')
-        call register.restore()
-        Assert Equals(getreg('='), '300')
-        Assert Equals(getreg('=', 1), '100 + 100 + 100')
-      End
+      if v:version >= 704
+        " NOTE:
+        " It seems expression register does not work in Vim 7.3 ?
+        " https://travis-ci.org/vim-jp/vital.vim/jobs/109619393
+        It restore a RAW value of the expression register when assigned
+          call setreg('=', '100 + 100 + 100')
+          let register = sf._new_register('@=')
+          call setreg('=', '100 * 5')
+          call register.restore()
+          Assert Equals(getreg('='), '300')
+          Assert Equals(getreg('=', 1), '100 + 100 + 100')
+        End
+      endif
     End
   End
   Describe [PRIVATE] s:_new_environment({name})
+    After
+      " Remove used environment variables (Works in Windows only)
+      let $_VITAL_VIM_GUARD_EMPTY = ''
+      let $_VITAL_VIM_GUARD_A = ''
+      let $_VITAL_VIM_GUARD_B = ''
+    End
     " NOTE:
     "   $PATH  : it should exist
-    "   $_EMPTY : it should exist and empty
+    "   $_VITAL_VIM_GUARD_EMPTY : it should exist and empty (Not in Windows)
     "   $_INVALID : it should NOT exist
     It throws an exception if {name} does not start from "$"
       Throw /An environment variable name "foo" requires to be started from "$"/
@@ -176,16 +188,18 @@ Describe Vim.Guard
       Assert Equals(environment.name, '$PATH')
       Assert Equals(environment.value, $PATH)
     End
-    It returns an environment variable instance of {name} even it is an empty string
-      let $_VITAL_VIM_GUARD_EMPTY = ''
-      let environment = sf._new_environment('$_VITAL_VIM_GUARD_EMPTY')
-      Assert KeyExists(environment, 'name')
-      Assert KeyExists(environment, 'value')
-      Assert KeyExists(environment, 'restore')
-      Assert Equals(environment.name, '$_VITAL_VIM_GUARD_EMPTY')
-      Assert Equals(environment.value, $_VITAL_VIM_GUARD_EMPTY)
-      " there is no way to unlet environment variable so leave it
-    End
+    if !s:is_windows
+      It returns an environment variable instance of {name} even it is an empty string
+        let $_VITAL_VIM_GUARD_EMPTY = ''
+        let environment = sf._new_environment('$_VITAL_VIM_GUARD_EMPTY')
+        Assert KeyExists(environment, 'name')
+        Assert KeyExists(environment, 'value')
+        Assert KeyExists(environment, 'restore')
+        Assert Equals(environment.name, '$_VITAL_VIM_GUARD_EMPTY')
+        Assert Equals(environment.value, $_VITAL_VIM_GUARD_EMPTY)
+        " there is no way to unlet environment variable so leave it
+      End
+    endif
     Describe An environment variable instance
       It restore a value of the environment when assigned
         let $_VITAL_VIM_GUARD_A = 'A'

--- a/test/Vim/Guard.vimspec
+++ b/test/Vim/Guard.vimspec
@@ -125,6 +125,7 @@ Describe Vim.Guard
       let register = sf._new_register('@@')
       Assert KeyExists(register, 'name')
       Assert KeyExists(register, 'value')
+      Assert KeyExists(register, 'type')
       Assert KeyExists(register, 'restore')
       Assert Equals(register.name, '')
       if Guard.is_third_argument_of_getreg_supported
@@ -132,17 +133,34 @@ Describe Vim.Guard
       else
         Assert Equals(register.value, getreg('', 1))
       endif
+      Assert Equals(register.type, 'v')
 
       let register = sf._new_register('@=')
       Assert KeyExists(register, 'name')
       Assert KeyExists(register, 'value')
       Assert KeyExists(register, 'restore')
+      Assert KeyExists(register, 'type')
       Assert Equals(register.name, '=')
       if Guard.is_third_argument_of_getreg_supported
         Assert Equals(register.value, getreg('=', 1, 1))
       else
         Assert Equals(register.value, getreg('=', 1))
       endif
+      Assert Equals(register.type, 'v')
+
+      call setreg('a', 'hoge', 'V')
+      let register = sf._new_register('@a')
+      Assert KeyExists(register, 'name')
+      Assert KeyExists(register, 'value')
+      Assert KeyExists(register, 'restore')
+      Assert KeyExists(register, 'type')
+      Assert Equals(register.name, 'a')
+      if Guard.is_third_argument_of_getreg_supported
+        Assert Equals(register.value, getreg('a', 1, 1))
+      else
+        Assert Equals(register.value, getreg('a', 1))
+      endif
+      Assert Equals(register.type, 'V')
     End
     Describe A register variable instace
       It restore a value of the register when assigned


### PR DESCRIPTION
Now you can

```vim
let list = []
let dict = {}
let guard = s:Guard.store('@a', '$PATH', [list], [dict], [list, 1], [dict, 1])
```