### PR TITLE
Process: system() should throw if "&" was given on neovim

### DIFF
--- a/autoload/vital/__vital__/Process.vim
+++ b/autoload/vital/__vital__/Process.vim
@@ -134,8 +134,11 @@ function! s:system(str, ...) abort
     let command = s:iconv(command, &encoding, 'char')
   endif
   let args = [command] + args
-  "NOTE: neovim cannot use '&' in system() at 2017-01-13, see :h system()
-  if background && (use_vimproc || !s:is_windows) && !has('nvim')
+  if background && (use_vimproc || !s:is_windows)
+    "NOTE: neovim cannot use '&' in system() at 2017-01-13, see :h system() on neovim
+    if has('nvim')
+      throw "Process.system(): neovim's system() doesn't support background(&) process (cmdline:".a:expr.')'
+    endif
     let args[0] = args[0] . ' &'
   endif
 

--- a/autoload/vital/__vital__/Process.vim
+++ b/autoload/vital/__vital__/Process.vim
@@ -38,7 +38,7 @@ function! s:spawn(expr, ...) abort
         let cmdline = substitute(cmdline, '\([!%#]\|<[^<>]\+>\)', '\\\1', 'g')
       endif
     else
-      throw 'Process.spawn(): invalid argument (value type:' . type(a:expr) . ')'
+      throw 'vital: Process.spawn(): invalid argument (value type:' . type(a:expr) . ')'
     endif
     if s:is_windows
       silent execute '!start' cmdline
@@ -111,7 +111,7 @@ function! s:system(str, ...) abort
     elseif type(a:1) is s:TYPE_STRING
       let args += [s:iconv(a:1, &encoding, 'char')]
     else
-      throw 'Process.system(): invalid argument (value type:' . type(a:1) . ')'
+      throw 'vital: Process.system(): invalid argument (value type:' . type(a:1) . ')'
     endif
   elseif a:0 >= 2
     " {command} [, {input} [, {timeout}]]
@@ -128,7 +128,7 @@ function! s:system(str, ...) abort
   elseif type(a:str) is s:TYPE_STRING
     let command = a:str
   else
-    throw 'Process.system(): invalid argument (value type:' . type(a:str) . ')'
+    throw 'vital: Process.system(): invalid argument (value type:' . type(a:str) . ')'
   endif
   if s:need_trans
     let command = s:iconv(command, &encoding, 'char')
@@ -136,7 +136,7 @@ function! s:system(str, ...) abort
   let args = [command] + args
   if background && (use_vimproc || !s:is_windows)
     if has('nvim')
-      throw "Process.system(): neovim's system() doesn't support background(&) process (cmdline:" . a:str . ')'
+      throw "vital: Process.system(): neovim's system() doesn't support background(&) process (cmdline:" . a:str . ')'
     endif
     let args[0] = args[0] . ' &'
   endif

--- a/autoload/vital/__vital__/Process.vim
+++ b/autoload/vital/__vital__/Process.vim
@@ -38,7 +38,7 @@ function! s:spawn(expr, ...) abort
         let cmdline = substitute(cmdline, '\([!%#]\|<[^<>]\+>\)', '\\\1', 'g')
       endif
     else
-      throw 'vital: Process.spawn(): invalid argument (value type:' . type(a:expr) . ')'
+      throw 'vital: Process: invalid argument (value type:' . type(a:expr) . ')'
     endif
     if s:is_windows
       silent execute '!start' cmdline
@@ -111,7 +111,7 @@ function! s:system(str, ...) abort
     elseif type(a:1) is s:TYPE_STRING
       let args += [s:iconv(a:1, &encoding, 'char')]
     else
-      throw 'vital: Process.system(): invalid argument (value type:' . type(a:1) . ')'
+      throw 'vital: Process: invalid argument (value type:' . type(a:1) . ')'
     endif
   elseif a:0 >= 2
     " {command} [, {input} [, {timeout}]]
@@ -128,7 +128,7 @@ function! s:system(str, ...) abort
   elseif type(a:str) is s:TYPE_STRING
     let command = a:str
   else
-    throw 'vital: Process.system(): invalid argument (value type:' . type(a:str) . ')'
+    throw 'vital: Process: invalid argument (value type:' . type(a:str) . ')'
   endif
   if s:need_trans
     let command = s:iconv(command, &encoding, 'char')
@@ -136,7 +136,7 @@ function! s:system(str, ...) abort
   let args = [command] + args
   if background && (use_vimproc || !s:is_windows)
     if has('nvim')
-      throw "vital: Process.system(): neovim's system() doesn't support background(&) process (cmdline:" . a:str . ')'
+      throw "vital: Process: neovim's system() doesn't support background(&) process (cmdline:" . a:str . ')'
     endif
     let args[0] = args[0] . ' &'
   endif

--- a/autoload/vital/__vital__/Process.vim
+++ b/autoload/vital/__vital__/Process.vim
@@ -38,7 +38,7 @@ function! s:spawn(expr, ...) abort
         let cmdline = substitute(cmdline, '\([!%#]\|<[^<>]\+>\)', '\\\1', 'g')
       endif
     else
-      throw 'Process.spawn(): invalid argument (value type:'.type(a:expr).')'
+      throw 'Process.spawn(): invalid argument (value type:' . type(a:expr) . ')'
     endif
     if s:is_windows
       silent execute '!start' cmdline
@@ -111,7 +111,7 @@ function! s:system(str, ...) abort
     elseif type(a:1) is s:TYPE_STRING
       let args += [s:iconv(a:1, &encoding, 'char')]
     else
-      throw 'Process.system(): invalid argument (value type:'.type(a:1).')'
+      throw 'Process.system(): invalid argument (value type:' . type(a:1) . ')'
     endif
   elseif a:0 >= 2
     " {command} [, {input} [, {timeout}]]
@@ -128,16 +128,15 @@ function! s:system(str, ...) abort
   elseif type(a:str) is s:TYPE_STRING
     let command = a:str
   else
-    throw 'Process.system(): invalid argument (value type:'.type(a:str).')'
+    throw 'Process.system(): invalid argument (value type:' . type(a:str) . ')'
   endif
   if s:need_trans
     let command = s:iconv(command, &encoding, 'char')
   endif
   let args = [command] + args
   if background && (use_vimproc || !s:is_windows)
-    "NOTE: neovim cannot use '&' in system() at 2017-01-13, see :h system() on neovim
     if has('nvim')
-      throw "Process.system(): neovim's system() doesn't support background(&) process (cmdline:".a:expr.')'
+      throw "Process.system(): neovim's system() doesn't support background(&) process (cmdline:" . a:str . ')'
     endif
     let args[0] = args[0] . ' &'
   endif


### PR DESCRIPTION
ref. #467 

@rhysd さんが Twitter で呟いてて、確かにそうだと思ったので修正しました。

> ん，これは neovim でバックグラウンド実行したら jobstart() かエラーにすべきじゃないのか…
> https://twitter.com/Linda_pp/status/820171056186986496

#467 で入ったドキュメントの文言の修正は必要ないと思ったのでやっていません。