### PR TITLE
Data.Closure: Fix for Partial

### DIFF
--- a/autoload/vital/__vital__/Data/Closure.vim
+++ b/autoload/vital/__vital__/Data/Closure.vim
@@ -241,7 +241,7 @@ function! s:is_closure(expr) abort
   return type(a:expr) == type({}) &&
   \      has_key(a:expr, 'call') &&
   \      type(a:expr.call) == type(function('call')) &&
-  \      a:expr.call == s:Closure.call
+  \      get(a:expr, 'call') == get(s:Closure, 'call')
 endfunction
 
 function! s:is_callable(expr) abort


### PR DESCRIPTION
In latest Vim, `dict.func` returns a Partial.  And they are compared including the internals.  We don't expect it.