### PR TITLE
CI: Prefer GitHub tarballs to shallow cloning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: false
 git:
   depth: 10
 
+env:
+  global:
+    - VIMPROC_VERSION=master
+    - VIM_THEMIS_VERSION=v1.5.2.1
+
 matrix:
   include:
     - os: linux
@@ -29,17 +34,17 @@ install:
   - export PATH=$HOME/vim/bin:$PATH
 
 before_script:
-  - curl -fsSL https://github.com/thinca/vim-themis/archive/v1.5.2.1.tar.gz | tar -xz -C /tmp
-  - curl -fsSL https://github.com/Shougo/vimproc.vim/archive/master.tar.gz | tar -xz -C /tmp
-  - make -C /tmp/vimproc.vim-master
+  - mkdir /tmp/vim-themis && curl -fsSL https://github.com/thinca/vim-themis/archive/$VIM_THEMIS_VERSION.tar.gz | tar -xz --strip-components 1 -C /tmp/vim-themis
+  - mkdir /tmp/vimproc && curl -fsSL https://github.com/Shougo/vimproc.vim/archive/$VIMPROC_VERSION.tar.gz | tar -xz --strip-components 1 -C /tmp/vimproc
+  - make -C /tmp/vimproc
 
 script:
   - uname -a
   - which -a vim
   - vim --cmd version --cmd quit
   - vim --cmd "try | helptags doc/ | catch | cquit | endtry" --cmd quit
-  # - /tmp/vim-themis-1.5.2.1/bin/themis --runtimepath /tmp/vimproc.vim-master --reporter dot
-  - /tmp/vim-themis-1.5.2.1/bin/themis --runtimepath /tmp/vimproc.vim-master --exclude ConcurrentProcess --reporter dot
+  # - /tmp/vim-themis/bin/themis --runtimepath /tmp/vimproc --reporter dot
+  - /tmp/vim-themis/bin/themis --runtimepath /tmp/vimproc --exclude ConcurrentProcess --reporter dot
   - ruby scripts/check-changelog.rb
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ install:
   - export PATH=$HOME/vim/bin:$PATH
 
 before_script:
-  - mkdir /tmp/vim-themis && curl -fsSL https://github.com/thinca/vim-themis/archive/$VIM_THEMIS_VERSION.tar.gz | tar -xz --strip-components 1 -C /tmp/vim-themis
-  - mkdir /tmp/vimproc && curl -fsSL https://github.com/Shougo/vimproc.vim/archive/$VIMPROC_VERSION.tar.gz | tar -xz --strip-components 1 -C /tmp/vimproc
+  - mkdir /tmp/vim-themis && curl -fsSL --retry 3 https://github.com/thinca/vim-themis/archive/$VIM_THEMIS_VERSION.tar.gz | tar -xz --strip-components 1 -C /tmp/vim-themis
+  - mkdir /tmp/vimproc && curl -fsSL --retry 3 https://github.com/Shougo/vimproc.vim/archive/$VIMPROC_VERSION.tar.gz | tar -xz --strip-components 1 -C /tmp/vimproc
   - make -C /tmp/vimproc
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,17 @@ install:
   - export PATH=$HOME/vim/bin:$PATH
 
 before_script:
-  - git clone --depth 1 --branch v1.5.2.1 --single-branch https://github.com/thinca/vim-themis /tmp/vim-themis
-  - git clone --depth 1 https://github.com/Shougo/vimproc.vim /tmp/vimproc
-  - (cd /tmp/vimproc && make)
+  - curl -fsSL https://github.com/thinca/vim-themis/archive/v1.5.2.1.tar.gz | tar -xz -C /tmp
+  - curl -fsSL https://github.com/Shougo/vimproc.vim/archive/master.tar.gz | tar -xz -C /tmp
+  - make -C /tmp/vimproc.vim-master
 
 script:
   - uname -a
   - which -a vim
   - vim --cmd version --cmd quit
   - vim --cmd "try | helptags doc/ | catch | cquit | endtry" --cmd quit
