### PR TITLE
Unify error message format (vital: {module name}: ...)

### DIFF
--- a/autoload/vital/__vital__/ConcurrentProcess.vim
+++ b/autoload/vital/__vital__/ConcurrentProcess.vim
@@ -167,7 +167,7 @@ function! s:tick(label) abort
     call s:tick(a:label)
   else
     " must not happen
-    throw 'ConcurrentProcess: must not happen'
+    throw 'vital: ConcurrentProcess: must not happen'
   endif
 endfunction
 

--- a/autoload/vital/__vital__/Database/SQLite.vim
+++ b/autoload/vital/__vital__/Database/SQLite.vim
@@ -45,7 +45,7 @@ function! s:query_rawdata(db, q, ...) abort
   let xs = get(a:000, 0, [])
   " hmm...
   " if !filewritable(a:db)
-  "   throw printf("Database.SQLite.query() given db (%s) isn't writable.", a:db)
+  "   throw printf("vital: Database.SQLite: Given db (%s) isn't writable.", a:db)
   " endif
   let built = s:build_line_from_query_with_placeholders(a:q, xs)
   let cmd = printf(

--- a/autoload/vital/__vital__/Database/SQLite.vim
+++ b/autoload/vital/__vital__/Database/SQLite.vim
@@ -45,7 +45,7 @@ function! s:query_rawdata(db, q, ...) abort
   let xs = get(a:000, 0, [])
   " hmm...
   " if !filewritable(a:db)
-  "   throw printf("vital: Database.SQLite: Given db (%s) isn't writable.", a:db)
+  "   throw printf("vital: Database.SQLite: given db (%s) isn't writable.", a:db)
   " endif
   let built = s:build_line_from_query_with_placeholders(a:q, xs)
   let cmd = printf(

--- a/autoload/vital/__vital__/Experimental/Functor.vim
+++ b/autoload/vital/__vital__/Experimental/Functor.vim
@@ -42,7 +42,7 @@ function! s:wrap(callable) abort
       \}, 'force')
     endif
   endif
-  throw 'vital: Functor.wrap(): '
+  throw 'vital: Functor: wrap(): '
   \   . 'a:callable is not callable!'
 endfunction
 

--- a/autoload/vital/__vital__/Interpreter/Brainf__k.vim
+++ b/autoload/vital/__vital__/Interpreter/Brainf__k.vim
@@ -30,7 +30,7 @@ endfunction
 function! s:run_vim_parse_execute(bfcode) abort
   let [asts, rest] = s:_vim_parse(a:bfcode)
   if rest !=# ''
-    throw 'Vital.Interpreter.Brainf__k.run_vim_parse_execute(): parser failed to consume'
+    throw 'vital: Interpreter.Brainf__k: run_vim_parse_execute(): parser failed to consume'
   endif
   call s:_vim_execute(asts, 0, {})
 endfunction
@@ -38,7 +38,7 @@ endfunction
 function! s:run_lua_parse_execute(bfcode) abort
   let [asts, rest] =  s:_lua_parse(a:bfcode)
   if rest !=# ''
-    throw 'Vital.Interpreter.Brainf__k.run_vim_parse_execute(): parser failed to consume'
+    throw 'vital: Interpreter.Brainf__k: run_vim_parse_execute(): parser failed to consume'
   endif
   call s:_lua_execute(asts, 0, {})
 endfunction

--- a/autoload/vital/__vital__/Random/Xor128.vim
+++ b/autoload/vital/__vital__/Random/Xor128.vim
@@ -58,7 +58,7 @@ function! s:srand(...) abort
   elseif a:0 == 1
     let x = a:1
   else
-    throw 'vital: Random.Xor128.srand(): too many arguments'
+    throw 'vital: Random.Xor128: srand(): too many arguments'
   endif
   call s:common_generator.seed([x])
 endfunction

--- a/autoload/vital/__vital__/Text/Lexer.vim
+++ b/autoload/vital/__vital__/Text/Lexer.vim
@@ -24,7 +24,7 @@ function! s:_list2dict(list) abort
 endfunction
 
 function! s:_exception(msg) abort
-  throw printf('[Text.Lexer] %s', a:msg)
+  throw printf('vital: Text.Lexer: %s', a:msg)
 endfunction
 
 let s:obj = { 'tokens' : [] }
@@ -68,7 +68,7 @@ function! s:token(label,matched_text,col) abort
 endfunction
 
 function! s:simple_parser(expr) abort
