### PR TITLE
Avoid executing system() with '&' on neovim

### DIFF
--- a/autoload/vital/__vital__/Process.vim
+++ b/autoload/vital/__vital__/Process.vim
@@ -134,7 +134,8 @@ function! s:system(str, ...) abort
     let command = s:iconv(command, &encoding, 'char')
   endif
   let args = [command] + args
-  if background && (use_vimproc || !s:is_windows)
+  "NOTE: neovim cannot use '&' in system() at 2017-01-13, see :h system()
+  if background && (use_vimproc || !s:is_windows) && !has('nvim')
     let args[0] = args[0] . ' &'
   endif
 

--- a/doc/vital/Process.txt
+++ b/doc/vital/Process.txt
@@ -63,6 +63,8 @@ system({command} [, {dict}])
 	If {timeout} is specified, the command will be killed after {timeout}
 	milliseconds.  Note that {timeout} is available only when
 	|has_vimproc()| returns non-zero.
+	Note NeoVim cannot use system() with '&',
+	Please See :h system() on NeoVim.
 
 	When the 2nd argument is Dictionary, you can specify more options.
 	{dict} structure is:


### PR DESCRIPTION
NeoVimの`:h system()`によると
「system()で'&'を付けて実行はできないので、代わりにjobstart()を使って下さい」
とのことですが、ここでjobstart()ぶちこむのは違う気がするのと、すごいめんどくさそうなのでこれでどうでしょうか！