### PR TITLE
Vim.Buffer: Cleanup tempfile buffer in read_content()

### DIFF
--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -118,6 +118,7 @@ function! s:read_content(content, ...) abort
           \)
   finally
     call delete(tempfile)
+    execute 'bwipeout!' tempfile
   endtry
 endfunction
 

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -179,6 +179,11 @@ Describe Vim.Buffer
         Assert Equals(&fileencoding, 'utf-8')
       End
     End
+    It wipes out tempfile buffer
+      let fname = tempname()
+      call Buffer.read_content([''], {'tempfile': fname})
+      Assert Equals(bufnr(fname), -1)
+    End
   End
 
   Describe edit_content()


### PR DESCRIPTION
`read_content()` を呼ぶと tempfile が unlisted-buffer として残るが、無駄なので消したい。