### PR TITLE
Fix tags in introduction document

### DIFF
--- a/doc/vital.txt
+++ b/doc/vital.txt
@@ -16,8 +16,8 @@ LINKS				|Vital-links|
 ==============================================================================
 INTRODUCTION				*Vital-introduction*
 
-*Vital* is like a plugin which has both aspects of Bundler and jQuery at the
-same time.
+*vital* (or *vital.vim* ) is like a plugin which has both aspects of Bundler and
+jQuery at the same time.
 
  Bundler: http://gembundler.com/
  jQuery:  http://jquery.com/


### PR DESCRIPTION
I noticed that `:h vital.vim` doesn't show introduction of vital.vim. [Link to `vital.vim`](https://github.com/vim-jp/vital.vim/blob/06f830e2c10ee26f94b5665c73da72c6c9b422c5/doc/vital.txt#L40) even exists... So I added it.

(Note that `:h vital` also can't lead users to introduction page because tag is case sensitive. Should we change `Vital` tag to `vital`?)