### PR TITLE
Data.String.remove_ansi_sequences() is broken ?

### DIFF
--- a/autoload/vital/__vital__/Data/String.vim
+++ b/autoload/vital/__vital__/Data/String.vim
@@ -534,7 +534,7 @@ else
 endif
 
 function! s:remove_ansi_sequences(text) abort
-  return substitute(a:text, '\e\[\%(\%(\d;\)\?\d\{1,2}\)\?[mK]', '', 'g')
+  return substitute(a:text, '\e\[\%(\%(\d\+;\)*\d\+\)\?[mK]', '', 'g')
 endfunction
 
 function! s:escape_pattern(str) abort

--- a/doc/vital-data-string.txt
+++ b/doc/vital-data-string.txt
@@ -349,7 +349,7 @@ wcswidth({str})					*Vital.Data.String.wcswidth()*
 remove_ansi_sequences({text})	*Vital.Data.String.remove_ansi_sequences()*
 	Remove ANSI sequences from {text}
 >
-	echo s:S.remove_ansi_sequences('\033[47m\033[32mGreen\033[0m')
+	echo s:S.remove_ansi_sequences("\033[47m\033[32mGreen\033[0m")
 	" 'Green'
 <
 escape_pattern({str})		*Vital.Data.String.escape_pattern()*

--- a/test/Data/String.vimspec
+++ b/test/Data/String.vimspec
@@ -8,13 +8,12 @@ Describe Data.String
 
   Context .remove_ansi_sequences()
     It should remove ANSI sequences in {val}
-      let val = "\033[47m\033[32mGreen\033[0m"
-      Assert Equals(String.remove_ansi_sequences(val), 'Green')
+      Assert Equals(String.remove_ansi_sequences("\033[47m\033[32mGreen\033[0m"), 'Green')
+      Assert Equals(String.remove_ansi_sequences(" \033[38;5;226m   \\  /\033[0m       Partly Cloudy"), '    \  /       Partly Cloudy')
     End
 
     It shoud NOT remove any characters in {val}
-      let val = "Green"
-      Assert Equals(String.remove_ansi_sequences(val), 'Green')
+      Assert Equals(String.remove_ansi_sequences("Green"), 'Green')
     End
   End
 

--- a/test/Data/String.vimspec
+++ b/test/Data/String.vimspec
@@ -11,6 +11,11 @@ Describe Data.String
       let val = "\033[47m\033[32mGreen\033[0m"
       Assert Equals(String.remove_ansi_sequences(val), 'Green')
     End
+
+    It shoud NOT remove any characters in {val}
+      let val = "Green"
+      Assert Equals(String.remove_ansi_sequences(val), 'Green')
+    End
   End
 
   Describe .escape_pattern()


### PR DESCRIPTION
Data.String.remove_ansi_sequences() は渡した文字列中の制御コードを削除するものですが、試した感じではうまく動作していないようでした。
手元環境の制御コードでしか動作確認していないので、WindowsやMacなどでも動かしていただいたほうが良いかもです。

```vim
" Before output: "\033[47m\033[32mGreen\033[0m"
" After output: "Green"
echo s:S.remove_ansi_sequences("\033[47m\033[32mGreen\033[0m")
```