### PR TITLE
Improve vim buffer

### DIFF
--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -142,6 +142,30 @@ function! s:edit_content(content, ...) abort
   setlocal nomodified
 endfunction
 
+function! s:parse_cmdarg(...) abort
+  let cmdarg = get(a:000, 0, v:cmdarg)
+  let options = {}
+  if cmdarg =~# '++enc='
+    let options.encoding = matchstr(cmdarg, '++enc=\zs[^ ]\+\ze')
+  endif
+  if cmdarg =~# '++ff='
+    let options.fileformat = matchstr(cmdarg, '++ff=\zs[^ ]\+\ze')
+  endif
+  if cmdarg =~# '++bad='
+    let options.bad = matchstr(cmdarg, '++bad=\zs[^ ]\+\ze')
+  endif
+  if cmdarg =~# '++bin'
+    let options.binary = 1
+  endif
+  if cmdarg =~# '++nobin'
+    let options.nobinary = 1
+  endif
+  if cmdarg =~# '++edit'
+    let options.edit = 1
+  endif
+  return options
+endfunction
+
 let &cpo = s:save_cpo
 unlet s:save_cpo
 

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -49,6 +49,18 @@ function! s:open(buffer, opener) abort
   return loaded
 endfunction
 
+function! s:is_preview_opener(opener) abort
+  if a:opener =~# '\%(^\|\W\)ptag\?!\?\%(\W\|$\)'
+    return 1
+  elseif a:opener =~# '\%(^\|\W\)ped\%[it]!\?\%(\W\|$\)'
+    return 1
+  elseif a:opener =~# '\%(^\|\W\)ps\%[earch]!\?\%(\W\|$\)'
+    return 1
+  endif
+  return 0
+endfunction
+
+
 function! s:get_selected_text(...) abort
   echohl WarningMsg
   echom "[WARN] s:get_selected_text() is deprecated. Use 's:get_last_selected()'."

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -111,7 +111,7 @@ function! s:read_content(content, ...) abort
         \ 'nobinary': 0,
         \ 'bad': '',
         \ 'edit': 0,
