### PR TITLE
Fix for 64bit number

### DIFF
--- a/autoload/vital/__vital__/Bitwise.vim
+++ b/autoload/vital/__vital__/Bitwise.vim
@@ -38,17 +38,17 @@ endfunction
 
 if has('num64')
   function! s:sign_extension(n) abort
-    if s:and(a:n, 0x80000000)
-      return s:or(a:n, 0xFFFFFFFF00000000)
+    if and(a:n, 0x80000000)
+      return or(a:n, 0xFFFFFFFF00000000)
     else
-      return s:and(a:n, 0xFFFFFFFF)
+      return and(a:n, 0xFFFFFFFF)
     endif
   endfunction
   function! s:lshift32(a, n) abort
-    return s:and(s:lshift(a:a, s:and(a:n, s:mask32)), 0xFFFFFFFF)
+    return and(s:lshift(a:a, and(a:n, s:mask32)), 0xFFFFFFFF)
   endfunction
   function! s:rshift32(a, n) abort
-    return s:rshift(s:and(a:a, 0xFFFFFFFF), s:and(a:n, s:mask32))
+    return s:rshift(and(a:a, 0xFFFFFFFF), and(a:n, s:mask32))
   endfunction
 else
   function! s:sign_extension(n) abort

--- a/autoload/vital/__vital__/Bitwise.vim
+++ b/autoload/vital/__vital__/Bitwise.vim
@@ -35,6 +35,20 @@ function! s:rshift(a, n) abort
   \          : a:a / s:pow2[n]
 endfunction
 
+if has('num64')
+  function! s:sign_extension(n) abort
+    if s:and(a:n, 0x80000000)
+      return s:or(a:n, 0xFFFFFFFF00000000)
+    else
+      return s:and(a:n, 0xFFFFFFFF)
+    endif
+  endfunction
+else
+  function! s:sign_extension(n) abort
+    return a:n
+  endfunction
+endif
+
 if exists('*and')
   function! s:_vital_created(module) abort
     for op in ['and', 'or', 'xor', 'invert']

--- a/autoload/vital/__vital__/Random/Xor128.vim
+++ b/autoload/vital/__vital__/Random/Xor128.vim
@@ -22,16 +22,18 @@ function! s:Generator.next() abort
   let self._x = self._y
   let self._y = self._z
   let self._z = self._w
-  let self._w = s:B.xor(s:B.xor(w, s:B.rshift(w, 19)), s:B.xor(t, s:B.rshift(t, 8)))
-  return self._w
+  let self._w = s:B.xor(s:B.xor(w, s:B.rshift32(w, 19)), s:B.xor(t, s:B.rshift32(t, 8)))
+  return s:B.sign_extension(self._w)
 endfunction
 
+" 0x80000000 in 32bit and 0xFFFFFFFF80000000 in 64bit
 function! s:Generator.min() abort
-  return 0x80000000
+  return -2147483648
 endfunction
 
+" 0x7FFFFFFF in 32bit/64bit
 function! s:Generator.max() abort
-  return 0x7FFFFFFF
+  return 2147483647
 endfunction
 
 function! s:Generator.seed(seeds) abort

--- a/doc/vital-bitwise.txt
+++ b/doc/vital-bitwise.txt
@@ -59,6 +59,13 @@ sign_extension({expr})			*Vital.Bitwise.sign_extension()*
 	" 4294967295 == 0xFFFFFFFF
 	" -1 == 0xFFFFFFFFFFFFFFFF
 
+lshift32({expr}, {bits})			*Vital.Bitwise.lshift32()*
+	Similar to |Vital.Bitwise.lshift()|, but always treats 32bit number.
+	With |+num64|, upper 32bits of results are always 0.
+
+rshift32({expr}, {bits})			*Vital.Bitwise.rshift32()*
+	Similar to |Vital.Bitwise.rshift()|, but always treats 32bit number.
+	With |+num64|, upper 32bits of {expr} is ignored.
 
 
 ==============================================================================

--- a/doc/vital-bitwise.txt
+++ b/doc/vital-bitwise.txt
@@ -38,10 +38,10 @@ invert({expr})					*Vital.Bitwise.invert()*
 	Bitwise invert.
 
 lshift({expr}, {bits})				*Vital.Bitwise.lshift()*
-	Bitwise shifts to left.  {bits} is masked by 0x1F.
+	Bitwise shifts to left.  {bits} is masked by 0x1F or 0x3F(|+num64|).
 
 rshift({expr}, {bits})				*Vital.Bitwise.rshift()*
