### PR TITLE
Improve Vim.Buffer / Vim.BufferManager

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+f357fe99366e99cf0ae953303b7e3ea54b408df4
+	Modules: Vim.BufferManager
+	A value of 'newwin' returned 1 when a buffer was opened in an exiting window.
+	This commit reverse the value of 'newwin' to follow the document.
 b2e60b8ac7907f716950455efdb51ceff4e637a8
 	Modules: Random.Xor128
 	The algorithm of the initializer was changed to improve the randomness.

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 f357fe99366e99cf0ae953303b7e3ea54b408df4
 	Modules: Vim.BufferManager
 	A value of 'newwin' returned 1 when a buffer was opened in an exiting window.
-	This commit reverse the value of 'newwin' to follow the document.
+	This commit reverses the value of 'newwin' to follow the document.
 b2e60b8ac7907f716950455efdb51ceff4e637a8
 	Modules: Random.Xor128
 	The algorithm of the initializer was changed to improve the randomness.

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 f357fe99366e99cf0ae953303b7e3ea54b408df4
 	Modules: Vim.BufferManager
-	A value of 'newwin' returned 1 when a buffer was opened in an exiting window.
+	A value of 'newwin' returned 1 when a buffer was opened in an existing window.
 	This commit reverses the value of 'newwin' to follow the document.
 b2e60b8ac7907f716950455efdb51ceff4e637a8
 	Modules: Random.Xor128

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -22,9 +22,9 @@ else
 endif
 
 function! s:open(buffer, opener) abort
-  let save_wildignore = &wildignore
-  let &wildignore = ''
+  let guard = s:G.store(['&wildignore'])
   try
+    let &wildignore = ''
     if s:P.is_funcref(a:opener)
       let loaded = !bufloaded(a:buffer)
       call a:opener(a:buffer)
@@ -44,7 +44,7 @@ function! s:open(buffer, opener) abort
       endif
     endif
   finally
-    let &wildignore = save_wildignore
+    call guard.restore()
   endtry
   return loaded
 endfunction

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -32,6 +32,7 @@ function! s:open(buffer, ...) abort
     let options = get(a:000, 0, {})
   endif
   let options = extend({
+        \ 'mods': '',
         \ 'opener': empty(a:buffer) ? 'enew' : 'edit',
         \}, options
         \)
@@ -44,14 +45,14 @@ function! s:open(buffer, ...) abort
       call options.opener(a:buffer)
     elseif a:buffer is 0 || a:buffer is# ''
       let loaded = 1
-      silent execute options.opener
+      silent execute options.mods options.opener
       enew
     else
       let loaded = !bufloaded(a:buffer)
       if type(a:buffer) == s:t_string
-        execute options.opener '`=a:buffer`'
+        execute options.mods options.opener '`=a:buffer`'
       elseif type(a:buffer) == s:t_number
-        silent execute options.opener
+        silent execute options.mods options.opener
         execute a:buffer 'buffer'
       else
         throw 'vital: Vim.Buffer: Unknown {buffer} type.'

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -54,7 +54,7 @@ endfunction
 
 function! s:get_selected_text(...) abort
   echohl WarningMsg
-  echom "[WARN] s:get_selected_text() is deprecated. Use 's:get_last_selected()'."
+  echom "vital: Vim.Buffer: Warning: s:get_selected_text() is deprecated. Use 's:get_last_selected()'."
   echohl None
   return call('s:get_last_selected', a:000)
 endfunction

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -43,7 +43,7 @@ function! s:open(buffer, opener) abort
         silent execute a:opener
         execute a:buffer 'buffer'
       else
-        throw 'vital: Vim.Buffer: Unknown opener type.'
+        throw 'vital: Vim.Buffer: Unknown {buffer} type.'
       endif
     endif
   finally

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -1,14 +1,17 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+let s:t_funcref = type(function('tr'))
+let s:t_string = type('')
+let s:t_number = type(0)
+
 function! s:_vital_loaded(V) abort
   let s:V = a:V
-  let s:P = s:V.import('Prelude')
-  let s:G = s:V.import('Vim.Guard')
+  let s:Guard = s:V.import('Vim.Guard')
 endfunction
 
 function! s:_vital_depends() abort
-  return ['Prelude', 'Vim.Guard']
+  return ['Vim.Guard']
 endfunction
 
 if exists('*getcmdwintype')
@@ -22,10 +25,10 @@ else
 endif
 
 function! s:open(buffer, opener) abort
-  let guard = s:G.store(['&wildignore'])
+  let guard = s:Guard.store(['&wildignore'])
   try
     let &wildignore = ''
-    if s:P.is_funcref(a:opener)
+    if type(a:opener) == s:t_funcref
       let loaded = !bufloaded(a:buffer)
       call a:opener(a:buffer)
     elseif a:buffer is 0 || a:buffer is# ''
@@ -34,9 +37,9 @@ function! s:open(buffer, opener) abort
       enew
     else
       let loaded = !bufloaded(a:buffer)
-      if s:P.is_string(a:buffer)
+      if type(a:buffer) == s:t_string
         execute a:opener '`=a:buffer`'
-      elseif s:P.is_number(a:buffer)
+      elseif type(a:buffer) == s:t_number
         silent execute a:opener
         execute a:buffer 'buffer'
       else
@@ -132,7 +135,7 @@ function! s:edit_content(content, ...) abort
         \ 'edit': 1,
         \ 'lockmarks': 0,
         \}, get(a:000, 0, {}))
-  let guard = s:G.store(['&l:modifiable'])
+  let guard = s:Guard.store(['&l:modifiable'])
   let saved_view = winsaveview()
   try
     let &l:modifiable=1

--- a/autoload/vital/__vital__/Vim/Buffer.vim
+++ b/autoload/vital/__vital__/Vim/Buffer.vim
@@ -33,6 +33,7 @@ function! s:open(buffer, ...) abort
   endif
   let options = extend({
         \ 'mods': '',
+        \ 'cmdarg': '',
         \ 'opener': empty(a:buffer) ? 'enew' : 'edit',
         \}, options
         \)
