### PR TITLE
Add a link to "External vital modules" to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ Module						 | Description
 [Web.URI](doc/vital/Web/URI.txt)		 | URI manipulation library
 [Web.XML](doc/vital/Web/XML.txt)		 | XML parser written in pure Vim script
 
-... and see [External vital modules](https://github.com/vim-jp/vital.vim/wiki/External-vital-modules) for more information.
-
+... and you can also create your own vital modules. Please see [External vital modules](https://github.com/vim-jp/vital.vim/wiki/External-vital-modules) for more information.
 
 ## Let's get started
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Module						 | Description
 [Web.URI](doc/vital/Web/URI.txt)		 | URI manipulation library
 [Web.XML](doc/vital/Web/XML.txt)		 | XML parser written in pure Vim script
 
-... and more ...
+... and see [External vital modules](https://github.com/vim-jp/vital.vim/wiki/External-vital-modules) for more information.
 
 
 ## Let's get started


### PR DESCRIPTION
@rhysd さんからもらったアドバイスの件を追記しました。 https://github.com/vim-jp/vital.vim/issues/367#issuecomment-273769152

> README に [wiki](https://github.com/vim-jp/vital.vim/wiki/External-vital-modules) へのリンクがあると良い気がします．