-	Bitwise shifts to right.  {bits} is masked by 0x1F.
+	Bitwise shifts to right.  {bits} is masked by 0x1F or 0x3F(|+num64|).
 
 compare({expr}, {expr})				*Vital.Bitwise.compare()*
 	Compares as unsigned integer.  Returns -1, 0, or 1.

--- a/doc/vital-bitwise.txt
+++ b/doc/vital-bitwise.txt
@@ -41,7 +41,8 @@ lshift({expr}, {bits})				*Vital.Bitwise.lshift()*
 	Bitwise shifts to left.  {bits} is masked by 0x1F or 0x3F(|+num64|).
 
 rshift({expr}, {bits})				*Vital.Bitwise.rshift()*
-	Bitwise shifts to right.  {bits} is masked by 0x1F or 0x3F(|+num64|).
+	Bitwise logical shifts to right.  {bits} is masked by 0x1F or
+	0x3F(|+num64|).
 
 compare({expr}, {expr})				*Vital.Bitwise.compare()*
 	Compares as unsigned integer.  Returns -1, 0, or 1.

--- a/doc/vital-bitwise.txt
+++ b/doc/vital-bitwise.txt
@@ -47,6 +47,18 @@ rshift({expr}, {bits})				*Vital.Bitwise.rshift()*
 compare({expr}, {expr})				*Vital.Bitwise.compare()*
 	Compares as unsigned integer.  Returns -1, 0, or 1.
 
+sign_extension({expr})			*Vital.Bitwise.sign_extension()*
+	Apply sign extension to {expr}.
+	This reappears 32bit number in |+num64| environment.
+	With |+num64|, when the 32nd bit is 0, upper 32bits are filled by 0.
+	Otherwise, it is filled by 1.
+	Without |+num64|, returns {expr}.
+	Example(with |+num64|): >
+	echo B.sign_extension(4294967295)
+	" => -1
+	" 4294967295 == 0xFFFFFFFF
+	" -1 == 0xFFFFFFFFFFFFFFFF
+
 
 
 ==============================================================================

--- a/doc/vital-random-mt19937ar.txt
+++ b/doc/vital-random-mt19937ar.txt
@@ -25,6 +25,9 @@ imported from the implementation.
 
 https://github.com/ynkdir/vim-funlib/blob/master/autoload/random/mt19937ar.vim
 
+This implementation always generates 32bit number [-2147483648, 2147483647],
+even when you use Vim with |+num64|.
+
 >
 	let s:V = vital#of("vital")
 	let s:M = s:V.import("Random.Mt19937ar")

--- a/doc/vital-random-xor128.txt
+++ b/doc/vital-random-xor128.txt
@@ -18,6 +18,8 @@ INTRODUCTION				*Vital.Random.Xor128-introduction*
 xorshift algorithm.  Although xorshift has a reasonable period (2^128-1), it
 is fast and has less internal states.
 The paper about xorshift is http://www.jstatsoft.org/v08/i14/paper .
+This implementation always generates 32bit number [-2147483648, 2147483647],
+even when you use Vim with |+num64|.
 
 >
 	let s:V = vital#of("vital")

--- a/test/Bitwise.vimspec
+++ b/test/Bitwise.vimspec
@@ -4,57 +4,116 @@ Describe Bitwise
   End
 
   Describe .lshift()
-    It shifts bits to left
-      Assert Equals(B.lshift(0, 0), 0)
-      Assert Equals(B.lshift(0, 1), 0)
-      Assert Equals(B.lshift(0, 31), 0)
-      Assert Equals(B.lshift(0, 32), 0)
-      Assert Equals(B.lshift(1, 0), 0x1)
-      Assert Equals(B.lshift(1, 1), 0x2)
-      Assert Equals(B.lshift(1, 31), 0x80000000)
-      Assert Equals(B.lshift(1, 32), 1)
-      Assert Equals(B.lshift(0x80000000, 0), 0x80000000)
-      Assert Equals(B.lshift(0x80000000, 1), 0)
+    Context with small numbers
+      It shifts bits to left
+        Assert Equals(B.lshift(0, 0), 0)
+        Assert Equals(B.lshift(0, 1), 0)
+        Assert Equals(B.lshift(0, 31), 0)
+        Assert Equals(B.lshift(0, 32), 0)
+        Assert Equals(B.lshift(1, 0), 0x1)
+        Assert Equals(B.lshift(1, 1), 0x2)
+        Assert Equals(B.lshift(1, 31), 0x80000000)
+        Assert Equals(B.lshift(0x80000000, 0), 0x80000000)
+      End
     End
