### PR TITLE
Fix tests on Mac OS X in Travis

### DIFF
--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -14,6 +14,7 @@ case "${TRAVIS_OS_NAME}" in
 		;;
 	osx)
 		brew update
+		brew upgrade
 		brew install lua
 		brew install vim --with-lua
 		;;


### PR DESCRIPTION
It seems `brew upgrade` is required to upgrade the version of Python on Mac OS X in Travis