### PR TITLE
Web.URI: Use robust operators !=# instead of !=

### DIFF
--- a/autoload/vital/__vital__/Web/URI.vim
+++ b/autoload/vital/__vital__/Web/URI.vim
@@ -439,7 +439,7 @@ function! s:_parse_relative_ref(relstr, pattern_set) abort
     let fragment = ''
   endif
   " no trailing string allowed.
-  if rest != ''
+  if rest !=# ''
     throw 'uri parse error(relative-ref): unnecessary string at the end.'
   endif
 


### PR DESCRIPTION
From vint