### PR TITLE
Data.List: Add funcref support for .find()

### DIFF
--- a/autoload/vital/__vital__/Data/List.vim
+++ b/autoload/vital/__vital__/Data/List.vim
@@ -286,7 +286,7 @@ function! s:find(list, default, f) abort
   return a:default
 endfunction
 
-function! s:_call_string_expr(expr, args)
+function! s:_call_string_expr(expr, args) abort
   return eval(substitute(a:expr, 'v:val', string(a:args[0]), 'g'))
 endfunction
 

--- a/autoload/vital/__vital__/Data/List.vim
+++ b/autoload/vital/__vital__/Data/List.vim
@@ -274,31 +274,20 @@ endfunction
 
 " similar to Ruby's detect or Haskell's find.
 function! s:find(list, default, f) abort
-  if type(a:f) is type(function('function'))
-    return s:find_impl_for_funcref_expr(a:list, a:default, a:f)
-  else
-    return s:find_impl_for_string_expr(a:list, a:default, a:f)
-  endif
-endfunction
+  let l:Caller = type(a:f) is type(function('function'))
+  \            ? function('call')
+  \            : function('s:_call_string_expr')
 
-" s:find() implementation for function representation of funcref
-function! s:find_impl_for_funcref_expr(list, default, f) abort
   for x in a:list
-    if a:f(x)
+    if l:Caller(a:f, [x])
       return x
     endif
   endfor
   return a:default
 endfunction
 
-" s:find() implementation for function representation of string
-function! s:find_impl_for_string_expr(list, default, f) abort
-  for x in a:list
-    if eval(substitute(a:f, 'v:val', string(x), 'g'))
-      return x
-    endif
-  endfor
-  return a:default
+function! s:_call_string_expr(expr, args)
+  return eval(substitute(a:expr, 'v:val', string(a:args[0]), 'g'))
 endfunction
 
 " Returns the index of the first element which satisfies the given expr.

--- a/autoload/vital/__vital__/Data/List.vim
+++ b/autoload/vital/__vital__/Data/List.vim
@@ -274,6 +274,25 @@ endfunction
 
 " similar to Ruby's detect or Haskell's find.
 function! s:find(list, default, f) abort
+  if type(a:f) is type(function('function'))
+    return s:find_impl_for_funcref_expr(a:list, a:default, a:f)
+  else
+    return s:find_impl_for_string_expr(a:list, a:default, a:f)
+  endif
+endfunction
+
+" s:find() implementation for function representation of funcref
+function! s:find_impl_for_funcref_expr(list, default, f) abort
+  for x in a:list
+    if a:f(x)
+      return x
+    endif
+  endfor
+  return a:default
+endfunction
+
+" s:find() implementation for function representation of string
+function! s:find_impl_for_string_expr(list, default, f) abort
   for x in a:list
     if eval(substitute(a:f, 'v:val', string(x), 'g'))
       return x

--- a/autoload/vital/__vital__/Data/List.vim
+++ b/autoload/vital/__vital__/Data/List.vim
@@ -274,12 +274,12 @@ endfunction
 
 " similar to Ruby's detect or Haskell's find.
 function! s:find(list, default, f) abort
-  let l:Caller = type(a:f) is type(function('function'))
-  \            ? function('call')
-  \            : function('s:_call_string_expr')
+  let l:Call = type(a:f) is type(function('function'))
+  \          ? function('call')
+  \          : function('s:_call_string_expr')
 
   for x in a:list
-    if l:Caller(a:f, [x])
+    if l:Call(a:f, [x])
       return x
     endif
   endfor

--- a/autoload/vital/__vital__/Data/List.vim
+++ b/autoload/vital/__vital__/Data/List.vim
@@ -287,7 +287,7 @@ function! s:find(list, default, f) abort
 endfunction
 
 function! s:_call_string_expr(expr, args) abort
-  return eval(substitute(a:expr, 'v:val', string(a:args[0]), 'g'))
+  return map([a:args[0]], a:expr)[0]
 endfunction
 
 " Returns the index of the first element which satisfies the given expr.

--- a/doc/vital/Data/List.txt
+++ b/doc/vital/Data/List.txt
@@ -115,10 +115,10 @@ concat({list})				*Vital.Data.List.concat()*
 	echo s:L.concat([[1], [2, 3]])
 	" [1, 2, 3]
 <
