### PR TITLE
OptionParser: Remove extra lockvar!

### DIFF
--- a/autoload/vital/__vital__/OptionParser.vim
+++ b/autoload/vital/__vital__/OptionParser.vim
@@ -398,8 +398,6 @@ function! s:_DEFAULT_PARSER.complete_greedily(arglead, cmdline, cursorpos) abort
   endif
 endfunction
 
-lockvar! s:_DEFAULT_PARSER
-
 function! s:new() abort
   return deepcopy(s:_DEFAULT_PARSER)
 endfunction


### PR DESCRIPTION
This also locks copied parser.  This is unuseful.