-    It shifts bits to left (random)
-      Assert Equals(B.lshift(1483929134, 14), -1114931200)
-      Assert Equals(B.lshift(152442939, 25), 1979711488)
-      Assert Equals(B.lshift(505850863, -32), 505850863)
-      Assert Equals(B.lshift(1997594360, 18), 2078277632)
-      Assert Equals(B.lshift(2121708807, -5), 939524096)
-      Assert Equals(B.lshift(344493590, -27), -1861107008)
-      Assert Equals(B.lshift(630127521, 14), -1092075520)
-      Assert Equals(B.lshift(-601661263, 0), -601661263)
-      Assert Equals(B.lshift(661012213, -26), -644891328)
-      Assert Equals(B.lshift(828605241, -14), 216268800)
-    End
+    if has('num64')
+      Context with 64bit number
+        It shifts bits to left
+          Assert Equals(B.lshift(1, 32), 0x100000000)
+          Assert Equals(B.lshift(0x80000000, 1), 0x100000000)
+          Assert Equals(B.lshift(1, 63), 0x8000000000000000)
+          Assert Equals(B.lshift(1, 64), 1)
+        End
+        It shifts bits to left (random)
+          Assert Equals(B.lshift(-6547820378035905891, -9), 5656521131977342976)
+          Assert Equals(B.lshift(-3338945565435194024, -25), -1203960834368208896)
+          Assert Equals(B.lshift(5765087922765281421, 52), -8588364489395535872)
+          Assert Equals(B.lshift(8920998653320978603, 11), 7928609028908079104)
+          Assert Equals(B.lshift(8442026461925972002, 38), -2096979230645551104)
+          Assert Equals(B.lshift(3547367712430972932, 54), 72057594037927936)
+          Assert Equals(B.lshift(8382076105951341210, 4), 4986009179254598048)
+          Assert Equals(B.lshift(4785275337718270894, -6), -5188146770730811392)
+          Assert Equals(B.lshift(-6707534047010871283, -13), 4640959416005296128)
+          Assert Equals(B.lshift(5188294801009928667, -20), 4511955915741593600)
+        End
+      End
+    else
+      Context with 32bit number
+        It shifts bits to left
+          Assert Equals(B.lshift(1, 32), 1)
+          Assert Equals(B.lshift(0x80000000, 1), 0)
+        End
+        It shifts bits to left (random)
+          Assert Equals(B.lshift(1483929134, 14), -1114931200)
+          Assert Equals(B.lshift(152442939, 25), 1979711488)
+          Assert Equals(B.lshift(505850863, -32), 505850863)
+          Assert Equals(B.lshift(1997594360, 18), 2078277632)
+          Assert Equals(B.lshift(2121708807, -5), 939524096)
+          Assert Equals(B.lshift(344493590, -27), -1861107008)
+          Assert Equals(B.lshift(630127521, 14), -1092075520)
+          Assert Equals(B.lshift(-601661263, 0), -601661263)
+          Assert Equals(B.lshift(661012213, -26), -644891328)
+          Assert Equals(B.lshift(828605241, -14), 216268800)
+        End
+      End
+    endif
   End
 
   Describe .rshift()
-    It shifts bits to right
-      Assert Equals(B.rshift(0, 0), 0)
-      Assert Equals(B.rshift(0, 1), 0)
-      Assert Equals(B.rshift(0, 31), 0)
-      Assert Equals(B.rshift(0, 32), 0)
-      Assert Equals(B.rshift(0x80000000, 0), 0x80000000)
-      Assert Equals(B.rshift(0x80000000, 1), 0x40000000)
-      Assert Equals(B.rshift(0x80000000, 31), 0x1)
-      Assert Equals(B.rshift(0x80000000, 32), 0x80000000)
-      Assert Equals(B.rshift(1, 0), 0x1)
-      Assert Equals(B.rshift(1, 1), 0)
+    Context with small numbers
+      It shifts bits to right
+        Assert Equals(B.rshift(0, 0), 0)
+        Assert Equals(B.rshift(0, 1), 0)
+        Assert Equals(B.rshift(0, 31), 0)
+        Assert Equals(B.rshift(0, 32), 0)
+        Assert Equals(B.rshift(0x80000000, 0), 0x80000000)
+        Assert Equals(B.rshift(0x80000000, 1), 0x40000000)
+        Assert Equals(B.rshift(0x80000000, 31), 0x1)
+        Assert Equals(B.rshift(1, 0), 0x1)
+        Assert Equals(B.rshift(1, 1), 0)
+      End
     End
