### PR TITLE
Appveyor:  Clone depth number is too small

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '{build}'
-clone_depth: 1
+clone_depth: 10
 environment:
   matrix:
     - VIM_URL: http://files.kaoriya.net/vim/vim74-kaoriya-win64.zip


### PR DESCRIPTION
If you do a lot of commits producing queued builds, git checkout operation following git clone can fail because requested commit is not present in a cloned repository.

ref: https://www.appveyor.com/docs/how-to/repository-shallow-clone#setting-depth-of-git-clone-command