### PR TITLE
Fix and improve Vim.Buffer.read_content/edit_content

### DIFF
--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -100,6 +100,7 @@ function! s:read_content(content, ...) abort
         \ 'bad': '',
         \ 'edit': 0,
         \ 'line': '',
+        \ 'lockmarks': 0,
         \}, get(a:000, 0, {}))
   let tempfile = empty(options.tempfile) ? tempname() : options.tempfile
   let optnames = [
@@ -113,7 +114,8 @@ function! s:read_content(content, ...) abort
   let optname = join(filter(optnames, '!empty(v:val)'))
   try
     call writefile(a:content, tempfile)
-    execute printf('keepalt keepjumps %sread %s%s',
+    execute printf('keepalt keepjumps %s%sread %s%s',
+          \ options.lockmarks ? 'lockmarks ' : '',
           \ options.line,
           \ empty(optname) ? '' : optname . ' ',
           \ fnameescape(tempfile),
@@ -127,16 +129,23 @@ endfunction
 function! s:edit_content(content, ...) abort
   let options = extend({
         \ 'edit': 1,
+        \ 'lockmarks': 0,
         \}, get(a:000, 0, {}))
   let guard = s:G.store(['&l:modifiable'])
   let saved_view = winsaveview()
   try
     let &l:modifiable=1
-    silent keepjumps %delete _
+    silent execute printf(
+          \ 'keepjumps %s%%delete _',
+          \ options.lockmarks ? 'lockmarks ' : '',
+          \)
     silent call s:read_content(a:content, options)
-    silent keepjumps 1delete _
+    silent execute printf(
+          \ 'keepjumps %s1delete _',
+          \ options.lockmarks ? 'lockmarks ' : '',
+          \)
   finally
-    keepjump call winrestview(saved_view)
+    keepjumps call winrestview(saved_view)
     call guard.restore()
   endtry
   setlocal nomodified

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -122,7 +122,8 @@ function! s:read_content(content, ...) abort
           \)
   finally
     call delete(tempfile)
-    execute 'bwipeout!' tempfile
+    " To remove 'tempfile' from unlisted-buffer #439
+    silent execute 'bwipeout!' fnameescape(tempfile)
   endtry
 endfunction
 

--- a/doc/vital/Vim/Buffer.txt
+++ b/doc/vital/Vim/Buffer.txt
@@ -96,6 +96,10 @@ read_content({content}[, {options}])	*Vital.Vim.Buffer.read_content()*
 	'line'
 	To append content after the specified linenum.
 	A default value is '' which append content after the cursor line.
+	'lockmarks'
+	Use |lockmarks| to execute command so that the marks are not adjusted
+	during the operation.
+	A default value is 0.
 
 edit_content({content}[, {options}])	*Vital.Vim.Bufer.edit_content()*
 	Replace content of the current buffer to {content}. It is similar to


### PR DESCRIPTION
1. Fix 'no such buffer' exception during 'read_content' (ref: https://github.com/lambdalisue/vim-gista/issues/81#issuecomment-271821407)
2. Add 'lockmarks' option to lock marks on the buffer