-    It shifts bits to right (random)
-      Assert Equals(B.rshift(-488472937, -18), 232329)
-      Assert Equals(B.rshift(2077835096, 9), 4058271)
-      Assert Equals(B.rshift(-944346085, -27), 104706912)
-      Assert Equals(B.rshift(-410125501, -23), 7587581)
-      Assert Equals(B.rshift(-976767239, 10), 3240429)
-      Assert Equals(B.rshift(999071336, 20), 952)
-      Assert Equals(B.rshift(1103884747, -13), 2105)
-      Assert Equals(B.rshift(1971440513, -1), 0)
-      Assert Equals(B.rshift(-440231805, -25), 30115121)
-      Assert Equals(B.rshift(1872776440, 23), 223)
-    End
+    if has('num64')
+      Context with 64bit number
+        It shifts bits to right
+          Assert Equals(B.rshift(0x80000000, 32), 0)
+          Assert Equals(B.rshift(0x8000000000000000, 32), 0x80000000)
+          Assert Equals(B.rshift(0x8000000000000000, 63), 1)
+          Assert Equals(B.rshift(-1024, 1), 0x7ffffffffffffe00)
+        End
+        It shifts bits to right (random)
+          Assert Equals(B.rshift(-268801553147510890, -39), 541744903342)
+          Assert Equals(B.rshift(-8658667913393403549, 60), 8)
+          Assert Equals(B.rshift(8684623827924321670, -54), 8481077956957345)
+          Assert Equals(B.rshift(-2848134570708700373, 24), 929749578416)
+          Assert Equals(B.rshift(-9109203526092417183, 23), 1113121574833)
+          Assert Equals(B.rshift(1597408012962228558, 31), 743851071)
+          Assert Equals(B.rshift(8548771603265437164, -19), 242970)
+          Assert Equals(B.rshift(2784858960009211313, -9), 77)
+          Assert Equals(B.rshift(5980153482236010223, -56), 23359974539984414)
+          Assert Equals(B.rshift(5014075726800027940, -58), 78344933231250436)
+        End
+      End
+    else
+      Context with 32bit number
+        It shifts bits to right
+          Assert Equals(B.rshift(0x80000000, 32), 0x80000000)
+          Assert Equals(B.rshift(-1024, 1), 0x7ffffe00)
+        End
+        It shifts bits to right (random)
+          Assert Equals(B.rshift(-488472937, -18), 232329)
+          Assert Equals(B.rshift(2077835096, 9), 4058271)
+          Assert Equals(B.rshift(-944346085, -27), 104706912)
+          Assert Equals(B.rshift(-410125501, -23), 7587581)
+          Assert Equals(B.rshift(-976767239, 10), 3240429)
+          Assert Equals(B.rshift(999071336, 20), 952)
+          Assert Equals(B.rshift(1103884747, -13), 2105)
+          Assert Equals(B.rshift(1971440513, -1), 0)
+          Assert Equals(B.rshift(-440231805, -25), 30115121)
+          Assert Equals(B.rshift(1872776440, 23), 223)
+        End
+      End
+    endif
   End
 
   Describe .compare()

--- a/test/Bitwise.vimspec
+++ b/test/Bitwise.vimspec
@@ -222,4 +222,31 @@ Describe Bitwise
       Assert Equals(B.xor(838539477, 1024734483), 217001414)
     End
   End
+
+  Describe .sign_extension()
+    if has('num64')
+      Context with 64bit number
+        It applies sign extension
+          Assert Equals(B.sign_extension(0), 0)
+          Assert Equals(B.sign_extension(-1), -1)
+          Assert Equals(B.sign_extension(1), 1)
+          Assert Equals(B.sign_extension(0x7FFFFFFF), 0x7FFFFFFF)
+          Assert Equals(B.sign_extension(0xFFFFFFFF7FFFFFFF), 0x7FFFFFFF)
+          Assert Equals(B.sign_extension(0x80000000), 0xFFFFFFFF80000000)
+          Assert Equals(B.sign_extension(0xFFFFFFFF80000000), 0xFFFFFFFF80000000)
+          Assert Equals(B.sign_extension(0xFFFFFFFF), 0xFFFFFFFFFFFFFFFF)
+        End
+      End
+    else
+      Context with 32bit number
+        It returns the argument directly
+          Assert Equals(B.sign_extension(0), 0)
+          Assert Equals(B.sign_extension(-1), -1)
+          Assert Equals(B.sign_extension(1), 1)
+          Assert Equals(B.sign_extension(0x7FFFFFFF), 0x7FFFFFFF)
+          Assert Equals(B.sign_extension(0x80000000), 0x80000000)
+        End
+      End
+    endif
+  End
 End

