### PR TITLE
__latest__: fix s:_uniq

### DIFF
--- a/autoload/vital/__latest__.vim
+++ b/autoload/vital/__latest__.vim
@@ -264,10 +264,8 @@ else
     while 0 < i
       if a:list[i] ==# a:list[i - 1]
         call remove(a:list, i)
-        let i -= 2
-      else
-        let i -= 1
       endif
+      let i -= 1
     endwhile
     return a:list
   endfunction


### PR DESCRIPTION
I found a small mistake in s:_uniq.

```vim
echo uniq(['foo', 'foo', 'foo', 'bar', 'bar', 'bar'])

function! s:_uniq(list) abort
  let i = len(a:list) - 1
  while 0 < i
    if a:list[i] ==# a:list[i - 1]
      call remove(a:list, i)
      let i -= 2
    else
      let i -= 1
    endif
  endwhile
  return a:list
endfunction
echo s:_uniq(['foo', 'foo', 'foo', 'bar', 'bar', 'bar'])
```
```
['foo', 'bar']
['foo', 'foo', 'bar', 'bar']
```

This pull request fixes the behaviour.
```vim
echo uniq(['foo', 'foo', 'foo', 'bar', 'bar', 'bar'])

function! s:_uniq(list) abort
  let i = len(a:list) - 1
  while 0 < i
    if a:list[i] ==# a:list[i - 1]
      call remove(a:list, i)
    endif
    let i -= 1
  endwhile
  return a:list
endfunction
echo s:_uniq(['foo', 'foo', 'foo', 'bar', 'bar', 'bar'])
```
```
['foo', 'bar']
['foo', 'bar']
```

What do you think?