### PR TITLE
DateTime: Fix timezone on Windows 64 bit + Vim 32 bit

### DIFF
--- a/autoload/vital/__vital__/DateTime.vim
+++ b/autoload/vital/__vital__/DateTime.vim
@@ -7,6 +7,7 @@ function! s:_vital_loaded(V) abort
   let s:V = a:V
   let s:Prelude = s:V.import('Prelude')
   let s:Process = s:V.import('Process')
+  let s:Bitwise = s:V.import('Bitwise')
 
   let s:NUM_SECONDS = 60
   let s:NUM_MINUTES = 60
@@ -29,7 +30,7 @@ function! s:_vital_loaded(V) abort
     let key = 'HKLM\System\CurrentControlSet\Control\TimeZoneInformation'
     let regs = s:Process.system(printf('reg query "%s" /v Bias', key))
     let time = matchstr(regs, 'REG_DWORD\s*\zs0x\x\+')
-    let s:win_tz = empty(time) ? 0 : time / -s:NUM_MINUTES
+    let s:win_tz = empty(time) ? 0 : s:Bitwise.sign_extension(time) / -s:NUM_MINUTES
   endif
 
   " default values


### PR DESCRIPTION
Tests failed on Windows 64 because `REG_DWORD` is 32 bit long number,
but integers are stored on 64 bit, thus it have to be expanded to 64 bit
to get the right value (for negative numbers).