-        \ 'line': 0,
+        \ 'line': '',
         \}, get(a:000, 0, {}))
   let tempfile = empty(options.tempfile) ? tempname() : options.tempfile
   let optnames = [
@@ -126,7 +126,7 @@ function! s:read_content(content, ...) abort
   try
     call writefile(a:content, tempfile)
     execute printf('keepalt keepjumps %sread %s%s',
-          \ empty(options.line) ? '' : options.line,
+          \ options.line,
           \ empty(optname) ? '' : optname . ' ',
           \ fnameescape(tempfile),
           \)

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -50,11 +50,11 @@ function! s:open(buffer, opener) abort
 endfunction
 
 function! s:is_preview_opener(opener) abort
-  if a:opener =~# '\%(^\|\W\)ptag\?!\?\%(\W\|$\)'
+  if a:opener =~# '\<ptag\?!\?\>'
     return 1
-  elseif a:opener =~# '\%(^\|\W\)ped\%[it]!\?\%(\W\|$\)'
+  elseif a:opener =~# '\<ped\%[it]!\?\>'
     return 1
-  elseif a:opener =~# '\%(^\|\W\)ps\%[earch]!\?\%(\W\|$\)'
+  elseif a:opener =~# '\<ps\%[earch]!\?\>'
     return 1
   endif
   return 0

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -49,18 +49,6 @@ function! s:open(buffer, opener) abort
   return loaded
 endfunction
 
-function! s:is_preview_opener(opener) abort
-  if a:opener =~# '\<ptag\?!\?\>'
-    return 1
-  elseif a:opener =~# '\<ped\%[it]!\?\>'
-    return 1
-  elseif a:opener =~# '\<ps\%[earch]!\?\>'
-    return 1
-  endif
-  return 0
-endfunction
-
-
 function! s:get_selected_text(...) abort
   echohl WarningMsg
   echom "[WARN] s:get_selected_text() is deprecated. Use 's:get_last_selected()'."

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -99,6 +99,7 @@ function! s:read_content(content, ...) abort
         \ 'nobinary': 0,
         \ 'bad': '',
         \ 'edit': 0,
+        \ 'line': 0,
         \}, get(a:000, 0, {}))
   let tempfile = empty(options.tempfile) ? tempname() : options.tempfile
   let optnames = [
@@ -112,7 +113,8 @@ function! s:read_content(content, ...) abort
   let optname = join(filter(optnames, '!empty(v:val)'))
   try
     call writefile(a:content, tempfile)
-    execute printf('keepalt keepjumps read %s%s',
+    execute printf('keepalt keepjumps %sread %s%s',
+          \ empty(options.line) ? '' : options.line,
           \ empty(optname) ? '' : optname . ' ',
           \ fnameescape(tempfile),
           \)

--- a/doc/vital-vim-buffer.txt
+++ b/doc/vital-vim-buffer.txt
@@ -42,10 +42,6 @@ is_cmdwin()				*Vital.Vim.Buffer.is_cmdwin()*
 	|command-line-window| or not. Note that most of buffer manipulation
 	does not work in the window.
 
-is_preview_opener({opener})		*Vital.Vim.Buffer.is_preview_opener()*
-	Return a boolean (0/1) which indicate whether opening a new buffer
-	with a {opener} opens |preview-window| or not.
-
 get_last_selected()			*Vital.Vim.Buffer.get_last_selected()*
 	Get the last selected text in visual mode.
 	This is almost the same as

--- a/doc/vital-vim-buffer.txt
+++ b/doc/vital-vim-buffer.txt
@@ -99,7 +99,7 @@ read_content({content}[, {options}])	*Vital.Vim.Buffer.read_content()*
 	A default value is 0.
 	'line'
 	To append content after the specified linenum.
-	A default value is 0 which append content after the cursor line.
+	A default value is '' which append content after the cursor line.
 
 edit_content({content}[, {options}])	*Vital.Vim.Bufer.edit_content()*
 	Replace content of the current buffer to {content}. It is similar to

--- a/doc/vital-vim-buffer.txt
+++ b/doc/vital-vim-buffer.txt
@@ -105,5 +105,12 @@ edit_content({content}[, {options}])	*Vital.Vim.Bufer.edit_content()*
 	so developers can change the behavior of internal |:read| command as
 	|Vital.Vim.Buffer.read_content()|.
 
+parse_cmdarg([{cmdarg}])		*Vital.Vim.Buffer.parse_cmdarg*
+	Parse {cmdarg} which is used as [++opt] in |:read| or |:edit| command
+	and return a {options} dictionary which can directly be used in
+	|Vital.Vim.Buffer.read_content()| or
+	|Vital.Vim.Buffer.edit_content()|.
+	If {cmdarg} is not specified, |v:cmdarg| is used instead.
+
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital-vim-buffer.txt
+++ b/doc/vital-vim-buffer.txt
@@ -42,6 +42,10 @@ is_cmdwin()				*Vital.Vim.Buffer.is_cmdwin()*
 	|command-line-window| or not. Note that most of buffer manipulation
 	does not work in the window.
 
+is_preview_opener({opener})		*Vital.Vim.Buffer.is_preview_opener()*
+	Return a boolean (0/1) which indicate whether opening a new buffer
+	with a {opener} opens |preview-window| or not.
+
 get_last_selected()			*Vital.Vim.Buffer.get_last_selected()*
 	Get the last selected text in visual mode.
 	This is almost the same as

--- a/doc/vital-vim-buffer.txt
+++ b/doc/vital-vim-buffer.txt
@@ -93,6 +93,9 @@ read_content({content}[, {options}])	*Vital.Vim.Buffer.read_content()*
 	'edit'
 	To keep option values as if editing a file. See |++edit|.
 	A default value is 0.
+	'line'
+	To append content after the specified linenum.
+	A default value is 0 which append content after the cursor line.
 
 edit_content({content}[, {options}])	*Vital.Vim.Bufer.edit_content()*
 	Replace content of the current buffer to {content}. It is similar to

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -184,6 +184,39 @@ Describe Vim.Buffer
       call Buffer.read_content([''], {'tempfile': fname})
       Assert Equals(bufnr(fname), -1)
     End
+
+    It append content after cursor
+        call setline(1, ['aaaaa', 'bbbbb', 'ccccc'])
+        let cursor = getpos('.')
+        call setpos('.', [0, 2, 1, 0])
+        let contents = readfile(
+              \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
+              \)
+        call Buffer.read_content(contents)
+        Assert Equals(getline(1, '$'), [
+              \ 'aaaaa',
+              \ 'bbbbb',
+              \ 'あいうえお',
+              \ 'ccccc',
+              \])
+        call setpos('.', cursor)
+    End
+
+    It append content after {options.line}
+        call setline(1, ['aaaaa', 'bbbbb', 'ccccc'])
+        let contents = readfile(
+              \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
+              \)
+        call Buffer.read_content(contents, {
+              \ 'line': 2,
+              \})
+        Assert Equals(getline(1, '$'), [
+              \ 'aaaaa',
+              \ 'bbbbb',
+              \ 'あいうえお',
+              \ 'ccccc',
+              \])
+    End
   End
 
   Describe edit_content()

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -187,7 +187,6 @@ Describe Vim.Buffer
 
     It append content after cursor
         call setline(1, ['aaaaa', 'bbbbb', 'ccccc'])
-        let cursor = getpos('.')
         call setpos('.', [0, 2, 1, 0])
         let contents = readfile(
               \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
@@ -199,7 +198,6 @@ Describe Vim.Buffer
               \ 'あいうえお',
               \ 'ccccc',
               \])
-        call setpos('.', cursor)
     End
 
     It append content after {options.line}

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -252,6 +252,22 @@ Describe Vim.Buffer
               \ 'ccccc',
               \])
     End
