### PR TITLE
Revert "Vim.Message: fix test after Vim 8.0.0467"

### DIFF
--- a/test/Vim/Message.vimspec
+++ b/test/Vim/Message.vimspec
@@ -11,11 +11,7 @@ Describe Vim.Message
       silent call Message.error('hi')
       redir END
       " TODO: how to check `echohl ErrorMsg`?
-      if has('patch-8.0.0467')
-        Assert Equals(output, "\n\nhi")
-      else
-        Assert Equals(output, "\nhi")
-      endif
+      Assert Equals(output, "\nhi")
     End
   End
 


### PR DESCRIPTION
Reverts vim-jp/vital.vim#491  
8.0.0547 で治るらしいので