-  echoerr 'Text.Lexer.simple_parser(expr) is obsolete. Use Text.Parser.parser() instead.'
+  echoerr 'vital: Text.Lexer: simple_parser(expr) is obsolete. Use Text.Parser.parser() instead.'
   let obj = { 'expr' : a:expr, 'idx' : 0, 'tokens' : [] }
   function! obj.end() dict abort
     return len(self.expr) <= self.idx

--- a/autoload/vital/__vital__/Text/Parser.vim
+++ b/autoload/vital/__vital__/Text/Parser.vim
@@ -3,7 +3,7 @@ set cpo&vim
 
 
 function! s:_exception(msg) abort
-  throw printf('[Text.Parser] %s', a:msg)
+  throw printf('vital: Text.Parser: %s', a:msg)
 endfunction
 
 

--- a/autoload/vital/__vital__/Web/URI.vim
+++ b/autoload/vital/__vital__/Web/URI.vim
@@ -145,7 +145,7 @@ function! s:_parse_uri(str, ignore_rest, pattern_set) abort
   endif
 
   if !a:ignore_rest && rest !=# ''
-    throw 'uri parse error: unnecessary string at the end.'
+    throw 'vital: Web.URI: uri parse error: unnecessary string at the end.'
   endif
 
   let obj = deepcopy(s:URI)
@@ -180,7 +180,7 @@ function! s:_eat_em(str, pat, ...) abort
   if empty(m)
     let prefix = printf('uri parse error%s: ', (a:0 ? '('.a:1.')' : ''))
     let msg = printf("can't parse '%s' with '%s'.", a:str, pat)
-    throw prefix . msg
+    throw 'vital: Web.URI: ' . prefix . msg
   endif
   let rest = strpart(a:str, strlen(m[0]))
   return [m[0], rest]
@@ -217,10 +217,10 @@ function! s:_eat_hier_part(rest, pattern_set) abort
     elseif rest ==# '' || rest =~# '^[?#]'    " zero characters
       let path = ''
     else
-      throw printf("uri parse error(hier-part): can't parse '%s'.", rest)
+      throw printf("vital: Web.URI: uri parse error(hier-part): can't parse '%s'.", rest)
     endif
   else
-    throw printf("uri parse error(hier-part): can't parse '%s'.", rest)
+    throw printf("vital: Web.URI: uri parse error(hier-part): can't parse '%s'.", rest)
   endif
   return [{
   \ 'userinfo': userinfo,
@@ -440,7 +440,7 @@ function! s:_parse_relative_ref(relstr, pattern_set) abort
   endif
   " no trailing string allowed.
   if rest !=# ''
-    throw 'uri parse error(relative-ref): unnecessary string at the end.'
+    throw 'vital: Web.URI: uri parse error(relative-ref): unnecessary string at the end.'
   endif
 
   let obj = deepcopy(s:URI)
@@ -486,7 +486,7 @@ function! s:_parse_relative_part(rel_uri, pattern_set) abort
     elseif rest ==# '' || rest =~# '^[?#]'    " zero characters
       let path = ''
     else
-      throw printf("uri parse error(relative-part): can't parse '%s'.", rest)
+      throw printf("vital: Web.URI: uri parse error(relative-part): can't parse '%s'.", rest)
     endif
   endif
   return [{

--- a/autoload/vital/__vital__/Web/URI.vim
+++ b/autoload/vital/__vital__/Web/URI.vim
@@ -102,7 +102,7 @@ function! s:_uri_new_sandbox(uri, ignore_rest, pattern_set, retall, NothrowValue
 endfunction
 
 function! s:_is_own_exception(str) abort
-  return a:str =~# '^uri parse error\%(([^)]\+)\)\?:'
+  return a:str =~# '^vital: Web.URI: uri parse error\%(([^)]\+)\)\?:'
 endfunction
 
 

--- a/autoload/vital/__vital__/Web/XML.vim
+++ b/autoload/vital/__vital__/Web/XML.vim
@@ -282,7 +282,7 @@ function! s:parse(xml) abort
     let &maxmempattern = oldmaxmempattern
     let &maxfuncdepth = oldmaxfuncdepth
   endtry
-  throw 'Parse Error'
+  throw 'vital: Web.XML: Parse Error'
 endfunction
 
 function! s:parseFile(fname) abort


### PR DESCRIPTION
エラーメッセージのフォーマット（ `vital: {module name}: ...` ）が統一されていない箇所を直しました．