@@ -50,7 +51,7 @@ function! s:open(buffer, ...) abort
     else
       let loaded = !bufloaded(a:buffer)
       if type(a:buffer) == s:t_string
-        execute options.mods options.opener '`=a:buffer`'
+        execute options.mods options.opener options.cmdarg '`=a:buffer`'
       elseif type(a:buffer) == s:t_number
         silent execute options.mods options.opener
         execute a:buffer 'buffer'

--- a/autoload/vital/__vital__/Vim/BufferManager.vim
+++ b/autoload/vital/__vital__/Vim/BufferManager.vim
@@ -42,7 +42,9 @@ function! s:Manager.open(bufname, ...) abort
     let Opener = eval(Opener[1 :])
   endwhile
 
-  let loaded = s:B.open(a:bufname, Opener)
+  let loaded = s:B.open(a:bufname, {
+        \ 'opener': Opener,
+        \})
   let new_bufnr = bufnr('%')
   let self._bufnrs[new_bufnr] = a:bufname
 

--- a/autoload/vital/__vital__/Vim/BufferManager.vim
+++ b/autoload/vital/__vital__/Vim/BufferManager.vim
@@ -1,5 +1,3 @@
-" buffer manager.
-
 let s:save_cpo = &cpo
 set cpo&vim
 
@@ -109,7 +107,7 @@ function! s:Manager.list() abort
 endfunction
 
 function! s:Manager.nearest(...) abort
-  let range = s:_make_config(self, map(copy(a:000), '{"range": v:val}')).range
+  let range = s:_make_config(self, map(copy(a:000), '{''range'': v:val}')).range
 
   if range ==# 'tabpage'
     let tabpages = [tabpagenr()]
@@ -131,7 +129,7 @@ function! s:Manager.nearest(...) abort
 endfunction
 
 function! s:Manager.move(...) abort
-  let range = s:_make_config(self, map(copy(a:000), '{"range": v:val}')).range
+  let range = s:_make_config(self, map(copy(a:000), '{''range'': v:val}')).range
   if range !=# 'all' && range !=# 'tabpage'
     return 0
   endif

