### PR TITLE
vital: add {nosuf} arg for globpath() in vital#of()

### DIFF
--- a/autoload/vital.vim
+++ b/autoload/vital.vim
@@ -1,5 +1,5 @@
 function! vital#of(name) abort
-  let files = globpath(&runtimepath, 'autoload/vital/' . a:name . '.vital')
+  let files = globpath(&runtimepath, 'autoload/vital/' . a:name . '.vital', 1)
   let file = split(files, "\n")
   if empty(file)
     throw 'vital: version file not found: ' . a:name


### PR DESCRIPTION
ref: #259

一斉に修正が反映されないのと修正しないのは話が別問題で，互換性がある変更なら修正していくべきかと思います．
どうせ #415 とかで deprecated にするけど，それでも `vital#of` の後方互換性のために autoload/vital.vim を配らないようになるというのは，やるとしてもすくなくともまだ先だし，バグのない autoload/vital.vim にしておいて損はないハズ．