-  # - /tmp/vim-themis/bin/themis --runtimepath /tmp/vimproc --reporter dot
-  - /tmp/vim-themis/bin/themis --runtimepath /tmp/vimproc --exclude ConcurrentProcess --reporter dot
+  # - /tmp/vim-themis-1.5.2.1/bin/themis --runtimepath /tmp/vimproc.vim-master --reporter dot
+  - /tmp/vim-themis-1.5.2.1/bin/themis --runtimepath /tmp/vimproc.vim-master --exclude ConcurrentProcess --reporter dot
   - ruby scripts/check-changelog.rb
 notifications:
   webhooks:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,9 @@
 version: '{build}'
 clone_depth: 10
 environment:
+  global:
+    VIMPROC_VERSION: ver.9.2
+    VIM_THEMIS_VERSION: v1.5.2.1
   matrix:
     - VIM_URL: http://vim-jp.org/redirects/koron/vim-kaoriya/vim74/oldest/win64/
     - VIM_URL: http://vim-jp.org/redirects/koron/vim-kaoriya/vim80/oldest/win64/
@@ -16,16 +19,16 @@ install:
       [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') > $null
       [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $vim)
       $Env:THEMIS_VIM = $vim + (Get-ChildItem $vim).Name + '\vim.exe'
-  - 'pushd %TEMP% && curl -fsSL https://github.com/Shougo/vimproc.vim/archive/ver.9.2.tar.gz | tar -xz && popd'
-  - 'appveyor DownloadFile https://github.com/Shougo/vimproc.vim/releases/download/ver.9.2/vimproc_win64.dll -FileName %TEMP%\vimproc.vim-ver.9.2\lib\vimproc_win64.dll'
+  - 'mkdir %TEMP%\vimproc && pushd %TEMP%\vimproc && curl -fsSL https://github.com/Shougo/vimproc.vim/archive/%VIMPROC_VERSION%.tar.gz | tar -xz --strip-components 1 && popd'
+  - 'appveyor DownloadFile https://github.com/Shougo/vimproc.vim/releases/download/%VIMPROC_VERSION%/vimproc_win64.dll -FileName %TEMP%\vimproc\lib\vimproc_win64.dll'
 
-  - 'pushd %TEMP% && curl -fsSL https://github.com/thinca/vim-themis/archive/v1.5.2.1.tar.gz | tar -xz && popd'
+  - 'mkdir %TEMP%\vim-themis && pushd %TEMP%\vim-themis && curl -fsSL https://github.com/thinca/vim-themis/archive/%VIM_THEMIS_VERSION%.tar.gz | tar -xz --strip-components 1 && popd'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'
 build: off
 test_script:
   - '%THEMIS_VIM% --version'
-  - '%TEMP%\vim-themis-1.5.2.1\bin\themis.bat --runtimepath %TEMP%\vimproc.vim-ver.9.2 --exclude ConcurrentProcess --reporter dot'
+  - '%TEMP%\vim-themis\bin\themis.bat --runtimepath %TEMP%\vimproc --exclude ConcurrentProcess --reporter dot'
 deploy: off
 notifications:
   - provider: Webhook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,16 +16,16 @@ install:
       [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') > $null
       [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $vim)
       $Env:THEMIS_VIM = $vim + (Get-ChildItem $vim).Name + '\vim.exe'
-  - 'git -c advice.detachedHead=false clone https://github.com/Shougo/vimproc.vim --quiet --branch ver.9.2 --single-branch --depth 1 %TEMP%\vimproc'
-  - 'appveyor DownloadFile https://github.com/Shougo/vimproc.vim/releases/download/ver.9.2/vimproc_win64.dll -FileName %TEMP%\vimproc\lib\vimproc_win64.dll'
+  - curl -fsSL https://github.com/Shougo/vimproc.vim/archive/ver.9.2.tar.gz | 7z x -y -si -so -tgzip | 7z x -y -si -o%TEMP% -ttar > NUL
+  - 'appveyor DownloadFile https://github.com/Shougo/vimproc.vim/releases/download/ver.9.2/vimproc_win64.dll -FileName %TEMP%\vimproc.vim-ver.9.2\lib\vimproc_win64.dll'
 
-  - 'git -c advice.detachedHead=false clone https://github.com/thinca/vim-themis --quiet --branch v1.5.2.1 --single-branch --depth 1 %TEMP%\vim-themis'
+  - curl -fsSL https://github.com/thinca/vim-themis/archive/v1.5.2.1.tar.gz | 7z x -y -si -so -tgzip | 7z x -y -si -o%TEMP% -ttar > NUL
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'
 build: off
 test_script:
   - '%THEMIS_VIM% --version'
-  - '%TEMP%\vim-themis\bin\themis.bat --runtimepath %TEMP%\vimproc --exclude ConcurrentProcess --reporter dot'
+  - '%TEMP%\vim-themis-1.5.2.1\bin\themis.bat --runtimepath %TEMP%\vimproc.vim-ver.9.2 --exclude ConcurrentProcess --reporter dot'
 deploy: off
 notifications:
   - provider: Webhook

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,10 @@ install:
       [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') > $null
       [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $vim)
       $Env:THEMIS_VIM = $vim + (Get-ChildItem $vim).Name + '\vim.exe'
-  - 'mkdir %TEMP%\vimproc && pushd %TEMP%\vimproc && curl -fsSL https://github.com/Shougo/vimproc.vim/archive/%VIMPROC_VERSION%.tar.gz | tar -xz --strip-components 1 && popd'
+  - 'mkdir %TEMP%\vimproc && pushd %TEMP%\vimproc && curl -fsSL --retry 3 https://github.com/Shougo/vimproc.vim/archive/%VIMPROC_VERSION%.tar.gz | tar -xz --strip-components 1 && popd'
   - 'appveyor DownloadFile https://github.com/Shougo/vimproc.vim/releases/download/%VIMPROC_VERSION%/vimproc_win64.dll -FileName %TEMP%\vimproc\lib\vimproc_win64.dll'
 
-  - 'mkdir %TEMP%\vim-themis && pushd %TEMP%\vim-themis && curl -fsSL https://github.com/thinca/vim-themis/archive/%VIM_THEMIS_VERSION%.tar.gz | tar -xz --strip-components 1 && popd'
+  - 'mkdir %TEMP%\vim-themis && pushd %TEMP%\vim-themis && curl -fsSL --retry 3 https://github.com/thinca/vim-themis/archive/%VIM_THEMIS_VERSION%.tar.gz | tar -xz --strip-components 1 && popd'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,10 @@ install:
       [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') > $null
       [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $vim)
       $Env:THEMIS_VIM = $vim + (Get-ChildItem $vim).Name + '\vim.exe'
-  - curl -fsSL https://github.com/Shougo/vimproc.vim/archive/ver.9.2.tar.gz | 7z x -y -si -so -tgzip | 7z x -y -si -o%TEMP% -ttar > NUL
+  - 'pushd %TEMP% && curl -fsSL https://github.com/Shougo/vimproc.vim/archive/ver.9.2.tar.gz | tar -xz && popd'
   - 'appveyor DownloadFile https://github.com/Shougo/vimproc.vim/releases/download/ver.9.2/vimproc_win64.dll -FileName %TEMP%\vimproc.vim-ver.9.2\lib\vimproc_win64.dll'
 
-  - curl -fsSL https://github.com/thinca/vim-themis/archive/v1.5.2.1.tar.gz | 7z x -y -si -so -tgzip | 7z x -y -si -o%TEMP% -ttar > NUL
+  - 'pushd %TEMP% && curl -fsSL https://github.com/thinca/vim-themis/archive/v1.5.2.1.tar.gz | tar -xz && popd'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32'
   - 'reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64'
 build: off


### PR DESCRIPTION
Downloading a GitHub tarball is a straightforward way.
`git` command is too complex for tasks such as downloading an external software and simple commands will make builds more robust.

## On the pipeline
* `curl -fsSL`: Downloads silently with following the redirect and writes the content to stdout, but shows the error and fails when some errors occur.
  `curl` is also available on Appveyor because MinGW in the git distribution contains it.
* `tar -xz -C dir`: Extract the gzipped tarball from stdin under `dir`.
* `7z x -y -si -so -tgzip`: Extract the gzipped file from stdin to stdout with answering yes to all the questions. Equivalent to `zcat`.
* `7z x -y -si -odir -ttar`: Extract the uncompressed tarball from stdin under `dir` with answering yes to all the questions. Equivalent to `tar -x -C dir`.