--- a/test/Bitwise.vimspec
+++ b/test/Bitwise.vimspec
@@ -249,4 +249,59 @@ Describe Bitwise
       End
     endif
   End
+
+  Describe .lshift32()
+    if has('num64')
+      Context with 64bit number
+        It shifts bits to left with the 32bit range
+          Assert Equals(B.lshift32(0xFFFF0000, 8), 0xFF000000)
+          Assert Equals(B.lshift32(0xFFFF0000, 32), 0xFFFF0000)
+        End
+      End
+    else
+      Context with 32bit number
+        It is save as lshift()
+          Assert Equals(B.lshift(0, 0), 0)
+          Assert Equals(B.lshift(0, 1), 0)
+          Assert Equals(B.lshift(0, 31), 0)
+          Assert Equals(B.lshift(0, 32), 0)
+          Assert Equals(B.lshift(1, 0), 0x1)
+          Assert Equals(B.lshift(1, 1), 0x2)
+          Assert Equals(B.lshift(1, 31), 0x80000000)
+          Assert Equals(B.lshift(0x80000000, 0), 0x80000000)
+
+          Assert Equals(B.lshift(1, 32), 1)
+          Assert Equals(B.lshift(0x80000000, 1), 0)
+        End
+      End
+    endif
+  End
+
+  Describe .rshift32()
+    if has('num64')
+      Context with 64bit number
+        It shifts bits to right with the 32bit range
+          Assert Equals(B.rshift32(0xFFFF000000, 8), 0x00FF0000)
+          Assert Equals(B.rshift32(0xFFFF0000, 32), 0xFFFF0000)
+        End
+      End
+    else
+      Context with 32bit number
+        It is save as rshift()
+          Assert Equals(B.rshift(0, 0), 0)
+          Assert Equals(B.rshift(0, 1), 0)
+          Assert Equals(B.rshift(0, 31), 0)
+          Assert Equals(B.rshift(0, 32), 0)
+          Assert Equals(B.rshift(0x80000000, 0), 0x80000000)
+          Assert Equals(B.rshift(0x80000000, 1), 0x40000000)
+          Assert Equals(B.rshift(0x80000000, 31), 0x1)
+          Assert Equals(B.rshift(1, 0), 0x1)
+          Assert Equals(B.rshift(1, 1), 0)
+
+          Assert Equals(B.rshift(0x80000000, 32), 0x80000000)
+          Assert Equals(B.rshift(-1024, 1), 0x7ffffe00)
+        End
+      End
+    endif
+  End
 End

--- a/test/Math.vim
+++ b/test/Math.vim
@@ -16,14 +16,14 @@ endfunction
 
 function! s:suite.fib()
   " It returns fib if it's less than or equal to 48
-  call s:assert.equals(0, s:M.fib(0))
-  call s:assert.equals(1, s:M.fib(1))
-  call s:assert.equals(55, s:M.fib(10))
-  call s:assert.equals(2971215073, s:M.fib(47))
+  call s:assert.equals(s:M.fib(0), 0)
+  call s:assert.equals(s:M.fib(1), 1)
+  call s:assert.equals(s:M.fib(10), 55)
+  call s:assert.equals(s:M.fib(47), 2971215073)
   if has('num64')
-    call s:assert.equals(4807526976, s:M.fib(48))
+    call s:assert.equals(s:M.fib(48), 4807526976)
   else
-    call s:assert.equals(512559680, s:M.fib(48))
+    call s:assert.equals(s:M.fib(48), 512559680)
   endif
 endfunction
 

--- a/test/Math.vim
+++ b/test/Math.vim
@@ -19,7 +19,12 @@ function! s:suite.fib()
   call s:assert.equals(0, s:M.fib(0))
   call s:assert.equals(1, s:M.fib(1))
   call s:assert.equals(55, s:M.fib(10))
-  call s:assert.equals(512559680, s:M.fib(48))
+  call s:assert.equals(2971215073, s:M.fib(47))
+  if has('num64')
+    call s:assert.equals(4807526976, s:M.fib(48))
+  else
+    call s:assert.equals(512559680, s:M.fib(48))
+  endif
 endfunction
 
 function! s:suite.lcm()


### PR DESCRIPTION
Vim に +num64 feature が追加され、整数のサイズが 64bit になり、その影響でいくつかのモジュールの動作がおかしくなった。

- Bitwise
- Random
- Random.Xor128
- Random.Mt19937ar

この PR はこれらを修正する。