+
+    It insert content before the first line when {options.line} is 0
+        call setline(1, ['aaaaa', 'bbbbb', 'ccccc'])
+        let contents = readfile(
+              \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
+              \)
+        call Buffer.read_content(contents, {
+              \ 'line': 0,
+              \})
+        Assert Equals(getline(1, '$'), [
+              \ 'あいうえお',
+              \ 'aaaaa',
+              \ 'bbbbb',
+              \ 'ccccc',
+              \])
+    End
   End
 
   Describe edit_content()

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -15,41 +15,6 @@ Describe Vim.Buffer
     windo bwipeout!
   End
 
-  Describe .is_preview_opener()
-    It returns 0 for 'edit'
-      Assert False(Buffer.is_preview_opener('e'))
-      Assert False(Buffer.is_preview_opener('edit'))
-    End
-
-    It returns 0 for 'new/vnew'
-      Assert False(Buffer.is_preview_opener('new'))
-      Assert False(Buffer.is_preview_opener('vnew'))
-    End
-
-    It returns 0 for 'split/vsplit'
-      Assert False(Buffer.is_preview_opener('split'))
-      Assert False(Buffer.is_preview_opener('vsplit'))
-    End
-
-    It returns 1 for 'ptag'
-      Assert True(Buffer.is_preview_opener('pta'))
-      Assert True(Buffer.is_preview_opener('ptag'))
-      Assert True(Buffer.is_preview_opener('botright ptag'))
-    End
-
-    It returns 1 for 'pedit'
-      Assert True(Buffer.is_preview_opener('ped'))
-      Assert True(Buffer.is_preview_opener('pedit'))
-      Assert True(Buffer.is_preview_opener('botright pedit'))
-    End
-
-    It returns 1 for 'psearch'
-      Assert True(Buffer.is_preview_opener('ps'))
-      Assert True(Buffer.is_preview_opener('psearch'))
-      Assert True(Buffer.is_preview_opener('botright psearch'))
-    End
-  End
-
   Describe .is_cmdwin()
     It detects if current window is cmdwin.
       " FIXME: CmdWin can not open from test environment

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -15,6 +15,41 @@ Describe Vim.Buffer
     windo bwipeout!
   End
 
