### PR TITLE
Fix Vital.Math.nr2str() example

### DIFF
--- a/doc/vital/Math.txt
+++ b/doc/vital/Math.txt
@@ -122,7 +122,7 @@ nr2str({expr} [, {base}])		*Vital.Math.nr2str()*
 	 When {base} is omitted base 10 is used.
 >
 	nr2str(10) == "10"
-	nr2str(10, 2) == "2"
+	nr2str(10, 2) == "1010"
 	nr2str(255, 16) == "FF"
 	nr2str(1295, 36) == "ZZ"
 <


### PR DESCRIPTION
The result of `nr2str(10, 2)` is `"1010"`.
It seems to be confused with `str2nr("10", 2) == 2`.