-flatten({list} [, {limit}])		*Vital.Data.List.flatten()*
 	This is similar to |Vital.Data.List.flatten()| but this doesn't
 	flatten recursively.
 
+flatten({list} [, {limit}])		*Vital.Data.List.flatten()*
 	Take each {list} elements in |List| {list} into a new {list}
 	recursively.  When the {limit} argument is given, the function keeps
 	nested items by the {limit} is maximum size.

--- a/doc/vital/Data/List.txt
+++ b/doc/vital/Data/List.txt
@@ -115,6 +115,7 @@ concat({list})				*Vital.Data.List.concat()*
 	echo s:L.concat([[1], [2, 3]])
 	" [1, 2, 3]
 <
+flatten({list} [, {limit}])		*Vital.Data.List.flatten()*
 	This is similar to |Vital.Data.List.flatten()| but this doesn't
 	flatten recursively.
 

--- a/doc/vital/Data/List.txt
+++ b/doc/vital/Data/List.txt
@@ -118,7 +118,6 @@ concat({list})				*Vital.Data.List.concat()*
 	This is similar to |Vital.Data.List.flatten()| but this doesn't
 	flatten recursively.
 
-flatten({list} [, {limit}])		*Vital.Data.List.flatten()*
 	Take each {list} elements in |List| {list} into a new {list}
 	recursively.  When the {limit} argument is given, the function keeps
 	nested items by the {limit} is maximum size.
@@ -435,6 +434,11 @@ find({list}, {default}, {f})			 *Vital.Data.List.find()*
 	" 2
 	echo s:L.find([1, 2, 3], '*not-found*', 'v:val % 10 == 0')
 	" '*not-found*'
+<
+	If you have +lambda, you can use lambda expression as {f}.
+>
+	echo s:L.find([1, 2, 3, 1, 2, 3], '*not-found*', {x -> x % 2 == 0})
+	" 2
 <
 	If you know Haskell, this find() is like Haskell's Data.List.find
 	just for your info.

--- a/doc/vital/Data/List.txt
+++ b/doc/vital/Data/List.txt
@@ -427,19 +427,21 @@ with_index({list} [, {offset}])		*Vital.Data.List.with_index()*
 		echo idx.': '.line
 	endfor
 <
-find({list}, {default}, {f})			 *Vital.Data.List.find()*
+find({list}, {default}, {expr})			 *Vital.Data.List.find()*
 	Returns the first value in {list} where the given {expr} is satisfied.
-	{default} is returned when no item satisfies {expr}.
+	{default} is returned when no item satisfies {expr}. {expr} must be a
+	|String| or a |Funcref|.
 >
+	function! MyPredicate(x)
+	  return a:x % 2 == 0
+	endfunction
+
+	echo s:L.find([1, 2, 3, 1, 2, 3], '*not-found*', function('MyPredicate'))
+	" 2
 	echo s:L.find([1, 2, 3, 1, 2, 3], '*not-found*', 'v:val % 2 == 0')
 	" 2
 	echo s:L.find([1, 2, 3], '*not-found*', 'v:val % 10 == 0')
 	" '*not-found*'
-<
-	If you have +lambda, you can use lambda expression as {f}.
->
-	echo s:L.find([1, 2, 3, 1, 2, 3], '*not-found*', {x -> x % 2 == 0})
-	" 2
 <
 	If you know Haskell, this find() is like Haskell's Data.List.find
 	just for your info.

--- a/test/Data/List.vimspec
+++ b/test/Data/List.vimspec
@@ -348,6 +348,19 @@ Describe Data.List
   End
 
   Describe .find()
+    Before all
+      function! MyPredicate(x) abort
+        return a:x % 2 == 0
+      endfunction
+
+      function! MyPredicate2(x) abort
+        return a:x % 10 == 0
+      endfunction
+
+      function! MyPredicate3(x) abort
+        return a:x =~ 'y'
+      endfunction
+    End
     It returns the value if found by string expression
       Assert Equals(List.find([1, 2, 3], '*not-found*', 'v:val % 2 == 0'), 2)
       Assert Equals(List.find([1, 2, 3, 1, 2, 3], '*not-found*', 'v:val % 2 == 0'), 2)
@@ -356,16 +369,18 @@ Describe Data.List
 
       Assert Equals(List.find(['hi', 'yo'], -1, 'v:val =~ "y"'), 'yo')
     End
-
     It returns the value if found by funcref