+  Describe .is_preview_opener()
+    It returns 0 for 'edit'
+      Assert False(Buffer.is_preview_opener('e'))
+      Assert False(Buffer.is_preview_opener('edit'))
+    End
+
+    It returns 0 for 'new/vnew'
+      Assert False(Buffer.is_preview_opener('new'))
+      Assert False(Buffer.is_preview_opener('vnew'))
+    End
+
+    It returns 0 for 'split/vsplit'
+      Assert False(Buffer.is_preview_opener('split'))
+      Assert False(Buffer.is_preview_opener('vsplit'))
+    End
+
+    It returns 1 for 'ptag'
+      Assert True(Buffer.is_preview_opener('pta'))
+      Assert True(Buffer.is_preview_opener('ptag'))
+      Assert True(Buffer.is_preview_opener('botright ptag'))
+    End
+
+    It returns 1 for 'pedit'
+      Assert True(Buffer.is_preview_opener('ped'))
+      Assert True(Buffer.is_preview_opener('pedit'))
+      Assert True(Buffer.is_preview_opener('botright pedit'))
+    End
+
+    It returns 1 for 'psearch'
+      Assert True(Buffer.is_preview_opener('ps'))
+      Assert True(Buffer.is_preview_opener('psearch'))
+      Assert True(Buffer.is_preview_opener('botright psearch'))
+    End
+  End
+
   Describe .is_cmdwin()
     It detects if current window is cmdwin.
       " FIXME: CmdWin can not open from test environment

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -272,4 +272,54 @@ Describe Vim.Buffer
       End
     End
   End
+
+  Describe parse_cmdarg()
+    It returns an empty dictionary for non cmdarg
+      let ret = Buffer.parse_cmdarg('')
+      Assert Equals(ret, {})
+    End
+    It parses "++enc=XXX" and return "encoding: XXX" dictionary
+      let ret = Buffer.parse_cmdarg('++enc=utf-8')
+      Assert Equals(ret, { 'encoding': 'utf-8' })
+    End
+
+    It parses "++ff=XXX" and return "fileformat: XXX" dictionary
+      let ret = Buffer.parse_cmdarg('++ff=dos')
+      Assert Equals(ret, { 'fileformat': 'dos' })
+    End
+
+    It parses "++bad=XXX" and return "bad: XXX" dictionary
+      let ret = Buffer.parse_cmdarg('++bad=keep')
+      Assert Equals(ret, { 'bad': 'keep' })
+    End
+
+    It parses "++bin" and return "binary: 1" dictionary
+      let ret = Buffer.parse_cmdarg('++binary')
+      Assert Equals(ret, { 'binary': 1 })
+    End
+
+    It parses "++nobin" and return "nobinary: 1" dictionary
+      let ret = Buffer.parse_cmdarg('++nobin')
+      Assert Equals(ret, { 'nobinary': 1 })
+    End
+
+    It parses "++edit" and return "edit: 1" dictionary
+      let ret = Buffer.parse_cmdarg('++edit')
+      Assert Equals(ret, { 'edit': 1 })
+    End
+
+    It parses multiple opts specification and return a correct dictionary
+      let ret = Buffer.parse_cmdarg(
+            \ '++enc=utf-8 ++ff=dos ++bad=keep ++binary ++nobinary ++edit'
+            \)
+      Assert Equals(ret, {
+            \ 'encoding': 'utf-8',
+            \ 'fileformat': 'dos',
+            \ 'bad': 'keep',
+            \ 'binary': 1,
+            \ 'nobinary': 1,
+            \ 'edit': 1,
+            \})
+    End
+  End
 End


### PR DESCRIPTION
- `read_content()` で挿入位置を指定可能にした
- `read_content()` や `edit_content()` で使う `{options}` を作るメソッドを追加
- <del> `open()` で使う（文字列の） `opener` が preview-window を開くか判断するメソッドを追加 </del>

<del> 最後のプレビューか判断する奴の使用用途は「バッファが開いてからコンテンツを書き換えたいが preview-window だとフォーカスが動かないので preview-window の場合は明示的に `wincmd P` を呼び出したい」などの場合用です。 </del>