### PR TITLE
System.Filepath: Case-insensitive only on Windows

### DIFF
--- a/autoload/vital/__vital__/System/Filepath.vim
+++ b/autoload/vital/__vital__/System/Filepath.vim
@@ -12,7 +12,7 @@ let s:is_cygwin = has('win32unix')
 let s:is_mac = !s:is_windows && !s:is_cygwin
       \ && (has('mac') || has('macunix') || has('gui_macvim') ||
       \   (!isdirectory('/proc') && executable('sw_vers')))
-let s:is_case_tolerant = filereadable(expand('<sfile>:r') . '.VIM')
+let s:is_case_tolerant = s:is_windows
 
 " Get the directory separator.
 function! s:separator() abort


### PR DESCRIPTION
This PR fixes the problem that `Filepath.contains` mistakenly recognizes a POSIX system as a case-torelant system when the library is placed on a case-insensitive filesystem such as [osxfs in Docker](https://docs.docker.com/docker-for-mac/osxfs/).

## Rationale
POSIX paths (on Linux, BSD, and macOS) are case-sensitive in nature, and individual filesystems can have different settings.
Windows paths are case-insensitive.