--- a/autoload/vital/__vital__/Vim/BufferManager.vim
+++ b/autoload/vital/__vital__/Vim/BufferManager.vim
@@ -14,6 +14,8 @@ endfunction
 let s:default_config = {
 \   'range': 'tabpage',
 \   'opener': 'split',
+\   'mods': '',
+\   'cmdarg': '',
 \ }
 let s:Manager = {
 \   '_config': s:default_config,
@@ -44,6 +46,8 @@ function! s:Manager.open(bufname, ...) abort
 
   let loaded = s:B.open(a:bufname, {
         \ 'opener': Opener,
+        \ 'mods': config.mods,
+        \ 'cmdarg': config.cmdarg,
         \})
   let new_bufnr = bufnr('%')
   let self._bufnrs[new_bufnr] = a:bufname

--- a/autoload/vital/__vital__/Vim/BufferManager.vim
+++ b/autoload/vital/__vital__/Vim/BufferManager.vim
@@ -131,7 +131,7 @@ endfunction
 function! s:Manager.move(...) abort
   let range = s:_make_config(self, map(copy(a:000), '{''range'': v:val}')).range
   if range !=# 'all' && range !=# 'tabpage'
-    return 0
+    return self.is_managed(bufnr('%'))
   endif
   let near = self.nearest(range)
   if empty(near)

--- a/autoload/vital/__vital__/Vim/BufferManager.vim
+++ b/autoload/vital/__vital__/Vim/BufferManager.vim
@@ -48,7 +48,7 @@ function! s:Manager.open(bufname, ...) abort
 
   let info = {
   \   'loaded': loaded,
-  \   'newwin': moved,
+  \   'newwin': !moved,
   \   'newbuf': lastbuf < bufnr('%'),
   \   'bufnr': new_bufnr,
   \   'bufname': a:bufname,

--- a/doc/vital/Vim/Buffer.txt
+++ b/doc/vital/Vim/Buffer.txt
@@ -71,10 +71,20 @@ open({buffer} [, {options}])		*Vital.Vim.Buffer.open()*
 			When a string has specified, the string is used in a
 			|execute| command to open a buffer.
 			When a funcref has specified, the funcref is called
-			with {buffer} and the funcref will have a
-			responsibility to open a buffer.
+			with {buffer} as a dictionary function of {options}
+			and the funcref will have a responsibility to open a
+			buffer.
 			The defaulte value is "enew" or "edit", depends on a
 			value of {buffer}.
+	
+	"mods"		A command modifiers like |vertical| or |botright|.
+			It is used as a prefix of "opener" when opening a
+			buffer.
+
+	"cmdarg"	A command argument (|++opt|) used to open a new named
+			buffer. Note that it may not affect properties of an
+			existing buffer or unnamed buffer due to the
+			limitation of Vim's builtin command.
 
 	For backward compatibility, an "opener" is allowed to directly
 	assigned to the {options} attribute.
@@ -87,6 +97,23 @@ open({buffer} [, {options}])		*Vital.Vim.Buffer.open()*
 
 	" Open 'foo' with 'split' (deprecated)
 	call s:Buffer.open('foo', 'split')
+
+	" Open 'foo' with 'botright split ++enc=utf8 ++ff=dos'
+	call s:Buffer.open('foo', {
+	      \ 'opener': 'split',
+	      \ 'mods': 'botright',
+	      \ 'cmdarg': '++enc=utf8 ++ff=dos',
+	      \})
+
+	" Open 'foo' with 'botright split ++enc=utf8 ++ff=dos'
+	function! s:opener(buffer) abort dict
+	  execute self.mods 'split' self.cmdarg a:buffer
+	endfunction
+	call s:Buffer.open('foo', {
+	      \ 'opener': function('s:opener'),
+	      \ 'mods': 'botright',
+	      \ 'cmdarg': '++enc=utf8 ++ff=dos',
+	      \})
 <
 
 read_content({content}[, {options}])	*Vital.Vim.Buffer.read_content()*

--- a/doc/vital/Vim/Buffer.txt
+++ b/doc/vital/Vim/Buffer.txt
@@ -26,8 +26,8 @@ USAGE				*Vital.Vim.Buffer-usage*
 	let B = V.import('Vim.Buffer')
 	echo B.is_cmdwin() " 1 if you are in command-line-window.
 	
-	echo B.open('A.txt', 'split')	" Open A.txt via split. show 1 if
-					" the A.txt is newly loaded
+	" Open A.txt via split. show 1 if the A.txt is newly loaded
+	echo B.open('A.txt', {'opener': 'split'})
 <
 
 
@@ -51,19 +51,43 @@ get_last_selected()			*Vital.Vim.Buffer.get_last_selected()*
 	without changing unnamed register.
 	But this function can work even in |textlock|.
 
-open({buffer}, {opener})		*Vital.Vim.Buffer.open()*
-	Open a {buffer} with a specified {opener}. Return value is a boolean
-	(0/1) which indicate whether the buffer is newly loaded or not.
-	If 0 or an empty string is specified to {buffer}, the function open a
-	new empty buffer with a specified {opener}. In this case, the return
-	value is always 1.
-	The {opener} can be a |Number|, |String| or |Funcref|. If |Number| is
-	specified, the function will open a exiting buffer which is identified
-	by a buffer number (See |bufnr()|). If |String| is specified, it will open
-	a existing buffer which is identified by a buffer name, otherwise it
-	will open a new buffer and give {buffer} to the buffer as a buffer name
-	(See |bufname()|). If a |Funcref| is specified, the function will be called
-	with the {buffer} as a first argument.
+open({buffer} [, {options}])		*Vital.Vim.Buffer.open()*
+	Open a {buffer} and return a boolean which indicate whether the buffer
+	has newly loaded or not.
+
+	If 0 or an empty string has specified to {buffer}, the function open a
+	new unnamed buffer. In this case, the return value is always 1.
+
+	If a number has specified to {buffer}, the {buffer} is assumed as a
+	buffer number and an existing buffer will be opened.
+
+	If a string has specified to {buffer}, the {buffer} is assumed as a
+	buffer name and an existing buffer which is identified by the name or
+	new buffer will be opened.
+
+	In {options}, the following attributes are allowed
+
+	"opener"	A string or funcref used to open a buffer.
+			When a string has specified, the string is used in a
+			|execute| command to open a buffer.
+			When a funcref has specified, the funcref is called
+			with {buffer} and the funcref will have a
+			responsibility to open a buffer.
+			The defaulte value is "enew" or "edit", depends on a
+			value of {buffer}.
+
+	For backward compatibility, an "opener" is allowed to directly
+	assigned to the {options} attribute.
+>
+	" Open 'foo' with a default opener
+	call s:Buffer.open('foo')
+
+	" Open 'foo' with 'split'
+	call s:Buffer.open('foo', {'opener': 'split'})
+
+	" Open 'foo' with 'split' (deprecated)
+	call s:Buffer.open('foo', 'split')
+<
 
 read_content({content}[, {options}])	*Vital.Vim.Buffer.read_content()*
 	Insert {content} (|List|) below the cursor of the current buffer.

--- a/doc/vital/Vim/Buffer.txt
+++ b/doc/vital/Vim/Buffer.txt
@@ -55,15 +55,15 @@ open({buffer} [, {options}])		*Vital.Vim.Buffer.open()*
 	Open a {buffer} and return a boolean which indicates whether the buffer
 	has been newly loaded or not.
 
-	If 0 or an empty string has specified to {buffer}, the function open a
-	new unnamed buffer. In this case, the return value is always 1.
+	If 0 or an empty string has been specified to {buffer}, the function
+	opens a new unnamed buffer. In this case, the return value is always 1.
 
-	If a number has specified to {buffer}, the {buffer} is assumed as a
+	If a number has been specified to {buffer}, the {buffer} is assumed as a
 	buffer number and an existing buffer will be opened.
 
-	If a string has specified to {buffer}, the {buffer} is assumed as a
+	If a string has been specified to {buffer}, the {buffer} is assumed as a
 	buffer name and an existing buffer which is identified by the name or
-	new buffer will be opened.
+	a new buffer will be opened.
 
 	In {options}, the following attributes are allowed
 
@@ -74,7 +74,7 @@ open({buffer} [, {options}])		*Vital.Vim.Buffer.open()*
 			with {buffer} as a dictionary function of {options}
 			and the funcref will have a responsibility to open a
 			buffer.
-			The defaulte value is "enew" or "edit", depends on a
+			The default value is "enew" or "edit", depends on a
 			value of {buffer}.
 	
 	"mods"		A command modifiers like |vertical| or |botright|.
@@ -86,7 +86,7 @@ open({buffer} [, {options}])		*Vital.Vim.Buffer.open()*
 			existing buffer or unnamed buffer due to the
 			limitation of Vim's builtin command.
 
-	For backward compatibility, an "opener" is allowed to directly
+	For backward compatibility, an "opener" is allowed to directly be
 	assigned to the {options} attribute.
 >
 	" Open 'foo' with a default opener

--- a/doc/vital/Vim/Buffer.txt
+++ b/doc/vital/Vim/Buffer.txt
@@ -52,8 +52,8 @@ get_last_selected()			*Vital.Vim.Buffer.get_last_selected()*
 	But this function can work even in |textlock|.
 
 open({buffer} [, {options}])		*Vital.Vim.Buffer.open()*
-	Open a {buffer} and return a boolean which indicate whether the buffer
-	has newly loaded or not.
+	Open a {buffer} and return a boolean which indicates whether the buffer
+	has been newly loaded or not.
 
 	If 0 or an empty string has specified to {buffer}, the function open a
 	new unnamed buffer. In this case, the return value is always 1.

--- a/doc/vital/Vim/BufferManager.txt
+++ b/doc/vital/Vim/BufferManager.txt
@@ -164,7 +164,13 @@ range				*Vital.Vim.BufferManager-config-range*
 	"all"
 		Windows of all tabpages.
 
+mods				*Vital.Vim.BufferManager-config-mods*
+	A command modifiers used when opening a buffer.
+	See |Vital.Vim.Buffer.open()| for more detail.
 
+cmdarg				*Vital.Vim.BufferManager-config-cmdarg*
+	A command attribute used when opening a buffer.
+	See |Vital.Vim.Buffer.open()| for more detail.
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -1,16 +1,16 @@
 scriptencoding utf-8
 
-let s:V = vital#vital#new()
-let s:P = s:V.import('System.Filepath')
-let s:G = s:V.import('Vim.Guard')
-
 Describe Vim.Buffer
   Before all
-    let Buffer = s:V.import('Vim.Buffer')
+    let Path = vital#vital#import('System.Filepath')
+    let Guard = vital#vital#import('Vim.Guard')
+    let Buffer = vital#vital#import('Vim.Buffer')
   End
+
   After all
     windo bwipeout!
   End
+
   Before
     windo bwipeout!
   End
@@ -26,7 +26,7 @@ Describe Vim.Buffer
     Context for single byte characters
       Before
         execute printf('edit %s',
-              \ s:P.realpath('test/_testdata/Vim/Buffer/single.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/single.txt')
               \)
       End
 
@@ -69,7 +69,7 @@ Describe Vim.Buffer
     Context for wide characters
       Before
         execute printf('edit %s',
-              \ s:P.realpath('test/_testdata/Vim/Buffer/wide.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/wide.txt')
               \)
       End
 
@@ -87,10 +87,11 @@ Describe Vim.Buffer
         Assert Equals("あい\nかき", text)
       End
     End
+
     Context for mixed characters
       Before
         execute printf('edit %s',
-              \ s:P.realpath('test/_testdata/Vim/Buffer/mixed.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/mixed.txt')
               \)
       End
 
@@ -126,13 +127,14 @@ Describe Vim.Buffer
 
   Describe read_content()
     Before
-      let guard = s:G.store(['&fileencodings', '&fileencoding'])
+      let guard = Guard.store(['&fileencodings', '&fileencoding'])
       " Note:
       " 'read_content' uses 'read' command thus fileencodings requires to be
       " correctly configured.
       set fileencodings=utf-8,euc-jp,sjis
       set fileencoding=utf-8
     End
+
     After
       call guard.restore()
     End
@@ -141,7 +143,7 @@ Describe Vim.Buffer
       It appends contents to the current buffer
         call setline(1, 'あいうえお')
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
               \)
         call Buffer.read_content(contents)
         Assert Equals(getline(1, '$'), [
@@ -151,11 +153,12 @@ Describe Vim.Buffer
         Assert Equals(&fileencoding, 'utf-8')
       End
     End
+
     Context for sjis contents
       It appends contents to the current buffer
         call setline(1, 'あいうえお')
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/sjis.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/sjis.txt')
               \)
         call Buffer.read_content(contents)
         Assert Equals(getline(1, '$'), [
@@ -165,11 +168,12 @@ Describe Vim.Buffer
         Assert Equals(&fileencoding, 'utf-8')
       End
     End
+
     Context for euc-jp contents
       It appends contents to the current buffer
         call setline(1, 'あいうえお')
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/euc-jp.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/euc-jp.txt')
               \)
         call Buffer.read_content(contents)
         Assert Equals(getline(1, '$'), [
@@ -179,6 +183,7 @@ Describe Vim.Buffer
         Assert Equals(&fileencoding, 'utf-8')
       End
     End
+
     It wipes out tempfile buffer
       let fname = tempname()
       call Buffer.read_content([''], {'tempfile': fname})
@@ -189,7 +194,7 @@ Describe Vim.Buffer
         call setline(1, ['aaaaa', 'bbbbb', 'ccccc'])
         call setpos('.', [0, 2, 1, 0])
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
               \)
         call Buffer.read_content(contents)
         Assert Equals(getline(1, '$'), [
@@ -203,7 +208,7 @@ Describe Vim.Buffer
     It append content after {options.line}
         call setline(1, ['aaaaa', 'bbbbb', 'ccccc'])
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
               \)
         call Buffer.read_content(contents, {
               \ 'line': 2,
@@ -219,7 +224,7 @@ Describe Vim.Buffer
     It insert content before the first line when {options.line} is 0
         call setline(1, ['aaaaa', 'bbbbb', 'ccccc'])
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
               \)
         call Buffer.read_content(contents, {
               \ 'line': 0,
@@ -235,13 +240,14 @@ Describe Vim.Buffer
 
   Describe edit_content()
     Before
-      let guard = s:G.store(['&fileencodings', '&fileencoding'])
+      let guard = Guard.store(['&fileencodings', '&fileencoding'])
       " Note:
       " 'edit_content' uses 'read' command thus fileencodings requires to be
       " correctly configured.
       set fileencodings=utf-8,euc-jp,sjis
       set fileencoding=utf-8
     End
+
     After
       call guard.restore()
     End
@@ -250,7 +256,7 @@ Describe Vim.Buffer
       It replaces contents to the current buffer
         call setline(1, 'かきくけこ')
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/utf-8.txt')
               \)
         call Buffer.edit_content(contents)
         Assert Equals(getline(1, '$'), [
@@ -259,11 +265,12 @@ Describe Vim.Buffer
         Assert Equals(&fileencoding, 'utf-8')
       End
     End
+
     Context for sjis contents
       It replaces contents to the current buffer
         call setline(1, 'かきくけこ')
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/sjis.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/sjis.txt')
               \)
         call Buffer.edit_content(contents)
         Assert Equals(getline(1, '$'), [
@@ -272,11 +279,12 @@ Describe Vim.Buffer
         Assert Equals(&fileencoding, 'sjis')
       End
     End
+
     Context for euc-jp contents
       It replaces contents to the current buffer
         call setline(1, 'かきくけこ')
         let contents = readfile(
-              \ s:P.realpath('test/_testdata/Vim/Buffer/euc-jp.txt')
+              \ Path.realpath('test/_testdata/Vim/Buffer/euc-jp.txt')
               \)
         call Buffer.edit_content(contents)
         Assert Equals(getline(1, '$'), [
@@ -292,6 +300,7 @@ Describe Vim.Buffer
       let ret = Buffer.parse_cmdarg('')
       Assert Equals(ret, {})
     End
+
     It parses "++enc=XXX" and return "encoding: XXX" dictionary
       let ret = Buffer.parse_cmdarg('++enc=utf-8')
       Assert Equals(ret, { 'encoding': 'utf-8' })

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -83,11 +83,96 @@ Describe Vim.Buffer
         Assert Equals(bufname(winbufnr(3)), 'foo1')
         Assert Equals(result, 0)
       End
+
+      It opens a new unnamed buffer with a {options.mods} as a command modifiers
+        edit foo
+        let result = Buffer.open(0, {
+              \ 'opener': 'split'
+              \})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), '')
+        Assert Equals(bufname(winbufnr(2)), 'foo')
+        Assert Equals(result, 1)
+
+        let result = Buffer.open(0, {
+              \ 'mods': 'botright',
+              \ 'opener': 'split'
+              \})
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), '')
+        Assert Equals(bufname(winbufnr(2)), 'foo')
+        Assert Equals(bufname(winbufnr(3)), '')
+        Assert Equals(result, 1)
+        Assert NotEquals(winbufnr(1), winbufnr(3))
+      End
+
+      It opens a new {buffer} with a {options.mods} as a command modifiers
+        edit foo1
+        let result = Buffer.open('foo2', {
+              \ 'opener': 'split',
+              \})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(result, 1)
+
+        let result = Buffer.open('foo3', {
+              \ 'mods': 'botright',
+              \ 'opener': 'split',
+              \})
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(bufname(winbufnr(3)), 'foo3')
+        Assert Equals(result, 1)
+      End
+
+      It opens an existing {buffer} with a {options.mods} as a command modifiers
+        edit foo1
+        new foo2
+        let result = Buffer.open('foo1', {
+              \ 'opener': 'split',
+              \})
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+        Assert Equals(bufname(winbufnr(3)), 'foo1')
+        Assert Equals(result, 0)
+
+        let result = Buffer.open('foo2', {
+              \ 'mods': 'botright',
+              \ 'opener': 'split',
+              \})
+        Assert Equals(winnr('$'), 4)
+        Assert Equals(bufname(winbufnr(1)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+        Assert Equals(bufname(winbufnr(3)), 'foo1')
+        Assert Equals(bufname(winbufnr(4)), 'foo2')
+        Assert Equals(result, 0)
+      End
+
+      It opens an existing {buffer} with a {options.mods} as a command modifiers (when {buffer} is number)
+        edit foo1
+        new foo2
+        let result = Buffer.open(bufnr('foo1'), {
+              \ 'mods': 'botright',
+              \ 'opener': 'split',
+              \})
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(bufname(winbufnr(3)), 'foo1')
+        Assert Equals(result, 0)
+      End
     End
 
     Context with a funcref {options.opener}
       function! VitalVimBufferOpener(bufname) abort
         execute 'split' a:bufname
+      endfunction
+
+      function! VitalVimBufferOpener2(bufname) abort dict
+        execute self.mods 'split' a:bufname
       endfunction
 
       It opens a {buffer} with a funcref {options.opener} and returns if {buffer} was loaded
@@ -107,6 +192,27 @@ Describe Vim.Buffer
         Assert Equals(bufname(winbufnr(1)), 'foo2')
         Assert Equals(bufname(winbufnr(2)), 'foo2')
         Assert Equals(bufname(winbufnr(3)), 'foo1')
+        Assert Equals(result, 0)
+      End
+
+      It calls a funcref {options.opener} as a dictionary function of {options}
+        edit foo1
+        let result = Buffer.open('foo2', {
+              \ 'opener': function('VitalVimBufferOpener2'),
+              \})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(result, 1)
+
+        let result = Buffer.open('foo2', {
+              \ 'mods': 'botright',
+              \ 'opener': function('VitalVimBufferOpener2'),
+              \})
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(bufname(winbufnr(3)), 'foo2')
         Assert Equals(result, 0)
       End
     End

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -23,6 +23,10 @@ Describe Vim.Buffer
   End
 
   Describe .open()
+    It throws an exception when {buffer} is not string nor number
+      Throws /Unknown {buffer} type/ Buffer.open([], 'edit')
+    End
+
     Context with a string {opener}
       It opens a new unnamed buffer with a {opener} and returns 1
         let result = Buffer.open(0, 'enew')

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -27,14 +27,14 @@ Describe Vim.Buffer
       Throws /Unknown {buffer} type/ Buffer.open([], 'edit')
     End
 
-    Context with a string {opener}
-      It opens a new unnamed buffer with a {opener} and returns 1
-        let result = Buffer.open(0, 'enew')
+    Context with a string {options.opener}
+      It opens a new unnamed buffer with a {options.opener} and returns 1
+        let result = Buffer.open(0)
         Assert Equals(winnr('$'), 1)
         Assert Equals(bufname(winbufnr(1)), '')
         Assert Equals(result, 1)
 
-        let result = Buffer.open('', 'split')
+        let result = Buffer.open('', {'opener': 'split'})
         Assert Equals(winnr('$'), 2)
         Assert Equals(bufname(winbufnr(1)), '')
         Assert Equals(bufname(winbufnr(2)), '')
@@ -42,30 +42,30 @@ Describe Vim.Buffer
         Assert NotEquals(winbufnr(1), winbufnr(2))
       End
 
-      It opens a new {buffer} with a {opener} and returns 1
+      It opens a new {buffer} with a {options.opener} and returns 1
         edit foo1
-        let result = Buffer.open('foo2', 'edit')
+        let result = Buffer.open('foo2')
         Assert Equals(winnr('$'), 1)
         Assert Equals(bufname(winbufnr(1)), 'foo2')
         Assert Equals(result, 1)
 
-        let result = Buffer.open('foo3', 'split')
+        let result = Buffer.open('foo3', {'opener': 'split'})
         Assert Equals(winnr('$'), 2)
         Assert Equals(bufname(winbufnr(1)), 'foo3')
         Assert Equals(bufname(winbufnr(2)), 'foo2')
         Assert Equals(result, 1)
       End
 
-      It opens an existing {buffer} with a {opener} and returns 0
+      It opens an existing {buffer} with a {options.opener} and returns 0
         edit foo1
         new foo2 | setlocal bufhidden=hide
-        let result = Buffer.open('foo1', 'edit')
+        let result = Buffer.open('foo1')
         Assert Equals(winnr('$'), 2)
         Assert Equals(bufname(winbufnr(1)), 'foo1')
         Assert Equals(bufname(winbufnr(2)), 'foo1')
         Assert Equals(result, 0)
 
-        let result = Buffer.open('foo2', 'split')
+        let result = Buffer.open('foo2', {'opener': 'split'})
         Assert Equals(winnr('$'), 3)
         Assert Equals(bufname(winbufnr(1)), 'foo2')
         Assert Equals(bufname(winbufnr(2)), 'foo1')
@@ -73,10 +73,10 @@ Describe Vim.Buffer
         Assert Equals(result, 0)
       End
 
-      It opens an existing {buffer} with a {opener} and returns 0 (when {buffer} is number)
+      It opens an existing {buffer} with a {options.opener} and returns 0 (when {buffer} is number)
         edit foo1
         new foo2
-        let result = Buffer.open(bufnr('foo1'), 'split')
+        let result = Buffer.open(bufnr('foo1'), {'opener': 'split'})
         Assert Equals(winnr('$'), 3)
         Assert Equals(bufname(winbufnr(1)), 'foo1')
         Assert Equals(bufname(winbufnr(2)), 'foo2')
@@ -85,25 +85,111 @@ Describe Vim.Buffer
       End
     End
 
-    Context with a funcref {opener}
+    Context with a funcref {options.opener}
       function! VitalVimBufferOpener(bufname) abort
         execute 'split' a:bufname
       endfunction
 
-      It opens a {buffer} with a funcref {opener} and returns if {buffer} was loaded
+      It opens a {buffer} with a funcref {options.opener} and returns if {buffer} was loaded
         edit foo1
-        let result = Buffer.open('foo2', function('VitalVimBufferOpener'))
+        let result = Buffer.open('foo2', {
+              \ 'opener': function('VitalVimBufferOpener'),
+              \})
         Assert Equals(winnr('$'), 2)
         Assert Equals(bufname(winbufnr(1)), 'foo2')
         Assert Equals(bufname(winbufnr(2)), 'foo1')
         Assert Equals(result, 1)
 
-        let result = Buffer.open('foo2', function('VitalVimBufferOpener'))
+        let result = Buffer.open('foo2', {
+              \ 'opener': function('VitalVimBufferOpener'),
+              \})
         Assert Equals(winnr('$'), 3)
         Assert Equals(bufname(winbufnr(1)), 'foo2')
         Assert Equals(bufname(winbufnr(2)), 'foo2')
         Assert Equals(bufname(winbufnr(3)), 'foo1')
         Assert Equals(result, 0)
+      End
+    End
+
+    Context Backward compatibility
+      Context with a string {opener}
+        It opens a new unnamed buffer with a {opener} and returns 1
+          let result = Buffer.open(0, 'enew')
+          Assert Equals(winnr('$'), 1)
+          Assert Equals(bufname(winbufnr(1)), '')
+          Assert Equals(result, 1)
+
+          let result = Buffer.open('', 'split')
+          Assert Equals(winnr('$'), 2)
+          Assert Equals(bufname(winbufnr(1)), '')
+          Assert Equals(bufname(winbufnr(2)), '')
+          Assert Equals(result, 1)
+          Assert NotEquals(winbufnr(1), winbufnr(2))
+        End
+
+        It opens a new {buffer} with a {opener} and returns 1
+          edit foo1
+          let result = Buffer.open('foo2', 'edit')
+          Assert Equals(winnr('$'), 1)
+          Assert Equals(bufname(winbufnr(1)), 'foo2')
+          Assert Equals(result, 1)
+
+          let result = Buffer.open('foo3', 'split')
+          Assert Equals(winnr('$'), 2)
+          Assert Equals(bufname(winbufnr(1)), 'foo3')
+          Assert Equals(bufname(winbufnr(2)), 'foo2')
+          Assert Equals(result, 1)
+        End
+
+        It opens an existing {buffer} with a {opener} and returns 0
+          edit foo1
+          new foo2 | setlocal bufhidden=hide
+          let result = Buffer.open('foo1', 'edit')
+          Assert Equals(winnr('$'), 2)
+          Assert Equals(bufname(winbufnr(1)), 'foo1')
+          Assert Equals(bufname(winbufnr(2)), 'foo1')
+          Assert Equals(result, 0)
+
+          let result = Buffer.open('foo2', 'split')
+          Assert Equals(winnr('$'), 3)
+          Assert Equals(bufname(winbufnr(1)), 'foo2')
+          Assert Equals(bufname(winbufnr(2)), 'foo1')
+          Assert Equals(bufname(winbufnr(2)), 'foo1')
+          Assert Equals(result, 0)
+        End
+
+        It opens an existing {buffer} with a {opener} and returns 0 (when {buffer} is number)
+          edit foo1
+          new foo2
+          let result = Buffer.open(bufnr('foo1'), 'split')
+          Assert Equals(winnr('$'), 3)
+          Assert Equals(bufname(winbufnr(1)), 'foo1')
+          Assert Equals(bufname(winbufnr(2)), 'foo2')
+          Assert Equals(bufname(winbufnr(3)), 'foo1')
+          Assert Equals(result, 0)
+        End
+      End
+
+      Context with a funcref {opener}
+        function! VitalVimBufferOpener(bufname) abort
+          execute 'split' a:bufname
+        endfunction
+
+        It opens a {buffer} with a funcref {opener} and returns if {buffer} was loaded
+          edit foo1
+          let result = Buffer.open('foo2', function('VitalVimBufferOpener'))
+          Assert Equals(winnr('$'), 2)
+          Assert Equals(bufname(winbufnr(1)), 'foo2')
+          Assert Equals(bufname(winbufnr(2)), 'foo1')
+          Assert Equals(result, 1)
+
+          let result = Buffer.open('foo2', function('VitalVimBufferOpener'))
+          Assert Equals(winnr('$'), 3)
+          Assert Equals(bufname(winbufnr(1)), 'foo2')
+          Assert Equals(bufname(winbufnr(2)), 'foo2')
+          Assert Equals(bufname(winbufnr(3)), 'foo1')
+          Assert Equals(result, 0)
+        End
       End
     End
   End

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -22,6 +22,88 @@ Describe Vim.Buffer
     End
   End
 
+  Describe .open()
+    Context with a string {opener}
+      It opens a new unnamed buffer with a {opener} and returns 1
+        let result = Buffer.open(0, 'enew')
+        Assert Equals(winnr('$'), 1)
+        Assert Equals(bufname(winbufnr(1)), '')
+        Assert Equals(result, 1)
+
+        let result = Buffer.open('', 'split')
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), '')
+        Assert Equals(bufname(winbufnr(2)), '')
+        Assert Equals(result, 1)
+        Assert NotEquals(winbufnr(1), winbufnr(2))
+      End
+
+      It opens a new {buffer} with a {opener} and returns 1
+        edit foo1
+        let result = Buffer.open('foo2', 'edit')
+        Assert Equals(winnr('$'), 1)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(result, 1)
+
+        let result = Buffer.open('foo3', 'split')
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo3')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+        Assert Equals(result, 1)
+      End
+
+      It opens an existing {buffer} with a {opener} and returns 0
+        edit foo1
+        new foo2 | setlocal bufhidden=hide
+        let result = Buffer.open('foo1', 'edit')
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(result, 0)
+
+        let result = Buffer.open('foo2', 'split')
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(result, 0)
+      End
+
+      It opens an existing {buffer} with a {opener} and returns 0 (when {buffer} is number)
+        edit foo1
+        new foo2
+        let result = Buffer.open(bufnr('foo1'), 'split')
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+        Assert Equals(bufname(winbufnr(3)), 'foo1')
+        Assert Equals(result, 0)
+      End
+    End
+
+    Context with a funcref {opener}
+      function! VitalVimBufferOpener(bufname) abort
+        execute 'split' a:bufname
+      endfunction
+
+      It opens a {buffer} with a funcref {opener} and returns if {buffer} was loaded
+        edit foo1
+        let result = Buffer.open('foo2', function('VitalVimBufferOpener'))
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(result, 1)
+
+        let result = Buffer.open('foo2', function('VitalVimBufferOpener'))
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+        Assert Equals(bufname(winbufnr(3)), 'foo1')
+        Assert Equals(result, 0)
+      End
+    End
+  End
+
   Describe .get_last_selected()
     Context for single byte characters
       Before

--- a/test/Vim/Buffer.vimspec
+++ b/test/Vim/Buffer.vimspec
@@ -164,6 +164,66 @@ Describe Vim.Buffer
         Assert Equals(bufname(winbufnr(3)), 'foo1')
         Assert Equals(result, 0)
       End
+
+      It opens a new unnamed buffer with a {options.cmdarg} as a command argument but it should not work
+        edit foo
+        let result = Buffer.open(0, {
+              \ 'cmdarg': '++enc=sjis ++ff=mac',
+              \ 'opener': 'split'
+              \})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), '')
+        Assert Equals(bufname(winbufnr(2)), 'foo')
+        Assert Equals(result, 1)
+        Assert Equals(&fileencoding, '', 'cmdarg should not work on an unnamed buffer')
+        Assert NotEquals(&fileformat, 'mac', 'cmdarg should not work on an unnamed buffer')
+      End
+
+      It opens a new {buffer} with a {options.cmdarg} as a command argument
+        edit foo1
+        let result = Buffer.open('foo2', {
+              \ 'cmdarg': '++enc=sjis ++ff=mac',
+              \ 'opener': 'split',
+              \})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(result, 1)
+        Assert Equals(&fileencoding, 'sjis')
+        Assert Equals(&fileformat, 'mac')
+      End
+
+      It opens an existing {buffer} with a {options.cmdarg} as a command argument but it should not work
+        edit foo1
+        new foo2
+        let result = Buffer.open('foo1', {
+              \ 'cmdarg': '++enc=sjis ++ff=mac',
+              \ 'opener': 'split',
+              \})
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+        Assert Equals(bufname(winbufnr(3)), 'foo1')
+        Assert Equals(result, 0)
+        Assert Equals(&fileencoding, '', 'cmdarg should not work on an existing buffer')
+        Assert NotEquals(&fileformat, 'mac', 'cmdarg should not work on an existing buffer')
+      End
+
+      It opens an existing {buffer} with a {options.cmdarg} as a command argument but it should ot work (when {buffer} is number)
+        edit foo1
+        new foo2
+        let result = Buffer.open(bufnr('foo1'), {
+              \ 'cmdarg': '++enc=sjis ++ff=mac',
+              \ 'opener': 'split',
+              \})
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(bufname(winbufnr(1)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+        Assert Equals(bufname(winbufnr(3)), 'foo1')
+        Assert Equals(result, 0)
+        Assert Equals(&fileencoding, '', 'cmdarg should not work on an existing buffer')
+        Assert NotEquals(&fileformat, 'mac', 'cmdarg should not work on an existing buffer')
+      End
     End
 
     Context with a funcref {options.opener}

--- a/test/Vim/BufferManager.vimspec
+++ b/test/Vim/BufferManager.vimspec
@@ -115,6 +115,28 @@ Describe Vim.BufferManager
         Assert Equals(winnr('$'), 3)
         Assert Equals(tabpagenr(), 1)
       End
+
+      It opens a new buffer with a specified mods
+        edit foo1
+        call manager.open('foo2', {
+              \ 'mods': 'botright',
+              \})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+      End
+
+      It opens a new buffer with a specified cmdarg
+        edit foo1
+        call manager.open('foo2', {
+              \ 'cmdarg': '++enc=sjis ++ff=mac',
+              \})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        Assert Equals(&fileencoding, 'sjis')
+        Assert Equals(&fileformat, 'mac')
+      End
     End
   End
 End

--- a/test/Vim/BufferManager.vimspec
+++ b/test/Vim/BufferManager.vimspec
@@ -58,7 +58,7 @@ Describe Vim.BufferManager
         Assert Equals(bufname(winbufnr(2)), 'foo2')
       End
 
-      It search a managed window in a current window when range=current
+      It searches a managed window in a current window when range=current
         call manager.open('foo1', {'range': 'current'})
         Assert Equals(winnr('$'), 2)
 
@@ -72,7 +72,7 @@ Describe Vim.BufferManager
         Assert Equals(winnr('$'), 4)
       End
 
-      It search a managed window in a current tabpage when range=tabpage (Default)
+      It searches a managed window in a current tabpage when range=tabpage (Default)
         call manager.open('foo1', {'range': 'tabpage'})
         Assert Equals(winnr('$'), 2)
 
@@ -94,7 +94,7 @@ Describe Vim.BufferManager
         Assert Equals(tabpagenr(), 2)
       End
 
-      It search a managed window in all tabpages when range=all
+      It searches a managed window in all tabpages when range=all
         call manager.open('foo1', {'range': 'all'})
         Assert Equals(winnr('$'), 2)
 

--- a/test/Vim/BufferManager.vimspec
+++ b/test/Vim/BufferManager.vimspec
@@ -1,0 +1,120 @@
+Describe Vim.BufferManager
+  Before all
+    let Manager = vital#vital#import('Vim.BufferManager')
+  End
+
+  After all
+    windo bwipeout!
+  End
+
+  Before
+    tabdo windo bwipeout!
+  End
+
+  Context A manager instance
+    Before
+      let manager = Manager.new()
+    End
+
+    Describe .open()
+      It opens a new buffer in a new window when no managed window exists
+        let result = manager.open('foo')
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname('%'), 'foo')
+        Assert Equals(result.loaded, 1)
+        Assert Equals(result.newwin, 1)
+        Assert Equals(result.newbuf, 1)
+        Assert Equals(result.bufnr, bufnr('%'))
+        Assert Equals(result.bufname, 'foo')
+      End
+
+      It opens a new buffer in an existing window which contains a managed buffer
+        call manager.open('foo')
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname('%'), 'foo')
+
+        let result = manager.open('bar')
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname('%'), 'bar')
+        Assert Equals(result.loaded, 1)
+        Assert Equals(result.newwin, 0)
+        Assert Equals(result.newbuf, 1)
+        Assert Equals(result.bufnr, bufnr('%'))
+        Assert Equals(result.bufname, 'bar')
+      End
+
+      It opens a new window with a specified opener
+        edit foo1
+        call manager.open('foo2')
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo2')
+        Assert Equals(bufname(winbufnr(2)), 'foo1')
+        windo bwipeout!
+
+        edit foo1
+        call manager.open('foo2', {'opener': 'botright split'})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(bufname(winbufnr(1)), 'foo1')
+        Assert Equals(bufname(winbufnr(2)), 'foo2')
+      End
+
+      It search a managed window in a current window when range=current
+        call manager.open('foo1', {'range': 'current'})
+        Assert Equals(winnr('$'), 2)
+
+        call manager.open('foo2', {'range': 'current'})
+        Assert Equals(winnr('$'), 2)
+
+        new foo3
+        Assert Equals(winnr('$'), 3)
+
+        call manager.open('foo4', {'range': 'current'})
+        Assert Equals(winnr('$'), 4)
+      End
+
+      It search a managed window in a current tabpage when range=tabpage (Default)
+        call manager.open('foo1', {'range': 'tabpage'})
+        Assert Equals(winnr('$'), 2)
+
+        call manager.open('foo2', {'range': 'tabpage'})
+        Assert Equals(winnr('$'), 2)
+
+        new foo3
+        Assert Equals(winnr('$'), 3)
+
+        call manager.open('foo4', {'range': 'tabpage'})
+        Assert Equals(winnr('$'), 3)
+
+        tabnew foo5
+        Assert Equals(winnr('$'), 1)
+        Assert Equals(tabpagenr(), 2)
+
+        call manager.open('foo6', {'range': 'tabpage'})
+        Assert Equals(winnr('$'), 2)
+        Assert Equals(tabpagenr(), 2)
+      End
+
+      It search a managed window in all tabpages when range=all
+        call manager.open('foo1', {'range': 'all'})
+        Assert Equals(winnr('$'), 2)
+
+        call manager.open('foo2', {'range': 'all'})
+        Assert Equals(winnr('$'), 2)
+
+        new foo3
+        Assert Equals(winnr('$'), 3)
+
+        call manager.open('foo4', {'range': 'all'})
+        Assert Equals(winnr('$'), 3)
+
+        tabnew foo5
+        Assert Equals(winnr('$'), 1)
+        Assert Equals(tabpagenr(), 2)
+
+        call manager.open('foo6', {'range': 'all'})
+        Assert Equals(winnr('$'), 3)
+        Assert Equals(tabpagenr(), 1)
+      End
+    End
+  End
+End


### PR DESCRIPTION
- [x] Add unittest of `Vim.BufferManger.open()` (Only for core part)
- [x] Fix existing bug of `Vim.BufferManager`
  - [x] `'newwin'` in a result dictionary is opposite to the document (**CHANGE NOTE**)
  - [x] Behaviour when `'range': 'current'` has specified
- [x] Add unittest of `Vim.Buffer.open()`
- [x] Refactoring `Vim.Buffer`
  - [x] Liberate from `Prelude` module
  - [x] Use `Vim.Guard`
  - misc
- [x] Improve `Vim.Buffer.open()`
  - [x] Enable a dictionary to a second attribute (backward compatible)
  - [x] Add `'mods'` option
  - [x] Add `'cmdarg'` option
- [x] Improve `Vim.BufferManager.open()`
  - [x] Add `'mods'` option
  - [x] Add `'cmdarg'` option