-      if has('lambda')
-        Assert Equals(List.find([1, 2, 3], '*not-found*', {x -> x % 2 == 0}), 2)
-        Assert Equals(List.find([1, 2, 3, 1, 2, 3], '*not-found*', {x -> x % 2 == 0}), 2)
-        Assert Equals(List.find([1, 2, 3], '*not-found*', {x -> x % 10 == 0}), '*not-found*')
-        Assert Equals(List.find([], '*not-found*', {x -> x % 2 == 0}), '*not-found*')
+      Assert Equals(List.find([1, 2, 3], '*not-found*', function('MyPredicate')), 2)
+      Assert Equals(List.find([1, 2, 3, 1, 2, 3], '*not-found*', function('MyPredicate')), 2)
+      Assert Equals(List.find([1, 2, 3], '*not-found*', function('MyPredicate2')), '*not-found*')
+      Assert Equals(List.find([], '*not-found*', function('MyPredicate')), '*not-found*')
 
-        Assert Equals(List.find(['hi', 'yo'], -1, {x -> x =~ 'y'}), 'yo')
-      endif
+      Assert Equals(List.find(['hi', 'yo'], -1, function('MyPredicate3')), 'yo')
+    End
+    After all
+      delfunction MyPredicate
+      delfunction MyPredicate2
+      delfunction MyPredicate3
     End
   End
 

--- a/test/Data/List.vimspec
+++ b/test/Data/List.vimspec
@@ -348,13 +348,22 @@ Describe Data.List
   End
 
   Describe .find()
-    It returns the value if found
+    It returns the value if found by string expression
       Assert Equals(List.find([1, 2, 3], '*not-found*', 'v:val % 2 == 0'), 2)
       Assert Equals(List.find([1, 2, 3, 1, 2, 3], '*not-found*', 'v:val % 2 == 0'), 2)
       Assert Equals(List.find([1, 2, 3], '*not-found*', 'v:val % 10 == 0'), '*not-found*')
       Assert Equals(List.find([], '*not-found*', 'v:val % 2 == 0'), '*not-found*')
 
       Assert Equals(List.find(['hi', 'yo'], -1, 'v:val =~ "y"'), 'yo')
+    End
+
+    It returns the value if found by funcref
+      Assert Equals(List.find([1, 2, 3], '*not-found*', {x -> x % 2 == 0}), 2)
+      Assert Equals(List.find([1, 2, 3, 1, 2, 3], '*not-found*', {x -> x % 2 == 0}), 2)
+      Assert Equals(List.find([1, 2, 3], '*not-found*', {x -> x % 10 == 0}), '*not-found*')
+      Assert Equals(List.find([], '*not-found*', {x -> x % 2 == 0}), '*not-found*')
+
+      Assert Equals(List.find(['hi', 'yo'], -1, {x -> x =~ 'y'}), 'yo')
     End
   End
 

--- a/test/Data/List.vimspec
+++ b/test/Data/List.vimspec
@@ -358,12 +358,14 @@ Describe Data.List
     End
 
     It returns the value if found by funcref
-      Assert Equals(List.find([1, 2, 3], '*not-found*', {x -> x % 2 == 0}), 2)
-      Assert Equals(List.find([1, 2, 3, 1, 2, 3], '*not-found*', {x -> x % 2 == 0}), 2)
-      Assert Equals(List.find([1, 2, 3], '*not-found*', {x -> x % 10 == 0}), '*not-found*')
-      Assert Equals(List.find([], '*not-found*', {x -> x % 2 == 0}), '*not-found*')
+      if has('lambda')
+        Assert Equals(List.find([1, 2, 3], '*not-found*', {x -> x % 2 == 0}), 2)
+        Assert Equals(List.find([1, 2, 3, 1, 2, 3], '*not-found*', {x -> x % 2 == 0}), 2)
+        Assert Equals(List.find([1, 2, 3], '*not-found*', {x -> x % 10 == 0}), '*not-found*')
+        Assert Equals(List.find([], '*not-found*', {x -> x % 2 == 0}), '*not-found*')
 
-      Assert Equals(List.find(['hi', 'yo'], -1, {x -> x =~ 'y'}), 'yo')
+        Assert Equals(List.find(['hi', 'yo'], -1, {x -> x =~ 'y'}), 'yo')
+      endif
     End
   End
 


### PR DESCRIPTION
I want to use lambda expression in .find() .

- - -

But this supports only if vim has +lambda .

Can I add this ?