### PR TITLE
Add Stream module

### DIFF
--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -763,7 +763,7 @@ endfunction
 
 " a:expr is passed to v:val (but it is not meaningless value because
 " a:expr should not have 'v:val')
-function! s:_call_func0_expr(expr, args) abort
+function! s:_call_func0_expr(expr, _args) abort
   return map([a:expr], a:expr)[0]
 endfunction
 

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -917,7 +917,7 @@ function! s:Stream.any(f) abort
 endfunction
 
 function! s:Stream.all(f) abort
-  return self.filter(s:_not(a:f, 'all()')).first(s:NONE) is s:NONE
+  return self.map(a:f).filter('!v:val').first(s:NONE) is s:NONE
 endfunction
 
 function! s:Stream.none(f) abort
@@ -1029,22 +1029,6 @@ function! s:_slice(list, start, ...) abort
   let start = min([a:start, len])
   let end = a:0 ? min([a:1, len]) : len
   return a:list[start : end]
-endfunction
-
-function! s:_not(f, callee) abort
-  if s:Closure.is_closure(a:f)
-    return a:f.compose('=!a:1')
-  endif
-  let type = type(a:f)
-  if type is s:T_FUNC
-    return '!' . string(a:f) . '(v:val)'
-  elseif type is s:T_STRING
-    return '!map([v:val], ' . string(a:f) . ')[0]'
-  else
-    throw 'vital: Stream: ' . a:callee
-    \   . ': invalid type argument was given '
-    \   . '(expected funcref, string, or Data.Closure)'
-  endif
 endfunction
 
 " Get funcref of call()-ish function to call a:f (arity is 0)

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -746,9 +746,10 @@ function! s:Stream.sorted(...) abort
 endfunction
 
 function! s:Stream.get_comparator(...) abort
-  let l:C = a:0 ? a:1 : s:NONE
   if self.has_characteristics(s:SORTED)
-    let l:C = s:_find_comparator(self, l:C)
+    let l:C = s:_find_comparator(self, a:0 ? a:1 : s:NONE)
+  else
+    let l:C = a:0 ? a:1 : s:NONE
   endif
   if l:C is s:NONE
       throw 'vital: Stream: get_comparator(): comparator not found and '

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -10,11 +10,10 @@ set cpo&vim
 "
 " * __take_possible__(n)
 "   * n must be 0 or positive
-"     * callee must not pass negative value
-"     * in order to take all elements from the stream, pass 1/0
+"     * in order to take all elements from the stream, pass 1/0 (:help expr-/)
 "   * this function returns '[list, open]'
 "     * 'len(list) <= n'
-"     * callee must not invoke this function after 'open == 0' is returned
+"     * caller must not invoke this function after 'open == 0' is returned
 " * `__estimate_size__()`
 "   * this function must not change stream's state
 "   * if the number of elements is 'unknown', 1/0 is returned
@@ -33,6 +32,16 @@ endfunction
 
 function! s:_vital_depends() abort
   return ['Data.Closure']
+endfunction
+
+function! s:_vital_created(module) abort
+  call extend(a:module, {
+  \ 'ORDERED': s:ORDERED,
+  \ 'DISTINCT': s:DISTINCT,
+  \ 'SORTED': s:SORTED,
+  \ 'SIZED': s:SIZED,
+  \ 'IMMUTABLE': s:IMMUTABLE,
+  \})
 endfunction
 
 let s:NONE = []
@@ -56,26 +65,6 @@ let s:SIZED = 0x08
 " let s:NONNULL = 0x10
 let s:IMMUTABLE = 0x20
 " let s:CONCURRENT = 0x40
-
-function! s:ORDERED() abort
-  return s:ORDERED
-endfunction
-
-function! s:DISTINCT() abort
-  return s:DISTINCT
-endfunction
-
-function! s:SORTED() abort
-  return s:SORTED
-endfunction
-
-function! s:SIZED() abort
-  return s:SIZED
-endfunction
-
-function! s:IMMUTABLE() abort
-  return s:IMMUTABLE
-endfunction
 
 function! s:of(elem, ...) abort
   return s:_new_from_list([a:elem] + a:000, s:ORDERED + s:SIZED + s:IMMUTABLE, 'of()')

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -767,11 +767,9 @@ endfunction
 function! s:Stream.to_dict(key_mapper, value_mapper, ...) abort
   let l:CallKM = s:_get_callfunc_for_func1(a:key_mapper, 'to_dict()')
   let l:CallVM = s:_get_callfunc_for_func1(a:value_mapper, 'to_dict()')
-  if a:0
-    let l:CallMerge = s:_get_callfunc_for_func2(a:1, 'to_dict()')
-  endif
   let l:Result = {}
   if a:0
+    let l:CallMerge = s:_get_callfunc_for_func2(a:1, 'to_dict()')
     for l:Value in self.to_list()
       let key = l:CallKM(a:key_mapper, [l:Value])
       let l:Value = l:CallVM(a:value_mapper, [l:Value])
@@ -785,7 +783,7 @@ function! s:Stream.to_dict(key_mapper, value_mapper, ...) abort
       let key = l:CallKM(a:key_mapper, [l:Value])
       if has_key(l:Result, key)
         throw 'vital: Stream: to_dict(): duplicated elements exist in stream '
-        \   . '(key: ' . string(key . "") . ')'
+        \   . '(key: ' . string(key . '') . ')'
       endif
       let l:Result[key] = l:CallVM(a:value_mapper, [l:Value])
     endfor

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -173,7 +173,7 @@ function! s:range(expr, ...) abort
   return stream
 endfunction
 
-" a0 < a1, a2 > 0, a_0 = a0, i >= 0
+" a0 <= a1, a2 > 0, a_0 = a0, i >= 0
 " a_i = a0 + i * a2
 " num = (a1 - a_i) / a2 + 1
 "     = (a1 - a0) / a2 - i + 1

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -1,6 +1,14 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! s:_vital_loaded(V) abort
+  let s:Closure = a:V.import('Data.Closure')
+endfunction
+
+function! s:_vital_depends() abort
+  return ['Data.Closure']
+endfunction
+
 let s:NONE = []
 lockvar! s:NONE
 
@@ -819,31 +827,41 @@ function! s:Stream.foreach(f) abort
 endfunction
 
 function! s:_not(f, callee) abort
+  if s:Closure.is_closure(a:f)
+    return a:f.compose('=!a:1')
+  endif
   let type = type(a:f)
   if type is s:t_func
     return '!' . string(a:f) . '(v:val)'
   elseif type is s:t_string
     return '!map([v:val], ' . string(a:f) . ')[0]'
   else
-    " TODO: Support Data.Closure
     throw 'vital: Stream: ' . a:callee
-    \   . ': invalid type argument was given (expected funcref or string)'
+    \   . ': invalid type argument was given '
+    \   . '(expected funcref, string, or Data.Closure)'
   endif
 endfunction
 
 " Get funcref of call()-ish function to call a:f (arity is 0)
 " (see also s:_call_func0_expr())
 function! s:_get_callfunc_for_func0(f, callee) abort
+  if s:Closure.is_closure(a:f)
+    return function('s:_call_closure0')
+  endif
   let type = type(a:f)
   if type is s:t_func
     return function('call')
   elseif type is s:t_string
     return function('s:_call_func0_expr')
   else
-    " TODO: Support Data.Closure
     throw 'vital: Stream: ' . a:callee
-    \   . ': invalid type argument was given (expected funcref or string)'
+    \   . ': invalid type argument was given '
+    \   . '(expected funcref, string, or Data.Closure)'
   endif
+endfunction
+
+function! s:_call_closure0(closure, _args) abort
+  return a:closure.call()
 endfunction
 
 " a:expr is passed to v:val (but it is not meaningless value because
@@ -855,16 +873,23 @@ endfunction
 " Get funcref of call()-ish function to call a:f (arity is 1)
 " (see also s:_call_func1_expr())
 function! s:_get_callfunc_for_func1(f, callee) abort
+  if s:Closure.is_closure(a:f)
+    return function('s:_call_closure1')
+  endif
   let type = type(a:f)
   if type is s:t_func
     return function('call')
   elseif type is s:t_string
     return function('s:_call_func1_expr')
   else
-    " TODO: Support Data.Closure
     throw 'vital: Stream: ' . a:callee
-    \   . ': invalid type argument was given (expected funcref or string)'
+    \   . ': invalid type argument was given '
+    \   . '(expected funcref, string, or Data.Closure)'
   endif
+endfunction
+
+function! s:_call_closure1(closure, args) abort
+  return a:closure.call(a:args[0])
 endfunction
 
 " List of one element is passed to v:val
@@ -875,16 +900,23 @@ endfunction
 " Get funcref of call()-ish function to call a:f (arity is 2)
 " (see also s:_call_func2_expr())
 function! s:_get_callfunc_for_func2(f, callee) abort
+  if s:Closure.is_closure(a:f)
+    return function('s:_call_closure2')
+  endif
   let type = type(a:f)
   if type is s:t_func
     return function('call')
   elseif type is s:t_string
     return function('s:_call_func2_expr')
   else
-    " TODO: Support Data.Closure
     throw 'vital: Stream: ' . a:callee
-    \   . ': invalid type argument was given (expected funcref or string)'
+    \   . ': invalid type argument was given '
+    \   . '(expected funcref, string, or Data.Closure)'
   endif
+endfunction
+
+function! s:_call_closure2(closure, args) abort
+  return a:closure.call(a:args[0], a:args[1])
 endfunction
 
 " List of two elements is passed to v:val

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -852,10 +852,18 @@ endfunction
 
 function! s:Stream.reduce(f, ...) abort
   let l:Call = s:_get_callfunc_for_func2(a:f, 'reduce()')
-  let list = s:_get_non_empty_list_or_default(
-  \                 self, self.__estimate_size__(), a:0 ? [a:1] : s:NONE, 'reduce()')
-  let l:Result = list[0]
-  for l:Value in list[1:]
+  let list = self.to_list()
+  if a:0 ==# 0 && empty(list)
+    throw 'vital: Stream: reduce()' .
+    \     ': stream is empty and default value was not given'
+  endif
+  if a:0 > 0 || empty(list)
+    let l:Result = a:1
+  else
+    let l:Result = list[0]
+    let list = list[1:]
+  endif
+  for l:Value in list
     let l:Result = l:Call(a:f, [l:Result, l:Value])
     unlet l:Value
   endfor

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -629,7 +629,7 @@ endfunction
 function! s:Stream.reduce(f, init) abort
   let l:Call = s:_get_callfunc_for_func2(a:f, 'reduce()')
   let l:Result = a:init
-  for l:Value in self.__take_possible__(self.__estimate_size__())[0]
+  for l:Value in self.to_list()
     let l:Result = l:Call(a:f, [l:Result, l:Value])
   endfor
   return l:Result
@@ -725,7 +725,7 @@ endfunction
 
 function! s:Stream.count() abort
   if self.has_characteristics(s:SIZED)
-    return len(self.__take_possible__(self.__estimate_size__())[0])
+    return len(self.to_list())
   endif
   return 1/0
 endfunction

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -93,17 +93,17 @@ function! s:empty() abort
   return s:_new_from_list([], s:SIZED, 'empty()')
 endfunction
 
-function! s:_new_from_list(list, characteristics, callee) abort
+function! s:_new_from_list(list, characteristics, caller) abort
   let stream = s:_new(s:Stream)
   let stream._characteristics = a:characteristics
   let stream.__index = 0
   let stream.__end = 0
   let stream._list = a:list
-  let stream._callee = a:callee
+  let stream._caller = a:caller
   function! stream.__take_possible__(n) abort
     if self.__end
       throw 'vital: Stream: stream has already been operated upon or closed at '
-      \     . self._callee
+      \     . self._caller
     endif
     " max(): fix overflow
     let n = max([self.__index + a:n, a:n])
@@ -1033,7 +1033,7 @@ endfunction
 
 " Get funcref of call()-ish function to call a:f (arity is 0)
 " (see also s:_call_func0_expr())
-function! s:_get_callfunc_for_func0(f, callee) abort
+function! s:_get_callfunc_for_func0(f, caller) abort
   if s:Closure.is_closure(a:f)
     return function('s:_call_closure0')
   endif
@@ -1043,7 +1043,7 @@ function! s:_get_callfunc_for_func0(f, callee) abort
   elseif type is s:T_STRING
     return function('s:_call_func0_expr')
   else
-    throw 'vital: Stream: ' . a:callee
+    throw 'vital: Stream: ' . a:caller
     \   . ': invalid type argument was given '
     \   . '(expected funcref, string, or Data.Closure)'
   endif
@@ -1065,7 +1065,7 @@ endfunction
 
 " Get funcref of call()-ish function to call a:f (arity is 1)
 " (see also s:_call_func1_expr())
-function! s:_get_callfunc_for_func1(f, callee) abort
+function! s:_get_callfunc_for_func1(f, caller) abort
   if s:Closure.is_closure(a:f)
     return function('s:_call_closure1')
   endif
@@ -1075,7 +1075,7 @@ function! s:_get_callfunc_for_func1(f, callee) abort
   elseif type is s:T_STRING
     return function('s:_call_func1_expr')
   else
-    throw 'vital: Stream: ' . a:callee
+    throw 'vital: Stream: ' . a:caller
     \   . ': invalid type argument was given '
     \   . '(expected funcref, string, or Data.Closure)'
   endif
@@ -1092,7 +1092,7 @@ endfunction
 
 " Get funcref of call()-ish function to call a:f (arity is 2)
 " (see also s:_call_func2_expr())
-function! s:_get_callfunc_for_func2(f, callee) abort
+function! s:_get_callfunc_for_func2(f, caller) abort
   if s:Closure.is_closure(a:f)
     return function('s:_call_closure2')
   endif
@@ -1102,7 +1102,7 @@ function! s:_get_callfunc_for_func2(f, callee) abort
   elseif type is s:T_STRING
     return function('s:_call_func2_expr')
   else
-    throw 'vital: Stream: ' . a:callee
+    throw 'vital: Stream: ' . a:caller
     \   . ': invalid type argument was given '
     \   . '(expected funcref, string, or Data.Closure)'
   endif
@@ -1117,7 +1117,7 @@ function! s:_call_func2_expr(expr, args) abort
   return map([a:args], a:expr)[0]
 endfunction
 
-function! s:_get_non_empty_list_or_default(stream, size, default, callee) abort
+function! s:_get_non_empty_list_or_default(stream, size, default, caller) abort
   if a:stream.__estimate_size__() ==# 0
     let list = []
   else
@@ -1129,7 +1129,7 @@ function! s:_get_non_empty_list_or_default(stream, size, default, callee) abort
   if a:default isnot s:NONE
     return a:default
   else
-    throw 'vital: Stream: ' . a:callee .
+    throw 'vital: Stream: ' . a:caller .
     \     ': stream is empty and default value was not given'
   endif
 endfunction

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -383,7 +383,8 @@ endfunction
 " 'self._upstream.__take_possible__(n)' does not stop
 " unless .limit(n) was specified in downstream.
 " But regardless of whether .limit(n) was specified,
-" this method must stop for even upstream is infinite stream.
+" this method must stop for even upstream is infinite stream
+" if 'a:f' is not matched at any element in the stream.
 function! s:Stream.take_while(f) abort
   let stream = deepcopy(s:Stream)
   let stream._characteristics = self._characteristics

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -167,6 +167,38 @@ function! s:_inf_stream(f, init, call, expr) abort
   return stream
 endfunction
 
+function! s:generator(dict) abort
+  let stream = deepcopy(s:Stream)
+  let stream._characteristics = 0
+  let stream._dict = a:dict
+  let stream.__end = 0
+  let stream.__index = 0
+  function! stream.__take_possible__(n) abort
+    if self.__end
+      throw 'vital: Stream: stream has already been operated upon or closed at generator()'
+    endif
+    let list = []
+    let i = 0
+    let open = 1
+    while i < a:n
+      let l:Value = self._dict.yield(i + self.__index, s:NONE)
+      if l:Value is s:NONE
+        let open = 0
+        break
+      endif
+      let list += [l:Value]
+      let i += 1
+    endwhile
+    let self.__index += i
+    let self.__end = !open
+    return [list, open]
+  endfunction
+  function! stream.__estimate_size__() abort
+    return 1/0
+  endfunction
+  return stream
+endfunction
+
 function! s:zip(s1, s2, ...) abort
   let stream = deepcopy(s:Stream)
   let stream._characteristics =

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -85,7 +85,7 @@ endfunction
 
 function! s:lines(str, ...) abort
   let characteristics = get(a:000, 0, s:ORDERED + s:SIZED + s:IMMUTABLE)
-  let lines = a:str ==# '' ? [] : split(a:str, '\n', 1)
+  let lines = a:str ==# '' ? [] : split(a:str, '\r\?\n', 1)
   return s:_new_from_list(lines, characteristics, 'lines()')
 endfunction
 

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -722,6 +722,16 @@ function! s:Stream.string_join(...) abort
   return join(self.to_list(), sep)
 endfunction
 
+function! s:Stream.group_by(f) abort
+  let l:Call = s:_get_callfunc_for_func1(a:f, 'group_by()')
+  let l:Result = {}
+  for l:Value in self.to_list()
+    let key = l:Call(a:f, [l:Value])
+    let l:Result[key] = get(l:Result, key, []) + [l:Value]
+  endfor
+  return l:Result
+endfunction
+
 function! s:Stream.sum() abort
   return self.reduce('v:val[0] + v:val[1]', 0)
 endfunction

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -678,19 +678,10 @@ function! s:Stream.concat(stream) abort
   return s:concat(self, a:stream)
 endfunction
 
-function! s:Stream.reduce(f, init) abort
+function! s:Stream.reduce(f, ...) abort
   let l:Call = s:_get_callfunc_for_func2(a:f, 'reduce()')
-  let l:Result = a:init
-  for l:Value in self.to_list()
-    let l:Result = l:Call(a:f, [l:Result, l:Value])
-  endfor
-  return l:Result
-endfunction
-
-function! s:Stream.reduce_present(f) abort
-  let l:Call = s:_get_callfunc_for_func2(a:f, 'reduce_present()')
   let list = s:_get_present_list_or_throw(
-  \             self, self.__estimate_size__(), s:NONE, 'reduce_present()')
+  \                 self, self.__estimate_size__(), a:0 ? [a:1] : s:NONE, 'reduce()')
   let l:Result = list[0]
   for l:Value in list[1:]
     let l:Result = l:Call(a:f, [l:Result, l:Value])

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -175,8 +175,8 @@ endfunction
 
 " a0 <= a1, a2 > 0, a_0 = a0, i >= 0
 " a_i = a0 + i * a2
-" num = (a1 - a_i) / a2 + 1
-"     = (a1 - a0) / a2 - i + 1
+" size([a0,a1,a2],i) = (a1 - a_i) / a2 + 1
+"                    = (a1 - a0) / a2 - i + 1
 "
 " @assert a:args[2] != 0
 " @assert len(a:args) >= 3
@@ -188,7 +188,8 @@ function! s:_estimate_range_size(args, index) abort
   elseif a0 > a1
     return 0
   else
-    return (a1 - a0) / a2 - a:index + 1
+    " if a:index exceeds range, it becomes 0 or negative
+    return max([(a1 - a0) / a2 - a:index + 1, 0])
   endif
 endfunction
 

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -173,7 +173,7 @@ function! s:zip(s1, s2, ...) abort
     let smaller = min(map(copy(lists), 'len(v:val)'))
     " lists = [[1,2,3], [4,5,6]], list = [[1,4], [2,5], [3,6]]
     " let list = map(range(smaller), '[lists[0][v:val], lists[1][v:val], ...]')
-    let expr = '['.join(map(range(len(lists)), '"lists[".v:val."][v:val]"'), ',').']'
+    let expr = '['.join(map(range(len(lists)), '''lists[''.v:val.''][v:val]'''), ',').']'
     let list = map(range(smaller), expr)
     let self.__end = (self.__estimate_size__() ==# 0)
     return [list, !self.__end]

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -724,7 +724,7 @@ function! s:Stream.sorted(...) abort
     endif
     let list = s:_slice(self.__sorted_list, 0, a:n - 1)
     let self.__sorted_list = s:_slice(self.__sorted_list, a:n)
-    let self.__end = (self.__estimate_size__() > 0)
+    let self.__end = (self.__estimate_size__() ==# 0)
     return [list, !self.__end]
   endfunction
   function! stream.__compare__(a, b) abort

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -921,7 +921,7 @@ function! s:Stream.last(...) abort
 endfunction
 
 function! s:Stream.find(f, ...) abort
-  let s = self.filter(a:f).take(1)
+  let s = self.filter(a:f)
   return a:0 ? s.first(a:1) : s.first()
 endfunction
 
@@ -943,14 +943,7 @@ function! s:Stream.string_join(...) abort
 endfunction
 
 function! s:Stream.group_by(f) abort
-  let l:Call = s:_get_callfunc_for_func1(a:f, 'group_by()')
-  let l:Result = {}
-  for l:Value in self.to_list()
-    let key = l:Call(a:f, [l:Value])
-    let l:Result[key] = get(l:Result, key, []) + [l:Value]
-    unlet l:Value
-  endfor
-  return l:Result
+  return self.to_dict(a:f, '[v:val]', 'v:val[0] + v:val[1]')
 endfunction
 
 function! s:Stream.to_dict(key_mapper, value_mapper, ...) abort

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -614,8 +614,8 @@ function! s:Stream.skip(n) abort
   return stream
 endfunction
 
-function! s:Stream.zip(stream) abort
-  return s:zip(self, a:stream)
+function! s:Stream.zip(stream, ...) abort
+  return call('s:zip', [self, a:stream] + a:000)
 endfunction
 
 function! s:Stream.zip_with_index() abort

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -36,11 +36,9 @@ endfunction
 
 function! s:_vital_created(module) abort
   call extend(a:module, {
-  \ 'ORDERED': s:ORDERED,
   \ 'DISTINCT': s:DISTINCT,
   \ 'SORTED': s:SORTED,
   \ 'SIZED': s:SIZED,
-  \ 'IMMUTABLE': s:IMMUTABLE,
   \})
 endfunction
 
@@ -58,41 +56,41 @@ let s:T_NONE = 7
 let s:T_JOB = 8
 let s:T_CHANNEL = 9
 
-let s:ORDERED = 0x01
+" let s:ORDERED = 0x01
 let s:DISTINCT = 0x02
 let s:SORTED = 0x04
 let s:SIZED = 0x08
 " let s:NONNULL = 0x10
-let s:IMMUTABLE = 0x20
+" let s:IMMUTABLE = 0x20
 " let s:CONCURRENT = 0x40
 
 function! s:of(elem, ...) abort
-  return s:_new_from_list([a:elem] + a:000, s:ORDERED + s:SIZED + s:IMMUTABLE, 'of()')
+  return s:_new_from_list([a:elem] + a:000, s:SIZED, 'of()')
 endfunction
 
 function! s:chars(str, ...) abort
-  let characteristics = get(a:000, 0, s:ORDERED + s:SIZED + s:IMMUTABLE)
+  let characteristics = get(a:000, 0, s:SIZED)
   return s:_new_from_list(split(a:str, '\zs'), characteristics, 'chars()')
 endfunction
 
 function! s:lines(str, ...) abort
-  let characteristics = get(a:000, 0, s:ORDERED + s:SIZED + s:IMMUTABLE)
+  let characteristics = get(a:000, 0, s:SIZED)
   let lines = a:str ==# '' ? [] : split(a:str, '\r\?\n', 1)
   return s:_new_from_list(lines, characteristics, 'lines()')
 endfunction
 
 function! s:from_list(list, ...) abort
-  let characteristics = get(a:000, 0, s:ORDERED + s:SIZED + s:IMMUTABLE)
+  let characteristics = get(a:000, 0, s:SIZED)
   return s:_new_from_list(a:list, characteristics, 'from_list()')
 endfunction
 
 function! s:from_dict(dict, ...) abort
-  let characteristics = get(a:000, 0, s:DISTINCT + s:SIZED + s:IMMUTABLE)
+  let characteristics = get(a:000, 0, s:DISTINCT + s:SIZED)
   return s:_new_from_list(items(a:dict), characteristics, 'from_dict()')
 endfunction
 
 function! s:empty() abort
-  return s:_new_from_list([], s:ORDERED + s:SIZED + s:IMMUTABLE, 'empty()')
+  return s:_new_from_list([], s:SIZED, 'empty()')
 endfunction
 
 function! s:_new_from_list(list, characteristics, callee) abort
@@ -137,7 +135,7 @@ function! s:range(expr, ...) abort
   endif
   let stream = s:_new(s:Stream)
   let stream._characteristics =
-  \ s:ORDERED + s:DISTINCT + s:SORTED + s:SIZED + s:IMMUTABLE
+  \ s:DISTINCT + s:SORTED + s:SIZED
   let stream.__index = 0
   let stream._args = args
   let stream.__end = 0
@@ -197,7 +195,7 @@ endfunction
 
 function! s:_inf_stream(f, init, call, expr) abort
   let stream = s:_new(s:Stream)
-  let stream._characteristics = s:ORDERED + s:IMMUTABLE
+  let stream._characteristics = 0
   let stream._f = a:f
   let stream.__value = a:init
   let stream._call = a:call
@@ -397,7 +395,7 @@ endfunction
 function! s:Stream.map(f) abort
   let stream = s:_new(s:Stream)
   let stream._characteristics =
-  \ and(self._characteristics, invert(s:DISTINCT + s:SORTED + s:IMMUTABLE))
+  \ and(self._characteristics, invert(s:DISTINCT + s:SORTED))
   let stream._upstream = self
   let stream.__end = 0
   let stream._call = s:_get_callfunc_for_func1(a:f, 'map()')
@@ -420,7 +418,7 @@ endfunction
 function! s:Stream.flatmap(f) abort
   let stream = s:_new(s:Stream, [s:WithBuffered])
   let stream._characteristics =
-  \ and(self._characteristics, invert(s:DISTINCT + s:SORTED + s:IMMUTABLE))
+  \ and(self._characteristics, invert(s:DISTINCT + s:SORTED))
   let stream._upstream = self
   let stream.__end = 0
   let stream._call = s:_get_callfunc_for_func1(a:f, 'flatmap()')

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -196,6 +196,7 @@ function! s:generator(dict) abort
       endif
       let list += [l:Value]
       let i += 1
+      unlet l:Value
     endwhile
     let self.__index += i
     let self.__end = !open
@@ -778,13 +779,18 @@ function! s:Stream.to_dict(key_mapper, value_mapper, ...) abort
   let l:Result = {}
   if a:0
     let l:CallMerge = s:_get_callfunc_for_func2(a:1, 'to_dict()')
-    for l:Value in self.to_list()
-      let key = l:CallKM(a:key_mapper, [l:Value])
-      let l:Value = l:CallVM(a:value_mapper, [l:Value])
+    for l:Value1 in self.to_list()
+      let key = l:CallKM(a:key_mapper, [l:Value1])
+      let l:Value2 = l:CallVM(a:value_mapper, [l:Value1])
       if has_key(l:Result, key)
-        let l:Value = l:CallMerge(a:1, [l:Result[key], l:Value])
+        let l:Value3 = l:CallMerge(a:1, [l:Result[key], l:Value2])
+      else
+        let l:Value3 = l:Value2
       endif
-      let l:Result[key] = l:Value
+      let l:Result[key] = l:Value3
+      unlet l:Value1
+      unlet l:Value2
+      unlet l:Value3
     endfor
   else
     for l:Value in self.to_list()

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -732,6 +732,35 @@ function! s:Stream.group_by(f) abort
   return l:Result
 endfunction
 
+function! s:Stream.to_dict(key_mapper, value_mapper, ...) abort
+  let l:CallKM = s:_get_callfunc_for_func1(a:key_mapper, 'to_dict()')
+  let l:CallVM = s:_get_callfunc_for_func1(a:value_mapper, 'to_dict()')
+  if a:0
+    let l:CallMerge = s:_get_callfunc_for_func2(a:1, 'to_dict()')
+  endif
+  let l:Result = {}
+  if a:0
+    for l:Value in self.to_list()
+      let key = l:CallKM(a:key_mapper, [l:Value])
+      let l:Value = l:CallVM(a:value_mapper, [l:Value])
+      if has_key(l:Result, key)
+        let l:Value = l:CallMerge(a:1, [l:Result[key], l:Value])
+      endif
+      let l:Result[key] = l:Value
+    endfor
+  else
+    for l:Value in self.to_list()
+      let key = l:CallKM(a:key_mapper, [l:Value])
+      if has_key(l:Result, key)
+        throw 'vital: Stream: to_dict(): duplicated elements exist in stream '
+        \   . '(key: ' . string(key . "") . ')'
+      endif
+      let l:Result[key] = l:CallVM(a:value_mapper, [l:Value])
+    endfor
+  endif
+  return l:Result
+endfunction
+
 function! s:Stream.sum() abort
   return self.reduce('v:val[0] + v:val[1]', 0)
 endfunction

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -496,7 +496,7 @@ function! s:Stream.slice_before(f) abort
           let elem += [self.__buffer[i]]
         endif
       endfor
-      if !open
+      if !open && len(list) < a:n
         let list += [elem]
       endif
       if do_break

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -554,8 +554,8 @@ endfunction
 
 " __take_possible__(n): n may be 1/0, so when upstream is infinite stream,
 " 'self._upstream.__take_possible__(n)' does not stop
-" unless .limit(n) was specified in downstream.
-" But regardless of whether .limit(n) was specified,
+" unless .take(n) was specified in downstream.
+" But regardless of whether .take(n) was specified,
 " this method must stop for even upstream is infinite stream
 " if 'a:f' is not matched at any element in the stream.
 function! s:Stream.take_while(f) abort
@@ -770,9 +770,9 @@ function! s:_find_comparator(stream, default) abort
   endif
 endfunction
 
-function! s:Stream.limit(n) abort
+function! s:Stream.take(n) abort
   if a:n < 0
-    throw 'vital: Stream: limit(n): n must be 0 or positive'
+    throw 'vital: Stream: take(n): n must be 0 or positive'
   endif
   if a:n ==# 0
     return s:empty()
@@ -784,7 +784,7 @@ function! s:Stream.limit(n) abort
   let stream._max_n = a:n
   function! stream.__take_possible__(n) abort
     if self.__end
-      throw 'vital: Stream: stream has already been operated upon or closed at limit()'
+      throw 'vital: Stream: stream has already been operated upon or closed at take()'
     endif
     let n = min([self._upstream.__estimate_size__(), self._max_n, a:n])
     let [list, open] = self._upstream.__take_possible__(n)
@@ -797,9 +797,9 @@ function! s:Stream.limit(n) abort
   return stream
 endfunction
 
-function! s:Stream.skip(n) abort
+function! s:Stream.drop(n) abort
   if a:n < 0
-    throw 'vital: Stream: skip(n): n must be 0 or positive'
+    throw 'vital: Stream: drop(n): n must be 0 or positive'
   endif
   if a:n ==# 0
     return self
@@ -811,7 +811,7 @@ function! s:Stream.skip(n) abort
   let stream.__n = a:n
   function! stream.__take_possible__(n) abort
     if self.__end
-      throw 'vital: Stream: stream has already been operated upon or closed at skip()'
+      throw 'vital: Stream: stream has already been operated upon or closed at drop()'
     endif
     let open = self.__estimate_size__() > 0
     if self.__n > 0 && open
@@ -912,7 +912,7 @@ function! s:Stream.last(...) abort
 endfunction
 
 function! s:Stream.find(f, ...) abort
-  let s = self.filter(a:f).limit(1)
+  let s = self.filter(a:f).take(1)
   return a:0 ? s.first(a:1) : s.first()
 endfunction
 

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -702,6 +702,10 @@ function! s:Stream.to_list() abort
   return self.__take_possible__(self.__estimate_size__())[0]
 endfunction
 
+function! s:Stream.foreach(f) abort
+  call self.map(a:f).to_list()
+endfunction
+
 " Get funcref of call()-ish function to call a:f (arity is 1)
 " (see also s:_call_func1_expr())
 function! s:_get_callfunc_for_func1(f, callee) abort

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -74,8 +74,8 @@ function! s:IMMUTABLE() abort
   return s:IMMUTABLE
 endfunction
 
-function! s:of(...) abort
-  return s:_new_from_list(a:000, s:ORDERED + s:SIZED + s:IMMUTABLE, 'of()')
+function! s:of(elem, ...) abort
+  return s:_new_from_list([a:elem] + a:000, s:ORDERED + s:SIZED + s:IMMUTABLE, 'of()')
 endfunction
 
 function! s:chars(str, ...) abort

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -873,26 +873,26 @@ function! s:Stream.min_by(f, ...) abort
   return result[0]
 endfunction
 
-function! s:Stream.find_first(...) abort
+function! s:Stream.first(...) abort
   return s:_get_non_empty_list_or_default(
-  \           self, 1, a:0 ? [a:1] : s:NONE, 'find_first()')[0]
+  \           self, 1, a:0 ? [a:1] : s:NONE, 'first()')[0]
 endfunction
 
 function! s:Stream.find(f, ...) abort
   let s = self.filter(a:f).limit(1)
-  return a:0 ? s.find_first(a:1) : s.find_first()
+  return a:0 ? s.first(a:1) : s.first()
 endfunction
 
 function! s:Stream.any(f) abort
-  return self.filter(a:f).find_first(s:NONE) isnot s:NONE
+  return self.filter(a:f).first(s:NONE) isnot s:NONE
 endfunction
 
 function! s:Stream.all(f) abort
-  return self.filter(s:_not(a:f, 'all()')).find_first(s:NONE) is s:NONE
+  return self.filter(s:_not(a:f, 'all()')).first(s:NONE) is s:NONE
 endfunction
 
 function! s:Stream.none(f) abort
-  return self.filter(a:f).find_first(s:NONE) is s:NONE
+  return self.filter(a:f).first(s:NONE) is s:NONE
 endfunction
 
 function! s:Stream.string_join(...) abort

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -878,6 +878,11 @@ function! s:Stream.first(...) abort
   \           self, 1, a:0 ? [a:1] : s:NONE, 'first()')[0]
 endfunction
 
+function! s:Stream.last(...) abort
+  return s:_get_non_empty_list_or_default(
+  \           self, self.__estimate_size__(), a:0 ? [a:1] : s:NONE, 'last()')[-1]
+endfunction
+
 function! s:Stream.find(f, ...) abort
   let s = self.filter(a:f).limit(1)
   return a:0 ? s.first(a:1) : s.first()

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -401,7 +401,8 @@ endfunction
 
 function! s:Stream.map(f) abort
   let stream = s:_new(s:Stream)
-  let stream._characteristics = self._characteristics
+  let stream._characteristics =
+  \ and(self._characteristics, invert(s:DISTINCT + s:SORTED + s:IMMUTABLE))
   let stream._upstream = self
   let stream.__end = 0
   let stream._call = s:_get_callfunc_for_func1(a:f, 'map()')
@@ -423,7 +424,8 @@ endfunction
 
 function! s:Stream.flatmap(f) abort
   let stream = s:_new(s:Stream, [s:WithBufferred])
-  let stream._characteristics = self._characteristics
+  let stream._characteristics =
+  \ and(self._characteristics, invert(s:DISTINCT + s:SORTED + s:IMMUTABLE))
   let stream._upstream = self
   let stream.__end = 0
   let stream._call = s:_get_callfunc_for_func1(a:f, 'flatmap()')

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -706,6 +706,11 @@ function! s:Stream.none_match(f) abort
   return self.filter(a:f).find_first(s:NONE) is s:NONE
 endfunction
 
+function! s:Stream.string_join(...) abort
+  let sep = a:0 ? a:1 : ' '
+  return join(self.to_list(), sep)
+endfunction
+
 function! s:Stream.sum() abort
   return self.reduce('v:val[0] + v:val[1]', 0)
 endfunction

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -5,6 +5,9 @@ set cpo&vim
 
 " ============= Design of Internal API =============
 "
+" * a stream works like queue.
+"   __take_possible__(n) takes n or less elements from queue.
+"
 " * __take_possible__(n)
 "   * n must be 0 or positive
 "     * callee must not pass negative value
@@ -19,7 +22,7 @@ set cpo&vim
 "     * 'Stream.of(0,1,2,3).flatmap({n -> repeat([n], n)}).to_list() == [1,2,2,3,3,3]'
 "     * 'Stream.of(0,1,2,3).flatmap({n -> repeat([n], n)}).__estimate_size__() == 1/0'
 "   * if the stream is finite stream ('stream.has_characteristics(s:SIZED) == 1'),
-"     returns the number of rest elements
+"     returns the number of elements
 "   * if the stream is infinite stream ('stream.has_characteristics(s:SIZED) == 0'),
 "     returns 1/0
 "

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -866,15 +866,19 @@ function! s:_get_callfunc_for_func0(f, callee) abort
   endif
 endfunction
 
-function! s:_call_closure0(closure, _args) abort
+" @vimlint(EVL103, 1, a:args)
+function! s:_call_closure0(closure, args) abort
   return a:closure.call()
 endfunction
+" @vimlint(EVL103, 0, a:args)
 
 " a:expr is passed to v:val (but it is not meaningless value because
 " a:expr should not have 'v:val')
-function! s:_call_func0_expr(expr, _args) abort
+" @vimlint(EVL103, 1, a:args)
+function! s:_call_func0_expr(expr, args) abort
   return map([a:expr], a:expr)[0]
 endfunction
+" @vimlint(EVL103, 0, a:args)
 
 " Get funcref of call()-ish function to call a:f (arity is 1)
 " (see also s:_call_func1_expr())

--- a/autoload/vital/__vital__/Stream.vim
+++ b/autoload/vital/__vital__/Stream.vim
@@ -276,7 +276,7 @@ function! s:zip(s1, s2, ...) abort
     let smaller = min(map(copy(lists), 'len(v:val)'))
     " lists = [[1,2,3], [4,5,6]], list = [[1,4], [2,5], [3,6]]
     " let list = map(range(smaller), '[lists[0][v:val], lists[1][v:val], ...]')
-    let expr = '['.join(map(range(len(lists)), '''lists[''.v:val.''][v:val]'''), ',').']'
+    let expr = '[' . join(map(range(len(lists)), '''lists['' . v:val . ''][v:val]'''), ',') . ']'
     let list = map(range(smaller), expr)
     let self.__end = (self.__estimate_size__() ==# 0)
     return [list, !self.__end]

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -11,8 +11,8 @@ LIMITATION			|Vital.Stream-limitation|
 INTERFACE			|Vital.Stream-interface|
   FUNCTIONS			  |Vital.Stream-functions|
 STREAM OBJECT			|Vital.Stream-Stream-object|
-INTERMEDIATE OPERATIONS		|Vital.Stream-intermediate-operations|
-TERMINAL OPERATIONS		|Vital.Stream-terminal-operations|
+  INTERMEDIATE OPERATIONS	  |Vital.Stream-intermediate-operations|
+  TERMINAL OPERATIONS		  |Vital.Stream-terminal-operations|
 CHARACTERISTICS			|Vital.Stream-characteristics|
 TODO				|Vital.Stream-todo|
 

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -19,8 +19,9 @@ TODO				|Vital.Stream-todo|
 ==============================================================================
 INTRODUCTION				*Vital.Stream-introduction*
 
-*Vital.Stream* is a streaming library, that the API is made to resemble Java 8
+*Vital.Stream* is a streaming library, that its APIs are made to resemble Java 8
 Stream API (+ Ruby's Enumerable methods, and so on).
+https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html
 
 This module provides:
 
@@ -48,8 +49,26 @@ not aim to be like Java 8 Stream API.
 
 ==============================================================================
 EXAMPLES				*Vital.Stream-examples*
+
+FizzBuzz				*Vital.Stream-example-fizzbuzz*
+--------
 >
-	" Random generator (linear congruential generators)
+	let s:Stream = vital#{plugin-name}#new().import('Stream')
+
+	function! s:fizzbuzz(n) abort
+	  return a:n % 15 == 0 ? 'FizzBuzz' :
+	  \      a:n % 5  == 0 ? 'Buzz' :
+	  \      a:n % 3  == 0 ? 'Fizz' : a:n
+	endfunction
+
+	echo s:Stream.range(1, 100)
+	            \.map(function('s:fizzbuzz'))
+	            \.to_list()
+<
+Random number generator			*Vital.Stream-example-rng*
+-----------------------
+>
+	" Random number generator (linear congruential generators)
 	function! s:make_rand() abort
 	  let seed = reltime()[1]
 	  let max = float2nr(pow(2, 31) - 1)
@@ -96,7 +115,7 @@ chars({str} [, {characteristics}])	*Vital.Stream.chars()*
 
 lines({str} [, {characteristics}])	*Vital.Stream.lines()*
 	Shortcut for `s:Stream.from_list(split(str, '\r\?\n', 1), characteristics)` .
-	but this makes empty stream for empty string.
+	But this makes empty stream for empty string.
 
 from_dict({dict} [, {characteristics}])	*Vital.Stream.from_dict()*
 	Shortcut for `s:Stream.from_list(items(dict), characteristics)` .
@@ -199,11 +218,11 @@ concat({stream1}, {stream2} [, {stream3} ...])
 	        \.take(3).to_list()
 <
 iterate({init}, {func})		*Vital.Stream.iterate()*
-	Generates an infinite stream. {init} is the first element of stream.
-	the second element of stream is the value that {init} is applied to
+	Generates an infinite stream. {init} is the first element of a stream.
+	The second element of a stream is the value that {init} is applied to
 	{func}. And the result is applied to {func} until the end (if
-	downstream limited the number of elements, otherwise it results in
-	an infinite-loop).
+	downstream limited the number of elements, otherwise it results in an
+	infinite loop).
 >
 	" Output: [1,2,3]
 	echo s:Stream.iterate(1, 'v:val + 1').take(3).to_list()
@@ -232,7 +251,7 @@ range({expr} [, {max} [, {stride}]])
 	echo s:Stream.range(1, very_big_number).take(3).to_list()
 <
 generator({dict})		*Vital.Stream.generator()*
-	Creates an finite/infinite stream from generator object {dict}.
+	Creates a stream from generator object {dict}.
 	{dict} must have the following method:
 
 	yield({n}, {none})
@@ -252,9 +271,9 @@ generator({dict})		*Vital.Stream.generator()*
 	" This generator creates a finite stream
 	let dict = {}
 	function! dict.yield(times, NONE) abort
-	if a:times >= 3
-	  return a:NONE
-	endif
+	  if a:times >= 3
+	    return a:NONE
+	  endif
 	  return a:times
 	endfunction
 
@@ -276,13 +295,14 @@ Stream.get_comparator([{default}])
 	|Vital.Stream-Stream.sorted()| method).  Otherwise, if {default} was
 	given, returns {default}.  Or if {default} was not given, throws an
 	exception.
+
 	NOTE: If no comparator was passed to sorted() method, the
 	stream does not have a defined comparator.
 
-Intermediate operation			*Vital.Stream-intermediate-operations*
+Intermediate operations			*Vital.Stream-intermediate-operations*
 ----------------------
 
-Intermediate operations returns |Vital.Stream-Stream-object|.
+Intermediate operations return |Vital.Stream-Stream-object|.
 
 				*Vital.Stream-Stream.zip()*
 Stream.zip({stream1} [, {stream2} ...])
@@ -301,7 +321,7 @@ Stream.concat({stream1} [, {stream2} ...])
 Stream.peek({func})
 	Peeks elements of stream and does not change the values of elements.
 	This method is useful for debugging. You can pass a function which
-	causes side-effect. {func} is a function of 1 arity.
+	causes side effect. {func} is a function of 1 arity.
 >
 	let g:peek = []
 	" Output: [1,2,3]
@@ -317,16 +337,16 @@ Stream.peek({func})
 <
 				*Vital.Stream-Stream.map()*
 Stream.map({func})
-	Creates a stream which each element is applied {func}. {func} is a
-	function of 1 arity.
+	Creates a stream applying {func} to each element. {func} is a function
+	of 1 arity.
 >
 	" Output: [1,4,9]
 	echo s:Stream.of(1,2,3).map('v:val * 2').to_list()
 <
 				*Vital.Stream-Stream.flatmap()*
 Stream.flatmap({func})
-	Creates a flattened stream which each element is applied {func}
-	which returns |List|. {func} is a function of 1 arity.
+	Creates a flattened stream applying {func} to each element.
+	{func} returns |List|, and is a function of 1 arity.
 >
 	" Output: [1,2,2,3,3,3]
 	echo s:Stream.of(0,1,2,3).flatmap('repeat([v:val], v:val)').to_list()
@@ -336,7 +356,7 @@ Stream.flatmap({func})
 <
 				*Vital.Stream-Stream.filter()*
 Stream.filter({func})
-	Creates a filtered stream which each element is matched to {func}.
+	Creates a stream filtering elements with {func}
 	{func} is a function of 1 arity.
 >
 	" Output: [0,2,4]
@@ -344,7 +364,7 @@ Stream.filter({func})
 <
 				*Vital.Stream-Stream.slice_before()*
 Stream.slice_before({func})
-	Slices stream into each element before {func} returns non-zero. {func} is
+	Slices a stream into each element before {func} returns non-zero. {func} is
 	a function of 1 arity. (this method was inspired by Ruby's
 	Enumerable#slice_before())
 >
@@ -387,7 +407,7 @@ Stream.drop_while({func})
 				*Vital.Stream-Stream.distinct()*
 Stream.distinct([{stringifier}])
 	Gets rid of duplicate elements. {stringifier} is a function of 1 arity
-	which is used for stringification of an element to a key string. if
+	which is used for stringification of an element to a key string. If
 	the key string is same, only the first element is returned. Default
 	{stringifier} is |string()|.
 >
@@ -414,11 +434,11 @@ Stream.sorted([{comparator}])
 	" Output: ["a", "bb", "ccc"]
 	echo s:Stream.of('a', 'bb', 'ccc', 'ddd', 'ee').distinct('len(v:val)').to_list()
 <
-Terminal operation			*Vital.Stream-terminal-operations*
+Terminal operations			*Vital.Stream-terminal-operations*
 ------------------
 
-Terminal operations do not return |Vital.Stream-Stream-object|. And it cannot
-be called twice (because stream is already closed).
+Terminal operations do not return |Vital.Stream-Stream-object|. And the stream
+cannot be called twice (because stream is already closed).
 
 				*Vital.Stream-Stream.foreach()*
 Stream.foreach({func})
@@ -448,14 +468,18 @@ Stream.count([{func}])
 <
 				*Vital.Stream-Stream.reduce()*
 Stream.reduce({func} [, {init}])
-	Accumulates each element which is applied to {func}. {func} is a
-	function of 2 arity. If {init} is omitted and stream is empty, an
-	exception is thrown.
+	Accumulates each element by applying {func}. {func} is a function of 2
+	arity. If {init} was given, {init} is passed to the first argument of
+	{func}. Otherwise, the first element is passed. If {init} was not
+	given and stream is empty, an exception is thrown.
 >
 	" Output: 6
 	echo s:Stream.of(1,2,3).reduce('v:val[0] + v:val[1]', 0)
 	" Vim 8 version (lambda)
 	echo s:Stream.of(1,2,3).reduce({a,b -> a + b}, 0)
+
+	" Throws an exception
+	echo s:Stream.empty().reduce('v:val[0] + v:val[1]')
 
 	" Output: [3,2,1]
 	echo s:Stream.of(1,2,3).reduce('insert(v:val[0], v:val[1])', [])
@@ -479,7 +503,7 @@ Stream.sum()
 <
 				*Vital.Stream-Stream.max()*
 Stream.max([{default}])
-	Returns a maximum value in a stream. When the stream is empty, if
+	Returns a maximum value in a stream. When the stream is empty and if
 	{default} was given, returns {default}. Or if {default} was not given,
 	throws an exception.
 >
@@ -495,7 +519,7 @@ Stream.max([{default}])
 				*Vital.Stream-Stream.max_by()*
 Stream.max_by({func} [, {default}])
 	Returns an element whose value returned by {func} is a maximum value.
-	When the stream is empty, if {default} was given, returns {default}.
+	When the stream is empty and if {default} was given, returns {default}.
 	Or if {default} was not given, throws an exception.
 >
 	" Output: 'ccc'
@@ -509,7 +533,7 @@ Stream.max_by({func} [, {default}])
 <
 				*Vital.Stream-Stream.min()*
 Stream.min([{default}])
-	Returns a minimum value in a stream. When the stream is empty, if
+	Returns a minimum value in a stream. When the stream is empty if
 	{default} was given, returns {default}. Or if {default} was not given,
 	throws an exception.
 >
@@ -525,7 +549,7 @@ Stream.min([{default}])
 				*Vital.Stream-Stream.min_by()*
 Stream.min_by({func} [, {default}])
 	Returns an element whose value returned by {func} is a minimum value.
-	When the stream is empty, if {default} was given, returns {default}.
+	When the stream is empty and if {default} was given, returns {default}.
 	Or if {default} was not given, throws an exception.
 >
 	" Output: 'a'
@@ -539,7 +563,7 @@ Stream.min_by({func} [, {default}])
 <
 				*Vital.Stream-Stream.first()*
 Stream.first([{default}])
-	Returns the first element. When the stream is empty, if {default} was
+	Returns the first element. When the stream is empty and if {default} was
 	given, returns {default}. Or if {default} was not given, throws an
 	exception.
 >
@@ -554,7 +578,7 @@ Stream.first([{default}])
 <
 				*Vital.Stream-Stream.last()*
 Stream.last([{default}])
-	Returns the last element. When the stream is empty, if {default} was
+	Returns the last element. When the stream is empty and if {default} was
 	given, returns {default}. Or if {default} was not given, throws an
 	exception.
 >
@@ -651,8 +675,8 @@ Stream.to_dict({keymapper}, {valuemapper} [, {mergefunc}])
 <
 				*Vital.Stream-Stream.string_join()*
 Stream.string_join([{sep}])
-	|join()| each elements with {sep}.  Default value of {sep} is " " (one
-	whitespace) as well as Vim script's `join()`)
+	|join()| each elements with {sep}. Default value of {sep} is " " (one
+	whitespace) as well as Vim script's |join()|)
 >
 	" Output: 'Vim script'
 	echo s:Stream.of('Vim', 'script').string_join()
@@ -663,7 +687,8 @@ Stream.string_join([{sep}])
 <
 				*Vital.Stream-Stream.group_by()*
 Stream.group_by({func})
-	Shortcut for `stream.to_dict(func, '[v:val]', 'v:val[0] + v:val[1]')` .
+	Grouping elements of a stream with {func}. Shortcut for
+	`stream.to_dict(func, '[v:val]', 'v:val[0] + v:val[1]')` .
 >
 	" Output: {'even': [2,4], 'odd': [1,3,5]}
 	echo s:Stream.of(1,2,3,4,5).group_by('v:val % 2 == 0 ? "even" : "odd"')

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -252,16 +252,6 @@ generator({dict})		*Vital.Stream.generator()*
 ==============================================================================
 STREAM OBJECT				*Vital.Stream-Stream-object*
 
-				*Vital.Stream-Stream.get_comparator()*
-Stream.get_comparator([{default}])
-	Returns a comparator if the stream is marked as sorted and a defined
-	comparator (an argument passed to |Vital.Stream-Stream.sorted()|
-	method). Otherwise, if {default} was given, returns {default}. Or if
-	{default} was not given, throws an exception.
-
-	NOTE: If no comparator was passed to sorted() method, the
-	stream does not have a defined comparator.
-
 Intermediate operations			*Vital.Stream-intermediate-operations*
 ----------------------
 
@@ -449,82 +439,6 @@ Stream.reduce({func} [, {init}])
 	echo s:Stream.of(1,2,3).reduce('insert(v:val[0], v:val[1])', [])
 	echo s:Stream.of(1,2,3).reduce(function('insert'), [])
 <
-				*Vital.Stream-Stream.average()*
-Stream.average()
-	Returns the average of all elements. If a stream is empty, this throws
-	an exception.
->
-	" Output: 2
-	echo s:Stream.of(1,2,3).average()
-<
-				*Vital.Stream-Stream.sum()*
-Stream.sum()
-	Sums all elements. This is shortcut for
-	`stream.reduce({a,b -> a + b}, 0)`
->
-	" Output: 6
-	echo s:Stream.of(1,2,3).sum()
-<
-				*Vital.Stream-Stream.max()*
-Stream.max([{default}])
-	Returns a maximum value in a stream. When the stream is empty and if
-	{default} was given, returns {default}. Or if {default} was not given,
-	throws an exception.
->
-	" Output: 42
-	echo s:Stream.of(1,2,42).max()
-
-	" Throws an exception
-	echo s:Stream.empty().max()
-
-	" Output: 42
-	echo s:Stream.empty().max(42)
-<
-				*Vital.Stream-Stream.max_by()*
-Stream.max_by({func} [, {default}])
-	Returns an element whose value returned by {func} is a maximum value.
-	When the stream is empty and if {default} was given, returns {default}.
-	Or if {default} was not given, throws an exception.
->
-	" Output: 'ccc'
-	echo s:Stream.of('a', 'bb', 'ccc').max_by('len(v:val)')
-
-	" Throws an exception
-	echo s:Stream.empty().max_by('v:val')
-
-	" Output: 42
-	echo s:Stream.empty().max_by('v:val', 42)
-<
-				*Vital.Stream-Stream.min()*
-Stream.min([{default}])
-	Returns a minimum value in a stream. When the stream is empty if
-	{default} was given, returns {default}. Or if {default} was not given,
-	throws an exception.
->
-	" Output: 1
-	echo s:Stream.of(1,2,42).min()
-
-	" Throws an exception
-	echo s:Stream.of().min()
-
-	" Output: 42
-	echo s:Stream.of().min(42)
-<
-				*Vital.Stream-Stream.min_by()*
-Stream.min_by({func} [, {default}])
-	Returns an element whose value returned by {func} is a minimum value.
-	When the stream is empty and if {default} was given, returns {default}.
-	Or if {default} was not given, throws an exception.
->
-	" Output: 'a'
-	echo s:Stream.of('a', 'bb', 'ccc').min_by('len(v:val)')
-
-	" Throws an exception
-	echo s:Stream.empty().min_by('v:val')
-
-	" Output: 42
-	echo s:Stream.empty().min_by('v:val', 42)
-<
 				*Vital.Stream-Stream.first()*
 Stream.first([{default}])
 	Returns the first element. When the stream is empty and if {default} was
@@ -636,18 +550,6 @@ Stream.to_dict({keymapper}, {valuemapper} [, {mergefunc}])
 	" Output: {'1': 1, '2': 2, '3': 6}
 	echo s:Stream.of(1,2,3,3)
 	            \.to_dict('v:val', 'v:val', 'v:val[0] + v:val[1]')
-<
-				*Vital.Stream-Stream.string_join()*
-Stream.string_join([{sep}])
-	|join()| each elements with {sep}. Default value of {sep} is " " (one
-	whitespace) as well as Vim script's |join()|)
->
-	" Output: 'Vim script'
-	echo s:Stream.of('Vim', 'script').string_join()
-	" Output: 'JavaScript'
-	echo s:Stream.of('Java', 'Script').string_join('')
-	" Output: ''
-	echo s:Stream.empty().string_join()
 <
 				*Vital.Stream-Stream.group_by()*
 Stream.group_by({func})

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -16,28 +16,35 @@ TERMINAL OPERATIONS		|Vital.Stream-terminal-operations|
 CHARACTERISTICS			|Vital.Stream-characteristics|
 TODO				|Vital.Stream-todo|
 
-
-
 ==============================================================================
 INTRODUCTION				*Vital.Stream-introduction*
 
 *Vital.Stream* is a streaming library, that the API is made to resemble Java 8
-Stream API.
+Stream API (+ Ruby's Enumerable methods, and so on).
 
 This module provides:
 
-- **Laziness** like |Vital.Data.LazyList|
-- **chaining** like underscore.vim
+- Laziness like |Vital.Data.LazyList|
+- Chaining like underscore.vim
   - https://github.com/haya14busa/underscore.vim
 - Functional interface focusing what you want than how you solve a problem
   - Stream module builds execution plan instead of you
 - An interface of stream generation function like Java's Spliterator.
   See |Vital.Stream.generator()|
-- A higher-order function that supports string expression, |Funcref|,
+- Higher-order functions that support string expression, |Funcref|,
   |Vital.Data.Closure|
   - String expression: `s:Stream.of(1,2,3).map('v:val * 2')`
   - Funcref (lambda): `s:Stream.of(1,2,3).map({n -> n * 2})`
   - Data.Closure: `s:Stream.of(1,2,3).map(s:Closure.from_expr('a:1 * 2'))`
+  - NOTE: a function which receives 2 arguments receives |List| of 2 elements
+    in string expression. but Funcref and Data.Closure takes exact 2 arguments.
+    - String expression: `s:Stream.of(1,2,3).reduce('v:val[0] + v:val[1]')`
+    - Funcref (lambda): `s:Stream.of(1,2,3).reduce({a,b -> a + b})`
+    - Data.Closure: `s:Stream.of(1,2,3).reduce(s:Closure.from_operator('+'))`
+
+Some methods are not in Java 8 Stream API and vice versa (skip() -> drop(),
+limit() -> take(), and slice_before() is not in Stream API). This module does
+not aim to be like Java 8 Stream API.
 
 ==============================================================================
 EXAMPLES				*Vital.Stream-examples*
@@ -66,7 +73,6 @@ LIMITATION				*Vital.Stream-limitation*
 
 NOTE: A stream is not reusable as same as Java Stream API. This limitation
 allows internal optimization in the point of view of immutability.
-
 >
   let s = Stream.of([1,2,3,4,5])
   call s.map('v:val + 1').to_list()
@@ -83,7 +89,7 @@ empty()					*Vital.Stream.empty()*
 	Shortcut for `s:Stream.from_list([])` .
 
 of({elem1} [, {elem2} ...])		*Vital.Stream.of()*
-	Shortcut for `s:Stream.from_list([{elem1} [, {elem2} ...]])` .
+	Shortcut for `s:Stream.from_list([elem1, elem2, ...])` .
 
 chars({str} [, {characteristics}])	*Vital.Stream.chars()*
 	Shortcut for `s:Stream.from_list(split(str, '\zs'), characteristics)` .
@@ -131,13 +137,13 @@ IMMUTABLE()		*Vital.Stream.IMMUTABLE()*
 zip({stream1}, {stream2} [, {stream3} ...])
 	Combines given streams with the minimum number of elements.
 >
-	" Output is '[[1,3], [2,4]]'
+	" Output: [[1,3], [2,4]]
 	echo s:Stream.zip(s:Stream.of(1,2), s:Stream.of(3,4)).to_list()
 
-	" Output is '[[1,3]]'
+	" Output: [[1,3]]
 	echo s:Stream.zip(s:Stream.of(1,2), s:Stream.of(3)).to_list()
 
-	" Output is '[[1,3,5], [2,4,6]]'
+	" Output: [[1,3,5], [2,4,6]]
 	echo s:Stream.zip(
 	      \s:Stream.of(1,2),
 	      \s:Stream.of(3,4),
@@ -145,7 +151,7 @@ zip({stream1}, {stream2} [, {stream3} ...])
 	        \.to_list()
 
 	" You can zip infinite stream and finite stream
-	" Output is '[[1,'foo'], [2,'bar'], [3,'baz']]'
+	" Output: [[1,'foo'], [2,'bar'], [3,'baz']]
 	echo s:Stream.zip(
 	      \s:Stream.iterate(1, 'v:val + 1'),
 	      \s:Stream.of('foo', 'bar', 'baz))
@@ -153,7 +159,7 @@ zip({stream1}, {stream2} [, {stream3} ...])
 
 	" You can zip two infinite streams
 	" NOTE: .take(3) prohibits infinite loop
-	" Output is '[[1,-1], [2,-2], [3,-3]]'
+	" Output: [[1,-1], [2,-2], [3,-3]]
 	echo s:Stream.zip(
 	      \s:Stream.iterate(1, 'v:val + 1'),
 	      \s:Stream.iterate(-1, 'v:val - 1'))
@@ -164,13 +170,13 @@ concat({stream1}, {stream2} [, {stream3} ...])
 	Concatenates given streams.  If any of stream is an inifinite stream,
 	a result stream is an infinite stream.
 >
-	" Output is '[1,2,3,4]'
+	" Output: [1,2,3,4]
 	echo s:Stream.concat(s:Stream.of(1,2), s:Stream.of(3,4)).to_list()
 
-	" Output is '[1,2,3]'
+	" Output: [1,2,3]
 	echo s:Stream.concat(s:Stream.of(1,2), s:Stream.of(3)).to_list()
 
-	" Output is '[1,2,3,4,5,6]'
+	" Output: [1,2,3,4,5,6]
 	echo s:Stream.concat(
 	      \s:Stream.of(1,2),
 	      \s:Stream.of(3,4),
@@ -178,7 +184,7 @@ concat({stream1}, {stream2} [, {stream3} ...])
 	        \.to_list()
 
 	" You can combine infinite stream and finite stream
-	" Output is '[1,2,3,4,5]'
+	" Output: [1,2,3,4,5]
 	echo s:Stream.concat(
 	      \s:Stream.of(1,2,3),
 	      \s:Stream.iterate(4, 'v:val + 1'))
@@ -186,7 +192,7 @@ concat({stream1}, {stream2} [, {stream3} ...])
 
 	" You can combine two infinite streams
 	" NOTE: .take(3) prohibits infinite loop
-	" Output is '[[1,-1], [2,-2], [3,-3]]'
+	" Output: [[1,-1], [2,-2], [3,-3]]
 	echo s:Stream.concat(
 	      \s:Stream.iterate(1, 'v:val + 1'),
 	      \s:Stream.iterate(-1, 'v:val - 1'))
@@ -199,14 +205,14 @@ iterate({init}, {func})		*Vital.Stream.iterate()*
 	downstream limited the number of elements, otherwise it results in
 	an infinite-loop).
 >
-	" Output is '[1,2,3]'
+	" Output: [1,2,3]
 	echo s:Stream.iterate(1, 'v:val + 1').take(3).to_list()
 <
 generate({func})		*Vital.Stream.generate()*
 	Generates an infinite stream. This is normally used for a constant
 	stream.
 >
-	" Output is '[42,42,42]'
+	" Output: [42,42,42]
 	echo s:Stream.generate('42').take(3).to_list()
 <
 	But this can be also used for random number generation if {func}
@@ -222,7 +228,7 @@ range({expr} [, {max} [, {stride}]])
 >
 	" In Vim script, 1/0 is evaluated to the max value of number
 	let very_big_number = 1/0
-	" Output is '[1,2,3]'
+	" Output: [1,2,3]
 	echo s:Stream.range(1, very_big_number).take(3).to_list()
 <
 generator({dict})		*Vital.Stream.generator()*
@@ -240,7 +246,7 @@ generator({dict})		*Vital.Stream.generator()*
 	  return a:times
 	endfunction
 
-	" Output is '[0,1,2]'
+	" Output: [0,1,2]
 	echo s:Stream.generator(dict).take(3).to_list()
 
 	" This generator creates a finite stream
@@ -252,7 +258,7 @@ generator({dict})		*Vital.Stream.generator()*
 	  return a:times
 	endfunction
 
-	" Output is '[0,1,2]'
+	" Output: [0,1,2]
 	echo s:Stream.generator(dict).to_list()
 <
 ==============================================================================
@@ -267,9 +273,11 @@ Stream.has_characteristics({characteristics})
 Stream.get_comparator([{default}])
 	Returns a comparator if the stream has a SORTED characteristic and a
 	defined comparator (an argument passed to
-	|Vital.Stream-Stream.sorted()| method).
-	Otherwise, if {default} was given, returns {default}.
-	Or if {default} was not given, throws an exception.
+	|Vital.Stream-Stream.sorted()| method).  Otherwise, if {default} was
+	given, returns {default}.  Or if {default} was not given, throws an
+	exception.
+	NOTE: If no comparator was passed to sorted() method, the
+	stream does not have a defined comparator.
 
 Intermediate operation			*Vital.Stream-intermediate-operations*
 ----------------------
@@ -278,7 +286,7 @@ Intermediate operations returns |Vital.Stream-Stream-object|.
 
 				*Vital.Stream-Stream.zip()*
 Stream.zip({stream1} [, {stream2} ...])
-	Shortcut for `s:Stream.zip(self, {stream1}, {stream2}, ...)` .
+	Shortcut for `s:Stream.zip(self, stream1, stream2, ...)` .
 	See |Vital.Stream.zip()|.
 
 Stream.zip_with_index()		*Vital.Stream-Stream.zip_with_index()*
@@ -287,145 +295,379 @@ Stream.zip_with_index()		*Vital.Stream-Stream.zip_with_index()*
 
 				*Vital.Stream-Stream.concat()*
 Stream.concat({stream1} [, {stream2} ...])
-	Shortcut for `s:Stream.concat(self, {stream1}, {stream2}, ...)` .
+	Shortcut for `s:Stream.concat(self, stream1, stream2, ...)` .
 
 				*Vital.Stream-Stream.peek()*
 Stream.peek({func})
-  TODO
+	Peeks elements of stream and does not change the values of elements.
+	This method is useful for debugging. You can pass a function which
+	causes side-effect. {func} is a function of 1 arity.
+>
+	let g:peek = []
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,3).peek('add(g:peek, v:val)').to_list()
+	" Output: [1,2,3]
+	echo g:peek
 
+	let g:peek = []
+	" Output: [2,4,6]
+	echo s:Stream.of(1,2,3).peek('add(g:peek, v:val)').map('v:val * 2').to_list()
+	" Output: [1,2,3]
+	echo g:peek
+<
 				*Vital.Stream-Stream.map()*
 Stream.map({func})
-	Creates a stream which each element is applied {func}.
-
-  TODO
-
+	Creates a stream which each element is applied {func}. {func} is a
+	function of 1 arity.
+>
+	" Output: [1,4,9]
+	echo s:Stream.of(1,2,3).map('v:val * 2').to_list()
+<
 				*Vital.Stream-Stream.flatmap()*
 Stream.flatmap({func})
 	Creates a flattened stream which each element is applied {func}
-	which returns |List|.
+	which returns |List|. {func} is a function of 1 arity.
+>
+	" Output: [1,2,2,3,3,3]
+	echo s:Stream.of(0,1,2,3).flatmap('repeat([v:val], v:val)').to_list()
 
-  TODO
-
+	" Output: [0,4,8]
+	echo s:Stream.of(0,1,2,3,4).flatmap('v:val % 2 == 0 ? [v:val * 2] : []').to_list()
+<
 				*Vital.Stream-Stream.filter()*
 Stream.filter({func})
 	Creates a filtered stream which each element is matched to {func}.
-
-  TODO
-
+	{func} is a function of 1 arity.
+>
+	" Output: [0,2,4]
+	echo s:Stream.of(0,1,2,3,4).map('v:val % 2 == 0').to_list()
+<
 				*Vital.Stream-Stream.slice_before()*
 Stream.slice_before({func})
-  TODO
+	Slices stream into each element before {func} returns non-zero. {func} is
+	a function of 1 arity. (this method was inspired by Ruby's
+	Enumerable#slice_before())
+>
+	" Output: [[0,1], [2,3], [4,5]]
+	echo s:Stream.of(0,1,2,3,4,5).slice_before('v:val % 2 == 0').to_list()
 
+	" Output: [[1], [2,3], [4,5]]
+	echo s:Stream.of(1,2,3,4,5).slice_before('v:val % 2 == 0').to_list()
+<
 				*Vital.Stream-Stream.drop()*
 Stream.drop({n})
-  TODO
-
+	Drops the first {n} elements.
+>
+	" Output: [1,2,3]
+	echo s:Stream.of(42,1,2,3).drop(1).to_list()
+<
 				*Vital.Stream-Stream.take()*
 Stream.take({n})
-  TODO
-
+	Takes the first {n} elements.
+>
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,3,42).take(3).to_list()
+<
 				*Vital.Stream-Stream.take_while()*
 Stream.take_while({func})
-  TODO
-
+	Takes the first elements while {func} returns non-zero value. {func} is a
+	function of 1 arity.
+>
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,3,42,4,5,6).take_while('v:val < 10').to_list()
+<
 				*Vital.Stream-Stream.drop_while()*
 Stream.drop_while({func})
-  TODO
-
+	Drops the first elements while {func} returns non-zero value. {func} is a
+	function of 1 arity.
+>
+	" Output: [42,1,2,3]
+	echo s:Stream.of(1,2,3,42,4,5,6).drop_while('v:val < 10').to_list()
+<
 				*Vital.Stream-Stream.distinct()*
 Stream.distinct([{stringifier}])
-  TODO
+	Gets rid of duplicate elements. {stringifier} is a function of 1 arity
+	which is used for stringification of an element to a key string. if
+	the key string is same, only the first element is returned. Default
+	{stringifier} is |string()|.
+>
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,2,3,3).distinct().to_list()
 
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,3,2,1).distinct().to_list()
+
+	" Output: ["a", "bb", "ccc"]
+	echo s:Stream.of('a', 'bb', 'ccc', 'ddd', 'ee').distinct('len(v:val)').to_list()
+<
 				*Vital.Stream-Stream.sorted()*
 Stream.sorted([{comparator}])
-  TODO
+	Gets all elements from upstream and sorts all elements.
+	{comparator} is a function of 2 arity.
+>
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,2,3,3).distinct().to_list()
 
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,3,2,1).distinct().to_list()
+
+	" Output: ["a", "bb", "ccc"]
+	echo s:Stream.of('a', 'bb', 'ccc', 'ddd', 'ee').distinct('len(v:val)').to_list()
+<
 Terminal operation			*Vital.Stream-terminal-operations*
 ------------------
 
-Terminal operations do not return |Vital.Stream-Stream-object|.
+Terminal operations do not return |Vital.Stream-Stream-object|. And it cannot
+be called twice (because stream is already closed).
 
 				*Vital.Stream-Stream.foreach()*
 Stream.foreach({func})
-  TODO
-
+	Iterates each element and returns 0. {func} is a function of
+	1 arity.
+>
+	function! Echo(n)
+	  echo a:n
+	endfunction
+	call s:Stream.of(1,2,3).foreach('Echo(v:val)')
+<
 				*Vital.Stream-Stream.to_list()*
 Stream.to_list()
-  TODO
-
+	Returns |List| of elements.
+>
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,3).to_list()
+<
 				*Vital.Stream-Stream.count()*
 Stream.count([{func}])
-  TODO
-
+	Returns the number of elements. If {func} was given, it counts
+	elements only which {func} returns non-zero. {func} is a function of 1
+	arity.
+>
+	" Output: [1,2,3]
+	echo s:Stream.of(1,2,3).to_list()
+<
 				*Vital.Stream-Stream.reduce()*
 Stream.reduce({func} [, {init}])
-  TODO
+	Accumulates each element which is applied to {func}. {func} is a
+	function of 2 arity. If {init} is omitted and stream is empty, an
+	exception is thrown.
+>
+	" Output: 6
+	echo s:Stream.of(1,2,3).reduce('v:val[0] + v:val[1]', 0)
+	" Vim 8 version (lambda)
+	echo s:Stream.of(1,2,3).reduce({a,b -> a + b}, 0)
 
+	" Output: [3,2,1]
+	echo s:Stream.of(1,2,3).reduce('insert(v:val[0], v:val[1])', [])
+	echo s:Stream.of(1,2,3).reduce(function('insert'), [])
+<
 				*Vital.Stream-Stream.average()*
 Stream.average()
-  TODO
-
+	Returns the average of all elements. If a stream is empty, this throws
+	an exception.
+>
+	" Output: 2
+	echo s:Stream.of(1,2,3).average()
+<
 				*Vital.Stream-Stream.sum()*
 Stream.sum()
-  TODO
-
+	Sums all elements. This is shortcut for
+	`stream.reduce({a,b -> a + b}, 0)`
+>
+	" Output: 6
+	echo s:Stream.of(1,2,3).sum()
+<
 				*Vital.Stream-Stream.max()*
 Stream.max([{default}])
-  TODO
+	Returns a maximum value in a stream. When the stream is empty, if
+	{default} was given, returns {default}. Or if {default} was not given,
+	throws an exception.
+>
+	" Output: 42
+	echo s:Stream.of(1,2,42).max()
 
+	" Throws an exception
+	echo s:Stream.empty().max()
+
+	" Output: 42
+	echo s:Stream.empty().max(42)
+<
 				*Vital.Stream-Stream.max_by()*
 Stream.max_by({func} [, {default}])
-  TODO
+	Returns an element whose value returned by {func} is a maximum value.
+	When the stream is empty, if {default} was given, returns {default}.
+	Or if {default} was not given, throws an exception.
+>
+	" Output: 'ccc'
+	echo s:Stream.of('a', 'bb', 'ccc').max_by('len(v:val)')
 
+	" Throws an exception
+	echo s:Stream.empty().max_by('v:val')
+
+	" Output: 42
+	echo s:Stream.empty().max_by('v:val', 42)
+<
 				*Vital.Stream-Stream.min()*
 Stream.min([{default}])
-  TODO
+	Returns a minimum value in a stream. When the stream is empty, if
+	{default} was given, returns {default}. Or if {default} was not given,
+	throws an exception.
+>
+	" Output: 1
+	echo s:Stream.of(1,2,42).min()
 
+	" Throws an exception
+	echo s:Stream.of().min()
+
+	" Output: 42
+	echo s:Stream.of().min(42)
+<
 				*Vital.Stream-Stream.min_by()*
 Stream.min_by({func} [, {default}])
-  TODO
+	Returns an element whose value returned by {func} is a minimum value.
+	When the stream is empty, if {default} was given, returns {default}.
+	Or if {default} was not given, throws an exception.
+>
+	" Output: 'a'
+	echo s:Stream.of('a', 'bb', 'ccc').min_by('len(v:val)')
 
+	" Throws an exception
+	echo s:Stream.empty().min_by('v:val')
+
+	" Output: 42
+	echo s:Stream.empty().min_by('v:val', 42)
+<
 				*Vital.Stream-Stream.first()*
 Stream.first([{default}])
-	Returns the first element of a stream.
+	Returns the first element. When the stream is empty, if {default} was
+	given, returns {default}. Or if {default} was not given, throws an
+	exception.
+>
+	" Output: 42
+	echo s:Stream.of(42,1,2,3).first()
 
-  TODO
+	" Throws an exception
+	echo s:Stream.empty().first()
 
+	" Output: 42
+	echo s:Stream.empty().first(42)
+<
 				*Vital.Stream-Stream.last()*
 Stream.last([{default}])
-  TODO
+	Returns the last element. When the stream is empty, if {default} was
+	given, returns {default}. Or if {default} was not given, throws an
+	exception.
+>
+	" Output: 42
+	echo s:Stream.of(1,2,3,42).last()
 
+	" Throws an exception
+	echo s:Stream.empty().last()
+
+	" Output: 42
+	echo s:Stream.empty().last(42)
+<
 				*Vital.Stream-Stream.find()*
 Stream.find({func} [, {default}])
-	Shortcut for `filter(func).take(1).first(default)` .
+	Shortcut for `filter(func).first(default)` .
+	See |Vital.Stream-Stream.filter()| and |Vital.Stream-Stream.first()|.
+>
+	" Output: 42
+	echo s:Stream.of(1,2,42,3).find('v:val > 10')
 
+	" Throws an exception
+	echo s:Stream.of(1,2,3).find('v:val > 10')
+
+	" Output: 42
+	echo s:Stream.of(1,2,3).find('v:val > 10', 42)
+<
 				*Vital.Stream-Stream.any()*
 Stream.any({func})
-  TODO
+	Returns non-zero if any of the result value(s) which {func} returns
+	are non-zero. Otherwise returns zero. if a stream is empty, returns
+	zero.
+>
+	" Output: 1
+	echo s:Stream.of(1,2,42,3).any('v:val > 10')
 
+	" Output: 0
+	echo s:Stream.of(1,2,3).any('v:val > 10')
+
+	" Output: 0
+	echo s:Stream.empty().any('v:val > 10')
+<
 				*Vital.Stream-Stream.all()*
 Stream.all({func})
-  TODO
+	Returns non-zero if all of the result value(s) which {func} returns
+	are non-zero. Otherwise returns zero. if a stream is empty, returns
+	non-zero.
+>
+	" Output: 1
+	echo s:Stream.of(1,2,3).all('v:val > 0')
 
+	" Output: 0
+	echo s:Stream.of(1,2,3,-1).all('v:val > 0')
+
+	" Output: 1
+	echo s:Stream.empty().all('v:val > 0')
+<
 				*Vital.Stream-Stream.none()*
 Stream.none({func})
-  TODO
+	Returns non-zero if none of the result value(s) which {func} returns
+	are non-zero. Otherwise returns zero. if a stream is empty, returns
+	non-zero.
+>
+	" Output: 1
+	echo s:Stream.of(1,2,3).none('v:val < 0')
 
+	" Output: 0
+	echo s:Stream.of(1,2,3,-1).none('v:val < 0')
+
+	" Output: 1
+	echo s:Stream.empty().none('v:val < 0')
+<
 				*Vital.Stream-Stream.to_dict()*
 Stream.to_dict({keymapper}, {valuemapper} [, {mergefunc}])
-  TODO
+	Accumulates elements into a |Dictionary| whose keys and values are the
+	result of applying the provided mapping functions to the input
+	elements. {keymapper} / {valuemapper} create key / value pair. And If
+	{mergefunc} was given, {mergefunc} is invoked when the key is
+	duplicate to merge 2 values. If {mergefunc} was not given and met the
+	duplicate key, throws an exception. {keymapper} and {valuemapper} are
+	a function of 1 arity. {mergefunc} is a function of 2 arity.
+	See also |Vital.Stream-Stream.group_by()|.
+>
+	" Output: {'1': 2, '2': 4, '3': 6}
+	echo s:Stream.of(1,2,3)
+	            \.to_dict('v:val', 'v:val * 2')
 
+	" Throws an exception
+	echo s:Stream.of(1,2,3,3)
+	            \.to_dict('v:val', 'v:val')
+
+	" Output: {'1': 1, '2': 2, '3': 6}
+	echo s:Stream.of(1,2,3,3)
+	            \.to_dict('v:val', 'v:val', 'v:val[0] + v:val[1]')
+<
 				*Vital.Stream-Stream.string_join()*
 Stream.string_join([{sep}])
 	|join()| each elements with {sep}.  Default value of {sep} is " " (one
 	whitespace) as well as Vim script's `join()`)
-
-  TODO
-
+>
+	" Output: 'Vim script'
+	echo s:Stream.of('Vim', 'script').string_join()
+	" Output: 'JavaScript'
+	echo s:Stream.of('Java', 'Script').string_join('')
+	" Output: ''
+	echo s:Stream.empty().string_join()
+<
 				*Vital.Stream-Stream.group_by()*
 Stream.group_by({func})
-  TODO
-
+	Shortcut for `stream.to_dict(func, '[v:val]', 'v:val[0] + v:val[1]')` .
+>
+	" Output: {'even': [2,4], 'odd': [1,3,5]}
+	echo s:Stream.of(1,2,3,4,5).group_by('v:val % 2 == 0 ? "even" : "odd"')
+<
 ==============================================================================
 CHARACTERISTICS				*Vital.Stream-characteristics*
 

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -32,17 +32,14 @@ This module provides:
   - Stream module builds execution plan instead of you
 - An interface of stream generation function like Java's Spliterator
   See |Vital.Stream.generator()|
-- Higher-order functions that support string expression, |Funcref|,
-  |Vital.Data.Closure|
+- Higher-order functions that support string expression, |Funcref|
   - String expression: `s:Stream.of(1,2,3).map('v:val * 2')`
     `v:key` (index) cannot be used. see |Vital.Stream-tip-1|
   - Funcref (lambda): `s:Stream.of(1,2,3).map({n -> n * 2})`
-  - Data.Closure: `s:Stream.of(1,2,3).map(s:Closure.from_expr('a:1 * 2'))`
   - NOTE: a function which receives 2 arguments receives |List| of 2 elements
-    in string expression. but Funcref and Data.Closure takes exact 2 arguments
+    in string expression. but Funcref takes exact 2 arguments
     - String expression: `s:Stream.of(1,2,3).reduce('v:val[0] + v:val[1]')`
     - Funcref (lambda): `s:Stream.of(1,2,3).reduce({a,b -> a + b})`
-    - Data.Closure: `s:Stream.of(1,2,3).reduce(s:Closure.from_operator('+'))`
 
 Some methods are not in Java 8 Stream API and vice versa (skip() -> drop(),
 limit() -> take(), and slice_before() is not in Stream API). This module does
@@ -257,11 +254,10 @@ STREAM OBJECT				*Vital.Stream-Stream-object*
 
 				*Vital.Stream-Stream.get_comparator()*
 Stream.get_comparator([{default}])
-	Returns a comparator if the stream has a SORTED characteristic and a
-	defined comparator (an argument passed to
-	|Vital.Stream-Stream.sorted()| method).  Otherwise, if {default} was
-	given, returns {default}.  Or if {default} was not given, throws an
-	exception.
+	Returns a comparator if the stream is marked as sorted and a defined
+	comparator (an argument passed to |Vital.Stream-Stream.sorted()|
+	method). Otherwise, if {default} was given, returns {default}. Or if
+	{default} was not given, throws an exception.
 
 	NOTE: If no comparator was passed to sorted() method, the
 	stream does not have a defined comparator.

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -51,7 +51,7 @@ EXAMPLES				*Vital.Stream-examples*
 FizzBuzz				*Vital.Stream-example-fizzbuzz*
 --------
 >
-	let s:Stream = vital#{plugin-name}#new().import('Stream')
+	let s:Stream = vital#{plugin-name}#import('Stream')
 
 	function! s:fizzbuzz(n) abort
 	  return a:n % 15 == 0 ? 'FizzBuzz' :
@@ -358,11 +358,11 @@ Stream.drop_while({func})
 	echo s:Stream.of(1,2,3,42,4,5,6).drop_while('v:val < 10').to_list()
 <
 				*Vital.Stream-Stream.distinct()*
-Stream.distinct([{stringifier}])
-	Gets rid of duplicate elements. {stringifier} is a function of 1 arity
+Stream.distinct([{hashfunc}])
+	Gets rid of duplicate elements. {hashfunc} is a function of 1 arity
 	which is used for stringification of an element to a key string. If
 	the key string is same, only the first element is returned. Default
-	{stringifier} is |string()|.
+	{hashfunc} is |string()|.
 >
 	" Output: [1,2,3]
 	echo s:Stream.of(1,2,2,3,3).distinct().to_list()
@@ -417,8 +417,11 @@ Stream.count([{func}])
 	elements only which {func} returns non-zero. {func} is a function of 1
 	arity.
 >
-	" Output: [1,2,3]
-	echo s:Stream.of(1,2,3).to_list()
+	" Output: 3
+	echo s:Stream.of(1,2,3).count()
+
+	" Output: 1
+	echo s:Stream.of(1,2,3).count('v:val % 2 == 0')
 <
 				*Vital.Stream-Stream.reduce()*
 Stream.reduce({func} [, {init}])
@@ -485,9 +488,8 @@ Stream.find({func} [, {default}])
 <
 				*Vital.Stream-Stream.any()*
 Stream.any({func})
-	Returns non-zero if any of the result value(s) which {func} returns
-	are non-zero. Otherwise returns zero. if a stream is empty, returns
-	zero.
+	Returns 1 if any of the result value(s) which {func} returns are
+	non-zero. Otherwise returns 0. if a stream is empty, returns 0.
 >
 	" Output: 1
 	echo s:Stream.of(1,2,42,3).any('v:val > 10')
@@ -500,9 +502,8 @@ Stream.any({func})
 <
 				*Vital.Stream-Stream.all()*
 Stream.all({func})
-	Returns non-zero if all of the result value(s) which {func} returns
-	are non-zero. Otherwise returns zero. if a stream is empty, returns
-	non-zero.
+	Returns 1 if all of the result value(s) which {func} returns are
+	non-zero. Otherwise returns 0. if a stream is empty, returns 1.
 >
 	" Output: 1
 	echo s:Stream.of(1,2,3).all('v:val > 0')
@@ -515,9 +516,9 @@ Stream.all({func})
 <
 				*Vital.Stream-Stream.none()*
 Stream.none({func})
-	Returns non-zero if none of the result value(s) which {func} returns
-	are non-zero. Otherwise returns zero. if a stream is empty, returns
-	non-zero.
+	Returns 1 if none of the result value(s) which {func} returns
+	are non-zero. Otherwise returns 0. if a stream is empty, returns
+	1.
 >
 	" Output: 1
 	echo s:Stream.of(1,2,3).none('v:val < 0')
@@ -577,10 +578,19 @@ A. `v:key` is used for index number in |map()|.
 ==============================================================================
 TODO					*Vital.Stream-todo*
 
-- Create an execution plan and unroll a stream flow (do not create a s:Stream
+- Build an AST at each creation / intermediate operation.
+  And make an execution plan and unroll a stream flow (do not create a s:Stream
   object each time functions / methods are called)
   - `s:Stream.of(1,2,3).drop(1).take(1)` should create slice operation like
-    `[1,2,3][1:1]`.
+    `[1,2,3][1:1]`
+  - `s:Stream.range(1, 100).take(10).sorted()` should skip sorted() operation
+  - Java Stream API has "characteristics" like SORTED, DISTINCT which
+    represent the stream is already sorted(), or distinct(). But this module
+    should take essentially a different approach because Vim script is
+    interpreter language, that means, an execution of Ex command is slow even
+    just creating object
+- Better examples (|Vital.Stream-examples|) to show the power of this module
+- Provides a way to extend methods like underscore.vim
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -1,4 +1,4 @@
-*vital/Stream.txt*	Java Stream API like streaming library
+*vital/Stream.txt*	A streaming library
 
 Maintainer: tyru <tyru.exe@gmail.com>
 
@@ -14,6 +14,7 @@ STREAM OBJECT			|Vital.Stream-Stream-object|
   INTERMEDIATE OPERATIONS	  |Vital.Stream-intermediate-operations|
   TERMINAL OPERATIONS		  |Vital.Stream-terminal-operations|
 CHARACTERISTICS			|Vital.Stream-characteristics|
+TIPS				|Vital.Stream-tips|
 TODO				|Vital.Stream-todo|
 
 ==============================================================================
@@ -30,15 +31,16 @@ This module provides:
   - https://github.com/haya14busa/underscore.vim
 - Functional interface focusing what you want than how you solve a problem
   - Stream module builds execution plan instead of you
-- An interface of stream generation function like Java's Spliterator.
+- An interface of stream generation function like Java's Spliterator
   See |Vital.Stream.generator()|
 - Higher-order functions that support string expression, |Funcref|,
   |Vital.Data.Closure|
   - String expression: `s:Stream.of(1,2,3).map('v:val * 2')`
+    `v:key` (index) cannot be used. see |Vital.Stream-tip-1|
   - Funcref (lambda): `s:Stream.of(1,2,3).map({n -> n * 2})`
   - Data.Closure: `s:Stream.of(1,2,3).map(s:Closure.from_expr('a:1 * 2'))`
   - NOTE: a function which receives 2 arguments receives |List| of 2 elements
-    in string expression. but Funcref and Data.Closure takes exact 2 arguments.
+    in string expression. but Funcref and Data.Closure takes exact 2 arguments
     - String expression: `s:Stream.of(1,2,3).reduce('v:val[0] + v:val[1]')`
     - Funcref (lambda): `s:Stream.of(1,2,3).reduce({a,b -> a + b})`
     - Data.Closure: `s:Stream.of(1,2,3).reduce(s:Closure.from_operator('+'))`
@@ -119,26 +121,26 @@ lines({str} [, {characteristics}])	*Vital.Stream.lines()*
 
 from_dict({dict} [, {characteristics}])	*Vital.Stream.from_dict()*
 	Shortcut for `s:Stream.from_list(items(dict), characteristics)` .
-	Default {characteristics} is `[DISTINCT(), SIZED(), IMMUTABLE()]` .
+	Default {characteristics} is `[DISTINCT, SIZED, IMMUTABLE]` .
 
 from_list({list} [, {characteristics}])	*Vital.Stream.from_list()*
 	This makes a stream of elements of {list}.
 	See |Vital.Stream-Stream.has_characteristics()| for {characteristics}.
 
-ORDERED()		*Vital.Stream.ORDERED()*
+ORDERED		*Vital.Stream.ORDERED*
 	Characteristic value signifying that an encounter order is defined for
 	elements.  See also |Vital.Stream-Stream.has_characteristics()|.
 
-DISTINCT()		*Vital.Stream.DISTINCT()*
+DISTINCT		*Vital.Stream.DISTINCT*
 	Characteristic value signifying that, for each pair of encountered
 	elements x, y, `x != y` . See also
 	|Vital.Stream-Stream.has_characteristics()|.
 
-SORTED()		*Vital.Stream.SORTED()*
+SORTED		*Vital.Stream.SORTED*
 	Characteristic value signifying that encounter order follows a defined
 	sort order. See also |Vital.Stream-Stream.has_characteristics()|.
 
-SIZED()			*Vital.Stream.SIZED()*
+SIZED			*Vital.Stream.SIZED*
 	Characteristic value signifying that the value returned from internal
 	API `stream.__estimate_size__()` prior to traversal or splitting
 	represents a finite size that, in the absence of structural source
@@ -146,7 +148,7 @@ SIZED()			*Vital.Stream.SIZED()*
 	would be encountered by a complete traversal. See also
 	|Vital.Stream-Stream.has_characteristics()|.
 
-IMMUTABLE()		*Vital.Stream.IMMUTABLE()*
+IMMUTABLE		*Vital.Stream.IMMUTABLE*
 	Characteristic value signifying that the element source cannot be
 	structurally modified; that is, elements cannot be added, replaced, or
 	removed, so such changes cannot occur during traversal.  See also
@@ -699,32 +701,47 @@ CHARACTERISTICS				*Vital.Stream-characteristics*
 A stream has one or more "characteristics",
 and "characteristics" are flags to describe the stream.
 
-- |Vital.Stream.ORDERED()|
-- |Vital.Stream.DISTINCT()|
-- |Vital.Stream.SORTED()|
-- |Vital.Stream.SIZED()|
-- |Vital.Stream.IMMUTABLE()|
+- |Vital.Stream.ORDERED|
+- |Vital.Stream.DISTINCT|
+- |Vital.Stream.SORTED|
+- |Vital.Stream.SIZED|
+- |Vital.Stream.IMMUTABLE|
 
 The following code checks if a stream has one or more characteristics.
 >
 	let s:Stream = vital#{plugin-name}#new().import('Stream')
 	let stream = s:Stream.of(1,2,3)
-	if stream.has_characteristics(s:Stream.SIZED())
+	if stream.has_characteristics(s:Stream.SIZED)
 	  " the stream is finite stream
 	endif
 
 	let stream = s:Stream.iterate(1, 'v:val + 1')
-	if !stream.has_characteristics(s:Stream.SIZED())
+	if !stream.has_characteristics(s:Stream.SIZED)
 	  " the stream is infinite stream
 	endif
 
 	" you can check two or more characteristics at once
 	let stream = s:Stream.of(2,1,3).sorted()
-	if stream.has_characteristics([s:Stream.SIZED(), s:Stream.SORTED()])
+	if stream.has_characteristics([s:Stream.SIZED, s:Stream.SORTED])
 	  " the stream is finite and sorted stream
 	endif
 <
 
+==============================================================================
+TIPS					*Vital.Stream-tips*
+
+					*Vital.Stream-tip-1*
+Q. Can I use `v:key` in Stream.map() ?
+A. `v:key` is used for index number in |map()|.
+   In Stream module, you can use |Vital.Stream-Stream.zip_with_index()|
+   instead.
+>
+	" Output: ['0: foo', '1: bar', '2: baz']
+	echo s:Stream.of('foo', 'bar', 'baz')
+	            \.zip_with_index()
+	            \.map({l -> join(l, ': ')})
+	            \.to_list()
+<
 ==============================================================================
 TODO					*Vital.Stream-todo*
 

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -428,13 +428,14 @@ Stream.sorted([{comparator}])
 	{comparator} is a function of 2 arity.
 >
 	" Output: [1,2,3]
-	echo s:Stream.of(1,2,2,3,3).distinct().to_list()
+	echo s:Stream.of(2,1,3).sorted().to_list()
 
-	" Output: [1,2,3]
-	echo s:Stream.of(1,2,3,2,1).distinct().to_list()
-
-	" Output: ["a", "bb", "ccc"]
-	echo s:Stream.of('a', 'bb', 'ccc', 'ddd', 'ee').distinct('len(v:val)').to_list()
+	" Output: [3,2,1]
+	let by_desc = 'v:val[0] > v:val[1] ? -1 : v:val[0] ==# v:val[1] ? 0 : 1'
+	echo s:Stream.of(2,1,3).sorted(by_desc).to_list()
+	" Or
+	let l:ByDesc = {a,b -> a > b ? -1 : a ==# b ? 0 : 1}
+	echo s:Stream.of(2,1,3).sorted(l:ByDesc).to_list()
 <
 Terminal operations			*Vital.Stream-terminal-operations*
 ------------------

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -32,9 +32,9 @@ This module provides:
 - Functional interface focusing what you want than how you solve a problem
   - Stream module builds execution plan instead of you
 - An interface of stream generation function like Java's Spliterator.
-  See |Vital.Stream.generator()|.
+  See |Vital.Stream.generator()|
 - A higher-order function that supports string expression, |Funcref|,
-  |Vital.Data.Closure|.
+  |Vital.Data.Closure|
   - String expression: `s:Stream.of(1,2,3).map('v:val * 2')`
   - Funcref (lambda): `s:Stream.of(1,2,3).map({n -> n * 2})`
   - Data.Closure: `s:Stream.of(1,2,3).map(s:Closure.from_expr('a:1 * 2'))`
@@ -47,17 +47,17 @@ EXAMPLES				*Vital.Stream-examples*
 	  let seed = reltime()[1]
 	  let max = float2nr(pow(2, 31) - 1)
 	  " rand generates random numbers.
-	  " skip(): the first number seems too small...
-	  " map(): limits to 0.0 <= 1.0
+	  " drop(): the first number seems too small...
+	  " map(): limits to 0.0 <= val < 1.0
 	  " distinct(): gets rid of the same second decimal place of numbers
 	  return s:Stream.iterate(seed, '(48271 * v:val) % '.max)
-	                \.skip(1)
+	                \.drop(1)
 	                \.map('v:val / '.max.'.0')
 	                \.distinct('float2nr(round(v:val * 100))')
 	endfunction
 
 	" echo 20 random numbers
-	for d in s:make_rand().limit(20).to_list()
+	for d in s:make_rand().take(20).to_list()
 	  echo d
 	endfor
 <
@@ -152,12 +152,12 @@ zip({stream1}, {stream2} [, {stream3} ...])
 	        \.to_list()
 
 	" You can zip two infinite streams
-	" NOTE: .limit(3) prohibits infinite loop
+	" NOTE: .take(3) prohibits infinite loop
 	" Output is '[[1,-1], [2,-2], [3,-3]]'
 	echo s:Stream.zip(
 	      \s:Stream.iterate(1, 'v:val + 1'),
 	      \s:Stream.iterate(-1, 'v:val - 1'))
-	        \.limit(3).to_list()
+	        \.take(3).to_list()
 <
 				*Vital.Stream.concat()*
 concat({stream1}, {stream2} [, {stream3} ...])
@@ -182,15 +182,15 @@ concat({stream1}, {stream2} [, {stream3} ...])
 	echo s:Stream.concat(
 	      \s:Stream.of(1,2,3),
 	      \s:Stream.iterate(4, 'v:val + 1'))
-	        \.limit(5).to_list()
+	        \.take(5).to_list()
 
 	" You can combine two infinite streams
-	" NOTE: .limit(3) prohibits infinite loop
+	" NOTE: .take(3) prohibits infinite loop
 	" Output is '[[1,-1], [2,-2], [3,-3]]'
 	echo s:Stream.concat(
 	      \s:Stream.iterate(1, 'v:val + 1'),
 	      \s:Stream.iterate(-1, 'v:val - 1'))
-	        \.limit(3).to_list()
+	        \.take(3).to_list()
 <
 iterate({init}, {func})		*Vital.Stream.iterate()*
 	Generates an infinite stream. {init} is the first element of stream.
@@ -200,14 +200,14 @@ iterate({init}, {func})		*Vital.Stream.iterate()*
 	an infinite-loop).
 >
 	" Output is '[1,2,3]'
-	echo s:Stream.iterate(1, 'v:val + 1').limit(3).to_list()
+	echo s:Stream.iterate(1, 'v:val + 1').take(3).to_list()
 <
 generate({func})		*Vital.Stream.generate()*
 	Generates an infinite stream. This is normally used for a constant
 	stream.
 >
 	" Output is '[42,42,42]'
-	echo s:Stream.generate('42').limit(3).to_list()
+	echo s:Stream.generate('42').take(3).to_list()
 <
 	But this can be also used for random number generation if {func}
 	returns random values each time.
@@ -223,7 +223,7 @@ range({expr} [, {max} [, {stride}]])
 	" In Vim script, 1/0 is evaluated to the max value of number
 	let very_big_number = 1/0
 	" Output is '[1,2,3]'
-	echo s:Stream.range(1, very_big_number).limit(3).to_list()
+	echo s:Stream.range(1, very_big_number).take(3).to_list()
 <
 generator({dict})		*Vital.Stream.generator()*
 	Creates an finite/infinite stream from generator object {dict}.
@@ -241,7 +241,7 @@ generator({dict})		*Vital.Stream.generator()*
 	endfunction
 
 	" Output is '[0,1,2]'
-	echo s:Stream.generator(dict).limit(3).to_list()
+	echo s:Stream.generator(dict).take(3).to_list()
 
 	" This generator creates a finite stream
 	let dict = {}
@@ -316,12 +316,12 @@ Stream.filter({func})
 Stream.slice_before({func})
   TODO
 
-				*Vital.Stream-Stream.skip()*
-Stream.skip({n})
+				*Vital.Stream-Stream.drop()*
+Stream.drop({n})
   TODO
 
-				*Vital.Stream-Stream.limit()*
-Stream.limit({n})
+				*Vital.Stream-Stream.take()*
+Stream.take({n})
   TODO
 
 				*Vital.Stream-Stream.take_while()*
@@ -397,7 +397,7 @@ Stream.last([{default}])
 
 				*Vital.Stream-Stream.find()*
 Stream.find({func} [, {default}])
-	Shortcut for `filter(func).limit(1).first(default)` .
+	Shortcut for `filter(func).take(1).first(default)` .
 
 				*Vital.Stream-Stream.any()*
 Stream.any({func})
@@ -463,7 +463,7 @@ TODO					*Vital.Stream-todo*
 
 - Create an execution plan and unroll a stream flow (do not create a s:Stream
   object each time functions / methods are called)
-  - `s:Stream.of(1,2,3).skip(1).limit(1)` should create slice operation like
+  - `s:Stream.of(1,2,3).drop(1).take(1)` should create slice operation like
     `[1,2,3][1:1]`.
 
 ==============================================================================

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -13,7 +13,6 @@ INTERFACE			|Vital.Stream-interface|
 STREAM OBJECT			|Vital.Stream-Stream-object|
   INTERMEDIATE OPERATIONS	  |Vital.Stream-intermediate-operations|
   TERMINAL OPERATIONS		  |Vital.Stream-terminal-operations|
-CHARACTERISTICS			|Vital.Stream-characteristics|
 TIPS				|Vital.Stream-tips|
 TODO				|Vital.Stream-todo|
 
@@ -112,47 +111,18 @@ empty()					*Vital.Stream.empty()*
 of({elem1} [, {elem2} ...])		*Vital.Stream.of()*
 	Shortcut for `s:Stream.from_list([elem1, elem2, ...])` .
 
-chars({str} [, {characteristics}])	*Vital.Stream.chars()*
-	Shortcut for `s:Stream.from_list(split(str, '\zs'), characteristics)` .
+chars({str})	*Vital.Stream.chars()*
+	Shortcut for `s:Stream.from_list(split(str, '\zs'))` .
 
-lines({str} [, {characteristics}])	*Vital.Stream.lines()*
-	Shortcut for `s:Stream.from_list(split(str, '\r\?\n', 1), characteristics)` .
+lines({str})	*Vital.Stream.lines()*
+	Shortcut for `s:Stream.from_list(split(str, '\r\?\n', 1))` .
 	But this makes empty stream for empty string.
 
-from_dict({dict} [, {characteristics}])	*Vital.Stream.from_dict()*
-	Shortcut for `s:Stream.from_list(items(dict), characteristics)` .
-	Default {characteristics} is `[DISTINCT, SIZED, IMMUTABLE]` .
+from_dict({dict})	*Vital.Stream.from_dict()*
+	Shortcut for `s:Stream.from_list(items(dict))` .
 
-from_list({list} [, {characteristics}])	*Vital.Stream.from_list()*
+from_list({list})	*Vital.Stream.from_list()*
 	This makes a stream of elements of {list}.
-	See |Vital.Stream-Stream.has_characteristics()| for {characteristics}.
-
-ORDERED		*Vital.Stream.ORDERED*
-	Characteristic value signifying that an encounter order is defined for
-	elements.  See also |Vital.Stream-Stream.has_characteristics()|.
-
-DISTINCT		*Vital.Stream.DISTINCT*
-	Characteristic value signifying that, for each pair of encountered
-	elements x, y, `x != y` . See also
-	|Vital.Stream-Stream.has_characteristics()|.
-
-SORTED		*Vital.Stream.SORTED*
-	Characteristic value signifying that encounter order follows a defined
-	sort order. See also |Vital.Stream-Stream.has_characteristics()|.
-
-SIZED			*Vital.Stream.SIZED*
-	Characteristic value signifying that the value returned from internal
-	API `stream.__estimate_size__()` prior to traversal or splitting
-	represents a finite size that, in the absence of structural source
-	modification, represents an exact count of the number of elements that
-	would be encountered by a complete traversal. See also
-	|Vital.Stream-Stream.has_characteristics()|.
-
-IMMUTABLE		*Vital.Stream.IMMUTABLE*
-	Characteristic value signifying that the element source cannot be
-	structurally modified; that is, elements cannot be added, replaced, or
-	removed, so such changes cannot occur during traversal.  See also
-	|Vital.Stream-Stream.has_characteristics()|.
 
 			*Vital.Stream.zip()*
 zip({stream1}, {stream2} [, {stream3} ...])
@@ -284,11 +254,6 @@ generator({dict})		*Vital.Stream.generator()*
 <
 ==============================================================================
 STREAM OBJECT				*Vital.Stream-Stream-object*
-
-				*Vital.Stream-Stream.has_characteristics()*
-Stream.has_characteristics({characteristics})
-	Returns non-zero if the stream has {characteristics}.
-	See also |Vital.Stream-characteristics|.
 
 				*Vital.Stream-Stream.get_comparator()*
 Stream.get_comparator([{default}])
@@ -696,38 +661,6 @@ Stream.group_by({func})
 	" Output: {'even': [2,4], 'odd': [1,3,5]}
 	echo s:Stream.of(1,2,3,4,5).group_by('v:val % 2 == 0 ? "even" : "odd"')
 <
-==============================================================================
-CHARACTERISTICS				*Vital.Stream-characteristics*
-
-A stream has one or more "characteristics",
-and "characteristics" are flags to describe the stream.
-
-- |Vital.Stream.ORDERED|
-- |Vital.Stream.DISTINCT|
-- |Vital.Stream.SORTED|
-- |Vital.Stream.SIZED|
-- |Vital.Stream.IMMUTABLE|
-
-The following code checks if a stream has one or more characteristics.
->
-	let s:Stream = vital#{plugin-name}#new().import('Stream')
-	let stream = s:Stream.of(1,2,3)
-	if stream.has_characteristics(s:Stream.SIZED)
-	  " the stream is finite stream
-	endif
-
-	let stream = s:Stream.iterate(1, 'v:val + 1')
-	if !stream.has_characteristics(s:Stream.SIZED)
-	  " the stream is infinite stream
-	endif
-
-	" you can check two or more characteristics at once
-	let stream = s:Stream.of(2,1,3).sorted()
-	if stream.has_characteristics([s:Stream.SIZED, s:Stream.SORTED])
-	  " the stream is finite and sorted stream
-	endif
-<
-
 ==============================================================================
 TIPS					*Vital.Stream-tips*
 

--- a/doc/vital/Stream.txt
+++ b/doc/vital/Stream.txt
@@ -1,0 +1,470 @@
+*vital/Stream.txt*	Java Stream API like streaming library
+
+Maintainer: tyru <tyru.exe@gmail.com>
+
+==============================================================================
+CONTENTS				*Vital.Stream-contents*
+
+INTRODUCTION			|Vital.Stream-introduction|
+EXAMPLES			|Vital.Stream-examples|
+LIMITATION			|Vital.Stream-limitation|
+INTERFACE			|Vital.Stream-interface|
+  FUNCTIONS			  |Vital.Stream-functions|
+STREAM OBJECT			|Vital.Stream-Stream-object|
+INTERMEDIATE OPERATIONS		|Vital.Stream-intermediate-operations|
+TERMINAL OPERATIONS		|Vital.Stream-terminal-operations|
+CHARACTERISTICS			|Vital.Stream-characteristics|
+TODO				|Vital.Stream-todo|
+
+
+
+==============================================================================
+INTRODUCTION				*Vital.Stream-introduction*
+
+*Vital.Stream* is a streaming library, that the API is made to resemble Java 8
+Stream API.
+
+This module provides:
+
+- **Laziness** like |Vital.Data.LazyList|
+- **chaining** like underscore.vim
+  - https://github.com/haya14busa/underscore.vim
+- Functional interface focusing what you want than how you solve a problem
+  - Stream module builds execution plan instead of you
+- An interface of stream generation function like Java's Spliterator.
+  See |Vital.Stream.generator()|.
+- A higher-order function that supports string expression, |Funcref|,
+  |Vital.Data.Closure|.
+  - String expression: `s:Stream.of(1,2,3).map('v:val * 2')`
+  - Funcref (lambda): `s:Stream.of(1,2,3).map({n -> n * 2})`
+  - Data.Closure: `s:Stream.of(1,2,3).map(s:Closure.from_expr('a:1 * 2'))`
+
+==============================================================================
+EXAMPLES				*Vital.Stream-examples*
+>
+	" Random generator (linear congruential generators)
+	function! s:make_rand() abort
+	  let seed = reltime()[1]
+	  let max = float2nr(pow(2, 31) - 1)
+	  " rand generates random numbers.
+	  " skip(): the first number seems too small...
+	  " map(): limits to 0.0 <= 1.0
+	  " distinct(): gets rid of the same second decimal place of numbers
+	  return s:Stream.iterate(seed, '(48271 * v:val) % '.max)
+	                \.skip(1)
+	                \.map('v:val / '.max.'.0')
+	                \.distinct('float2nr(round(v:val * 100))')
+	endfunction
+
+	" echo 20 random numbers
+	for d in s:make_rand().limit(20).to_list()
+	  echo d
+	endfor
+<
+==============================================================================
+LIMITATION				*Vital.Stream-limitation*
+
+NOTE: A stream is not reusable as same as Java Stream API. This limitation
+allows internal optimization in the point of view of immutability.
+
+>
+  let s = Stream.of([1,2,3,4,5])
+  call s.map('v:val + 1').to_list()
+  " This throws 'vital: Stream: stream has already been operated upon or closed'
+  call s.map('v:val + 1').to_list()
+<
+==============================================================================
+INTERFACE				*Vital.Stream-interface*
+
+------------------------------------------------------------------------------
+FUNCTIONS				*Vital.Stream-functions*
+
+empty()					*Vital.Stream.empty()*
+	Shortcut for `s:Stream.from_list([])` .
+
+of({elem1} [, {elem2} ...])		*Vital.Stream.of()*
+	Shortcut for `s:Stream.from_list([{elem1} [, {elem2} ...]])` .
+
+chars({str} [, {characteristics}])	*Vital.Stream.chars()*
+	Shortcut for `s:Stream.from_list(split(str, '\zs'), characteristics)` .
+
+lines({str} [, {characteristics}])	*Vital.Stream.lines()*
+	Shortcut for `s:Stream.from_list(split(str, '\r\?\n', 1), characteristics)` .
+	but this makes empty stream for empty string.
+
+from_dict({dict} [, {characteristics}])	*Vital.Stream.from_dict()*
+	Shortcut for `s:Stream.from_list(items(dict), characteristics)` .
+	Default {characteristics} is `[DISTINCT(), SIZED(), IMMUTABLE()]` .
+
+from_list({list} [, {characteristics}])	*Vital.Stream.from_list()*
+	This makes a stream of elements of {list}.
+	See |Vital.Stream-Stream.has_characteristics()| for {characteristics}.
+
+ORDERED()		*Vital.Stream.ORDERED()*
+	Characteristic value signifying that an encounter order is defined for
+	elements.  See also |Vital.Stream-Stream.has_characteristics()|.
+
+DISTINCT()		*Vital.Stream.DISTINCT()*
+	Characteristic value signifying that, for each pair of encountered
+	elements x, y, `x != y` . See also
+	|Vital.Stream-Stream.has_characteristics()|.
+
+SORTED()		*Vital.Stream.SORTED()*
+	Characteristic value signifying that encounter order follows a defined
+	sort order. See also |Vital.Stream-Stream.has_characteristics()|.
+
+SIZED()			*Vital.Stream.SIZED()*
+	Characteristic value signifying that the value returned from internal
+	API `stream.__estimate_size__()` prior to traversal or splitting
+	represents a finite size that, in the absence of structural source
+	modification, represents an exact count of the number of elements that
+	would be encountered by a complete traversal. See also
+	|Vital.Stream-Stream.has_characteristics()|.
+
+IMMUTABLE()		*Vital.Stream.IMMUTABLE()*
+	Characteristic value signifying that the element source cannot be
+	structurally modified; that is, elements cannot be added, replaced, or
+	removed, so such changes cannot occur during traversal.  See also
+	|Vital.Stream-Stream.has_characteristics()|.
+
+			*Vital.Stream.zip()*
+zip({stream1}, {stream2} [, {stream3} ...])
+	Combines given streams with the minimum number of elements.
+>
+	" Output is '[[1,3], [2,4]]'
+	echo s:Stream.zip(s:Stream.of(1,2), s:Stream.of(3,4)).to_list()
+
+	" Output is '[[1,3]]'
+	echo s:Stream.zip(s:Stream.of(1,2), s:Stream.of(3)).to_list()
+
+	" Output is '[[1,3,5], [2,4,6]]'
+	echo s:Stream.zip(
+	      \s:Stream.of(1,2),
+	      \s:Stream.of(3,4),
+	      \s:Stream.of(5,6))
+	        \.to_list()
+
+	" You can zip infinite stream and finite stream
+	" Output is '[[1,'foo'], [2,'bar'], [3,'baz']]'
+	echo s:Stream.zip(
+	      \s:Stream.iterate(1, 'v:val + 1'),
+	      \s:Stream.of('foo', 'bar', 'baz))
+	        \.to_list()
+
+	" You can zip two infinite streams
+	" NOTE: .limit(3) prohibits infinite loop
+	" Output is '[[1,-1], [2,-2], [3,-3]]'
+	echo s:Stream.zip(
+	      \s:Stream.iterate(1, 'v:val + 1'),
+	      \s:Stream.iterate(-1, 'v:val - 1'))
+	        \.limit(3).to_list()
+<
+				*Vital.Stream.concat()*
+concat({stream1}, {stream2} [, {stream3} ...])
+	Concatenates given streams.  If any of stream is an inifinite stream,
+	a result stream is an infinite stream.
+>
+	" Output is '[1,2,3,4]'
+	echo s:Stream.concat(s:Stream.of(1,2), s:Stream.of(3,4)).to_list()
+
+	" Output is '[1,2,3]'
+	echo s:Stream.concat(s:Stream.of(1,2), s:Stream.of(3)).to_list()
+
+	" Output is '[1,2,3,4,5,6]'
+	echo s:Stream.concat(
+	      \s:Stream.of(1,2),
+	      \s:Stream.of(3,4),
+	      \s:Stream.of(5,6))
+	        \.to_list()
+
+	" You can combine infinite stream and finite stream
+	" Output is '[1,2,3,4,5]'
+	echo s:Stream.concat(
+	      \s:Stream.of(1,2,3),
+	      \s:Stream.iterate(4, 'v:val + 1'))
+	        \.limit(5).to_list()
+
+	" You can combine two infinite streams
+	" NOTE: .limit(3) prohibits infinite loop
+	" Output is '[[1,-1], [2,-2], [3,-3]]'
+	echo s:Stream.concat(
+	      \s:Stream.iterate(1, 'v:val + 1'),
+	      \s:Stream.iterate(-1, 'v:val - 1'))
+	        \.limit(3).to_list()
+<
+iterate({init}, {func})		*Vital.Stream.iterate()*
+	Generates an infinite stream. {init} is the first element of stream.
+	the second element of stream is the value that {init} is applied to
+	{func}. And the result is applied to {func} until the end (if
+	downstream limited the number of elements, otherwise it results in
+	an infinite-loop).
+>
+	" Output is '[1,2,3]'
+	echo s:Stream.iterate(1, 'v:val + 1').limit(3).to_list()
+<
+generate({func})		*Vital.Stream.generate()*
+	Generates an infinite stream. This is normally used for a constant
+	stream.
+>
+	" Output is '[42,42,42]'
+	echo s:Stream.generate('42').limit(3).to_list()
+<
+	But this can be also used for random number generation if {func}
+	returns random values each time.
+>
+	" Simple (but not so randomized?) implementation
+	echo s:Stream.generate('reltime()[0] % reltime()[1]').first()
+<
+				*Vital.Stream.range()*
+range({expr} [, {max} [, {stride}]])
+	Unlike Vim script's |range()|, this function does not create the large
+	number of elements of List like Vim script's |range()|.
+>
+	" In Vim script, 1/0 is evaluated to the max value of number
+	let very_big_number = 1/0
+	" Output is '[1,2,3]'
+	echo s:Stream.range(1, very_big_number).limit(3).to_list()
+<
+generator({dict})		*Vital.Stream.generator()*
+	Creates an finite/infinite stream from generator object {dict}.
+	{dict} must have the following method:
+
+	yield({n}, {none})
+	  Returns a value used for an element of a stream. If the return value
+	  is same as {none}, the stream ends. {n} is 0 or positive value that
+	  means the number of called times. At the first time, {n} is 0.
+>
+	" This generator creates an infinite stream
+	let dict = {}
+	function! dict.yield(times, NONE) abort
+	  return a:times
+	endfunction
+
+	" Output is '[0,1,2]'
+	echo s:Stream.generator(dict).limit(3).to_list()
+
+	" This generator creates a finite stream
+	let dict = {}
+	function! dict.yield(times, NONE) abort
+	if a:times >= 3
+	  return a:NONE
+	endif
+	  return a:times
+	endfunction
+
+	" Output is '[0,1,2]'
+	echo s:Stream.generator(dict).to_list()
+<
+==============================================================================
+STREAM OBJECT				*Vital.Stream-Stream-object*
+
+				*Vital.Stream-Stream.has_characteristics()*
+Stream.has_characteristics({characteristics})
+	Returns non-zero if the stream has {characteristics}.
+	See also |Vital.Stream-characteristics|.
+
+				*Vital.Stream-Stream.get_comparator()*
+Stream.get_comparator([{default}])
+	Returns a comparator if the stream has a SORTED characteristic and a
+	defined comparator (an argument passed to
+	|Vital.Stream-Stream.sorted()| method).
+	Otherwise, if {default} was given, returns {default}.
+	Or if {default} was not given, throws an exception.
+
+Intermediate operation			*Vital.Stream-intermediate-operations*
+----------------------
+
+Intermediate operations returns |Vital.Stream-Stream-object|.
+
+				*Vital.Stream-Stream.zip()*
+Stream.zip({stream1} [, {stream2} ...])
+	Shortcut for `s:Stream.zip(self, {stream1}, {stream2}, ...)` .
+	See |Vital.Stream.zip()|.
+
+Stream.zip_with_index()		*Vital.Stream-Stream.zip_with_index()*
+	Shortcut for `s:Stream.zip(s:Stream.iterate(1, 'v:val + 1'), self)` .
+	See |Vital.Stream.zip()|.
+
+				*Vital.Stream-Stream.concat()*
+Stream.concat({stream1} [, {stream2} ...])
+	Shortcut for `s:Stream.concat(self, {stream1}, {stream2}, ...)` .
+
+				*Vital.Stream-Stream.peek()*
+Stream.peek({func})
+  TODO
+
+				*Vital.Stream-Stream.map()*
+Stream.map({func})
+	Creates a stream which each element is applied {func}.
+
+  TODO
+
+				*Vital.Stream-Stream.flatmap()*
+Stream.flatmap({func})
+	Creates a flattened stream which each element is applied {func}
+	which returns |List|.
+
+  TODO
+
+				*Vital.Stream-Stream.filter()*
+Stream.filter({func})
+	Creates a filtered stream which each element is matched to {func}.
+
+  TODO
+
+				*Vital.Stream-Stream.slice_before()*
+Stream.slice_before({func})
+  TODO
+
+				*Vital.Stream-Stream.skip()*
+Stream.skip({n})
+  TODO
+
+				*Vital.Stream-Stream.limit()*
+Stream.limit({n})
+  TODO
+
+				*Vital.Stream-Stream.take_while()*
+Stream.take_while({func})
+  TODO
+
+				*Vital.Stream-Stream.drop_while()*
+Stream.drop_while({func})
+  TODO
+
+				*Vital.Stream-Stream.distinct()*
+Stream.distinct([{stringifier}])
+  TODO
+
+				*Vital.Stream-Stream.sorted()*
+Stream.sorted([{comparator}])
+  TODO
+
+Terminal operation			*Vital.Stream-terminal-operations*
+------------------
+
+Terminal operations do not return |Vital.Stream-Stream-object|.
+
+				*Vital.Stream-Stream.foreach()*
+Stream.foreach({func})
+  TODO
+
+				*Vital.Stream-Stream.to_list()*
+Stream.to_list()
+  TODO
+
+				*Vital.Stream-Stream.count()*
+Stream.count([{func}])
+  TODO
+
+				*Vital.Stream-Stream.reduce()*
+Stream.reduce({func} [, {init}])
+  TODO
+
+				*Vital.Stream-Stream.average()*
+Stream.average()
+  TODO
+
+				*Vital.Stream-Stream.sum()*
+Stream.sum()
+  TODO
+
+				*Vital.Stream-Stream.max()*
+Stream.max([{default}])
+  TODO
+
+				*Vital.Stream-Stream.max_by()*
+Stream.max_by({func} [, {default}])
+  TODO
+
+				*Vital.Stream-Stream.min()*
+Stream.min([{default}])
+  TODO
+
+				*Vital.Stream-Stream.min_by()*
+Stream.min_by({func} [, {default}])
+  TODO
+
+				*Vital.Stream-Stream.first()*
+Stream.first([{default}])
+	Returns the first element of a stream.
+
+  TODO
+
+				*Vital.Stream-Stream.last()*
+Stream.last([{default}])
+  TODO
+
+				*Vital.Stream-Stream.find()*
+Stream.find({func} [, {default}])
+	Shortcut for `filter(func).limit(1).first(default)` .
+
+				*Vital.Stream-Stream.any()*
+Stream.any({func})
+  TODO
+
+				*Vital.Stream-Stream.all()*
+Stream.all({func})
+  TODO
+
+				*Vital.Stream-Stream.none()*
+Stream.none({func})
+  TODO
+
+				*Vital.Stream-Stream.to_dict()*
+Stream.to_dict({keymapper}, {valuemapper} [, {mergefunc}])
+  TODO
+
+				*Vital.Stream-Stream.string_join()*
+Stream.string_join([{sep}])
+	|join()| each elements with {sep}.  Default value of {sep} is " " (one
+	whitespace) as well as Vim script's `join()`)
+
+  TODO
+
+				*Vital.Stream-Stream.group_by()*
+Stream.group_by({func})
+  TODO
+
+==============================================================================
+CHARACTERISTICS				*Vital.Stream-characteristics*
+
+A stream has one or more "characteristics",
+and "characteristics" are flags to describe the stream.
+
+- |Vital.Stream.ORDERED()|
+- |Vital.Stream.DISTINCT()|
+- |Vital.Stream.SORTED()|
+- |Vital.Stream.SIZED()|
+- |Vital.Stream.IMMUTABLE()|
+
+The following code checks if a stream has one or more characteristics.
+>
+	let s:Stream = vital#{plugin-name}#new().import('Stream')
+	let stream = s:Stream.of(1,2,3)
+	if stream.has_characteristics(s:Stream.SIZED())
+	  " the stream is finite stream
+	endif
+
+	let stream = s:Stream.iterate(1, 'v:val + 1')
+	if !stream.has_characteristics(s:Stream.SIZED())
+	  " the stream is infinite stream
+	endif
+
+	" you can check two or more characteristics at once
+	let stream = s:Stream.of(2,1,3).sorted()
+	if stream.has_characteristics([s:Stream.SIZED(), s:Stream.SORTED()])
+	  " the stream is finite and sorted stream
+	endif
+<
+
+==============================================================================
+TODO					*Vital.Stream-todo*
+
+- Create an execution plan and unroll a stream flow (do not create a s:Stream
+  object each time functions / methods are called)
+  - `s:Stream.of(1,2,3).skip(1).limit(1)` should create slice operation like
+    `[1,2,3][1:1]`.
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1402,8 +1402,10 @@ Describe Stream
 
     It reduces stream
       Assert Equals(Stream.empty().reduce('v:val', 42), 42)
+      Assert Equals(Stream.of(1).reduce('v:val[0] + v:val[1]'), 1)
       Assert Equals(Stream.of(1,2,3,4,5).reduce('v:val[0] + v:val[1]'), 15)
       Assert Equals(Stream.of(1,2,3,4,5).reduce('v:val[0] + v:val[1]', 0), 15)
+      Assert Equals(Stream.of(1,2,3).reduce('insert(v:val[0], v:val[1])', []), [3,2,1])
     End
 
     It reduces stream by funcref
@@ -1412,16 +1414,20 @@ Describe Stream
       endfunction
 
       Assert Equals(Stream.empty().reduce(function('Id'), 42), 42)
+      Assert Equals(Stream.of(1).reduce(function('Plus')), 1)
       Assert Equals(Stream.of(1,2,3,4,5).reduce(function('Plus')), 15)
       Assert Equals(Stream.of(1,2,3,4,5).reduce(function('Plus'), 0), 15)
+      Assert Equals(Stream.of(1,2,3).reduce(function('insert'), []), [3,2,1])
 
       delfunction Plus
     End
 
     It reduces stream by Data.Closure
       Assert Equals(Stream.empty().reduce(Closure.from_expr('a:1'), 42), 42)
+      Assert Equals(Stream.of(1).reduce(Closure.from_operator('+')), 1)
       Assert Equals(Stream.of(1,2,3,4,5).reduce(Closure.from_operator('+')), 15)
       Assert Equals(Stream.of(1,2,3,4,5).reduce(Closure.from_operator('+'), 0), 15)
+      Assert Equals(Stream.of(1,2,3).reduce(Closure.from_funcname('insert'), []), [3,2,1])
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -388,7 +388,7 @@ Describe Stream
   End
 
   Describe .zip()
-    It constructs infinite stream with function
+    It combines zipped stream
       Assert Equals(
         \Stream.zip(
           \Stream.empty(),
@@ -442,17 +442,24 @@ Describe Stream
         \Stream.zip(
           \Stream.iterate(1, 'v:val + 1'),
           \Stream.of(5, 4, 3, 2, 1))
-        \.limit(5).to_list(),
+        \.to_list(),
         \[[1,5], [2,4], [3,3], [4,2], [5,1]])
+
+      Assert Equals(
+        \Stream.zip(
+          \Stream.iterate(1, 'v:val + 1'),
+          \Stream.iterate(-1, 'v:val - 1'))
+        \.limit(5).to_list(),
+        \[[1,-1], [2,-2], [3,-3], [4,-4], [5,-5]])
     End
 
-    It constructs infinite stream with function
+    It combines zipped stream (method version)
       Assert Equals(
         \Stream.of(1,2,3).zip(Stream.of(4,5,6)).to_list(),
         \[[1,4], [2,5], [3,6]])
     End
 
-    It constructs stream from String with characteristics
+    It combines stream from String with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6))
       Assert True(s.has_characteristics(Stream.ORDERED()))
@@ -468,7 +475,7 @@ Describe Stream
       Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
 
-    It constructs stream with 3 or more than streams
+    It combines stream with 3 or more than streams
       Assert Equals(
           \Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
                 \.to_list(),
@@ -503,7 +510,7 @@ Describe Stream
           \[[1,4,7], [2,5,8], [3,6,9]])
     End
 
-    It constructs stream with 3 or more than streams with characteristics
+    It combines stream with 3 or more than streams with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
       Assert True(s.has_characteristics(Stream.ORDERED()))
@@ -521,7 +528,7 @@ Describe Stream
   End
 
   Describe .zip_with_index()
-    It constructs infinite stream with function
+    It combines infinite stream with function
       Assert Equals(
       \ Stream.empty().zip_with_index().to_list(),
       \ [])
@@ -533,7 +540,7 @@ Describe Stream
   End
 
   Describe .concat()
-    It constructs infinite stream with function
+    It concatenates stream
       Assert Equals(
         \Stream.concat(
           \Stream.of(1,2,3),
@@ -570,7 +577,7 @@ Describe Stream
         \[1,2,3,4,5])
     End
 
-    It constructs stream from 3 or more than streams
+    It concatenates stream from 3 or more than streams
       Assert Equals(
         \Stream.concat(
           \Stream.of(1),
@@ -589,7 +596,7 @@ Describe Stream
         \[1,2,3])
     End
 
-    It constructs stream from 3 or more than streams (method version)
+    It concatenates stream from 3 or more than streams (method version)
       Assert Equals(
         \Stream.of(1).concat(Stream.of(2), Stream.of(3)).to_list(),
         \[1,2,3])
@@ -599,7 +606,7 @@ Describe Stream
         \[1,2,3])
     End
 
-    It constructs infinite stream with function (method version)
+    It concatenates infinite stream with function (method version)
       Assert Equals(
         \Stream.of(1,2,3).concat(Stream.of(4,5)).to_list(),
         \[1,2,3,4,5])

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -21,17 +21,13 @@ Describe Stream
   After all
     delfunction Id
     delfunction Succ
+    delfunction IsEven
     delfunction Answer
   End
 
   Describe .of()
     It raises exception for empty arguments
-      try
-        call Stream.of()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      Throws Stream.of()
     End
 
     It constructs stream from arguments
@@ -161,12 +157,7 @@ Describe Stream
 
   Describe .range()
     It throws an exception for invalid arguments
-      try
-        call Stream.range(-2, 2, 0)
-        Assert 0
-      catch /vital: Stream: range(): stride is 0/
-        Assert 1
-      endtry
+      Throws /vital: Stream: range(): stride is 0/ Stream.range(-2, 2, 0)
     End
 
     It constructs stream from range
@@ -274,9 +265,23 @@ Describe Stream
     End
 
     It constructs infinite stream by funcref
+
       Assert Equals(
       \ Stream.generate(function('Answer')).take(5).to_list(),
       \ [42, 42, 42, 42, 42])
+
+      let g:count = 0
+      function! IncCount() abort
+        let g:count += 1
+        return g:count
+      endfunction
+
+      Assert Equals(
+      \ Stream.generate(function('IncCount')).take(5).to_list(),
+      \ [1,2,3,4,5])
+
+      unlet g:count
+      delfunction IncCount
     End
   End
 
@@ -499,18 +504,10 @@ Describe Stream
 
   Describe .take()
     It raises negative number argument
-      try
-        call Stream.of(1,2,3,4,5).take(-1)
-        Assert 0
-      catch /vital: Stream: take(n): n must be 0 or positive/
-        Assert 1
-      endtry
-      try
-        call Stream.of(1,2,3,4,5).take(0)
-        Assert 1
-      catch /vital: Stream: take(n): n must be 0 or positive/
-        Assert 0
-      endtry
+      Throws /vital: Stream: take(n): n must be 0 or positive/
+      \      Stream.of(1,2,3,4,5).take(-1)
+      " throws nothing
+      call Stream.of(1,2,3,4,5).take(0)
     End
 
     It limits stream
@@ -528,39 +525,23 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.take(3)
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.take(3).to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.take(3)
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws call s.take(3).to_list()
     End
   End
 
   Describe .drop()
     It raises negative number argument
-      try
-        call Stream.of(1,2,3,4,5).drop(-1)
-        Assert 0
-      catch /vital: Stream: drop(n): n must be 0 or positive/
-        Assert 1
-      endtry
-      try
-        call Stream.of(1,2,3,4,5).drop(0)
-        Assert 1
-      catch /vital: Stream: drop(n): n must be 0 or positive/
-        Assert 0
-      endtry
+      Throws /vital: Stream: drop(n): n must be 0 or positive/
+      \      Stream.of(1,2,3,4,5).drop(-1)
+      " throws nothing
+      call Stream.of(1,2,3,4,5).drop(0)
     End
 
     It limits stream
@@ -571,22 +552,14 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.drop(3)
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.drop(3).to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.drop(3)
+
+      let s = Stream.of(1,2,3,4,5)
+      Assert Equals(s.to_list(), [1,2,3,4,5])
+      Throws s.drop(3).to_list()
     End
   End
 
@@ -624,22 +597,14 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.peek('v:val')
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.peek('v:val').to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.peek('v:val')
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws s.peek('v:val').to_list()
     End
   End
 
@@ -663,21 +628,13 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.foreach('v:val')
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.foreach('v:val')
-        call s.foreach('v:val')
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.foreach('v:val')
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.foreach('v:val')
+      Throws s.foreach('v:val')
     End
   End
 
@@ -699,22 +656,14 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.map('v:val')
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.map('v:val').to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.map('v:val')
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws s.map('v:val').to_list()
     End
   End
 
@@ -769,22 +718,14 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.flatmap('v:val')
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.flatmap('v:val').to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.flatmap('v:val')
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws s.flatmap('v:val').to_list()
     End
   End
 
@@ -845,22 +786,14 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.slice_before('v:val')
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.slice_before('v:val').to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.slice_before('v:val')
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws s.slice_before('v:val').to_list()
     End
   End
 
@@ -882,22 +815,14 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.filter('v:val % 2 == 0')
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.filter('v:val % 2 == 0').to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.filter('v:val % 2 == 0')
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws s.filter('v:val % 2 == 0').to_list()
     End
   End
 
@@ -935,22 +860,14 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.take_while('v:val')
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.take_while('v:val').to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.take_while('v:val')
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws s.take_while('v:val').to_list()
     End
   End
 
@@ -986,22 +903,14 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.drop_while('v:val')
-        Assert 1
-      catch
-        Assert 0
-      endtry
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.drop_while('v:val').to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      " throws nothing
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      call s.drop_while('v:val')
+
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws s.drop_while('v:val').to_list()
     End
   End
 
@@ -1170,12 +1079,8 @@ Describe Stream
 
   Describe .reduce()
     It raises exception for empty stream
-      try
-        call Stream.empty().reduce('v:val')
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
+      Throws /vital: Stream: \w\+(): stream is empty and default value was not given/
+      \      Stream.empty().reduce('v:val')
     End
 
     It accumulates stream
@@ -1203,17 +1108,10 @@ Describe Stream
 
   Describe .first()
     It raises exception for empty stream
-      try
-        call Stream.empty().first()
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().first(42), 42)
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 0
-      endtry
+      Throws /vital: Stream: \w\+(): stream is empty and default value was not given/
+      \      Stream.empty().first()
+      " throws nothing
+      Assert Equals(Stream.empty().first(42), 42)
     End
 
     It returns the first element in stream
@@ -1224,17 +1122,10 @@ Describe Stream
 
   Describe .last()
     It raises exception for empty stream
-      try
-        call Stream.empty().last()
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().last(42), 42)
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 0
-      endtry
+      Throws /vital: Stream: \w\+(): stream is empty and default value was not given/
+      \      Stream.empty().last()
+      " throws nothing
+      Assert Equals(Stream.empty().last(42), 42)
     End
 
     It returns the last element in stream
@@ -1245,17 +1136,10 @@ Describe Stream
 
   Describe .find()
     It raises exception for empty stream
-      try
-        call Stream.empty().find('v:val')
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().find('v:val', 42), 42)
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 0
-      endtry
+      Throws /vital: Stream: \w\+(): stream is empty and default value was not given/
+      \      Stream.empty().find('v:val')
+      " throws nothing
+      Assert Equals(Stream.empty().find('v:val', 42), 42)
     End
 
     It returns the first element matching with given predicate function in stream
@@ -1391,35 +1275,21 @@ Describe Stream
     End
 
     It converts elements to Dictionary in stream with merge function
-      try
-        call Stream.of(1,2,3,2,1).to_dict('v:val', 'v:val')
-        Assert 0
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
-        Assert 1
-      endtry
-      try
-        Assert Equals(
-          \Stream.of(1,2,3,2,1)
-            \.to_dict('v:val', '[v:val]', 'v:val[0] + v:val[1]'),
-          \{'1': [1,1], '2': [2,2], '3': [3]})
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
-        Assert 0
-      endtry
+      Throws /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
+      \      Stream.of(1,2,3,2,1).to_dict('v:val', 'v:val')
+      " throws nothing
+      Assert Equals(
+        \Stream.of(1,2,3,2,1)
+          \.to_dict('v:val', '[v:val]', 'v:val[0] + v:val[1]'),
+        \{'1': [1,1], '2': [2,2], '3': [3]})
 
-      try
-        call Stream.of('a', 'bb', 'ccc', 'ddd').to_dict('len(v:val)', 'v:val')
-        Assert 0
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 1
-      endtry
-      try
-        Assert Equals(
-          \Stream.of('a', 'bb', 'ccc', 'ddd')
-            \.to_dict('len(v:val)', '[v:val]', 'v:val[0] + v:val[1]'),
-          \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 0
-      endtry
+      Throws /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
+      \      Stream.of('a', 'bb', 'ccc', 'ddd').to_dict('len(v:val)', 'v:val')
+      " throws nothing
+      Assert Equals(
+        \Stream.of('a', 'bb', 'ccc', 'ddd')
+          \.to_dict('len(v:val)', '[v:val]', 'v:val[0] + v:val[1]'),
+        \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
     End
 
     It converts elements to Dictionary in stream by funcref
@@ -1447,35 +1317,21 @@ Describe Stream
         return a:a + a:b
       endfunction
 
-      try
-        call Stream.of(1,2,3,2,1).to_dict(function('Id'), function('Id'))
-        Assert 0
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
-        Assert 1
-      endtry
-      try
-        Assert Equals(
-          \Stream.of(1,2,3,2,1)
-            \.to_dict(function('Id'), function('List'), function('Plus')),
-          \{'1': [1,1], '2': [2,2], '3': [3]})
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
-        Assert 0
-      endtry
+      Throws /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
+      \      Stream.of(1,2,3,2,1).to_dict(function('Id'), function('Id'))
+      " throws nothing
+      Assert Equals(
+        \Stream.of(1,2,3,2,1)
+          \.to_dict(function('Id'), function('List'), function('Plus')),
+        \{'1': [1,1], '2': [2,2], '3': [3]})
 
-      try
-        call Stream.of('a', 'bb', 'ccc', 'ddd').to_dict(function('Len'), function('Id'))
-        Assert 0
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 1
-      endtry
-      try
-        Assert Equals(
-          \Stream.of('a', 'bb', 'ccc', 'ddd')
-            \.to_dict(function('Len'), function('List'), function('Plus')),
-          \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 0
-      endtry
+      Throws /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
+      \      Stream.of('a', 'bb', 'ccc', 'ddd').to_dict(function('Len'), function('Id'))
+      " throws nothing
+      Assert Equals(
+        \Stream.of('a', 'bb', 'ccc', 'ddd')
+          \.to_dict(function('Len'), function('List'), function('Plus')),
+        \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
 
       delfunction Len
       delfunction List
@@ -1509,14 +1365,9 @@ Describe Stream
     End
 
     It must not reuse stream
-      try
-        let s = Stream.of(1,2,3,4,5)
-        call s.to_list()
-        call s.to_list()
-        Assert 0
-      catch
-        Assert 1
-      endtry
+      let s = Stream.of(1,2,3,4,5)
+      call s.to_list()
+      Throws s.to_list()
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -613,6 +613,17 @@ Describe Stream
       unlet g:foreach
     End
 
+    It peeks stream by funcref
+      let g:foreach = []
+      function! Add(v) abort
+        let g:foreach += [a:v]
+      endfunction
+      Assert Equals(Stream.of(1,2,3).foreach(function('Add')), 0)
+      Assert Equals(g:foreach, [1,2,3])
+      unlet g:foreach
+      delfunction Add
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -965,6 +976,17 @@ Describe Stream
       Assert Equals(Stream.empty().reduce('v:val', 42), 42)
       Assert Equals(Stream.of(1,2,3,4,5).reduce('v:val[0] + v:val[1]', 0), 15)
     End
+
+    It reduces stream
+      function! Plus(a, b) abort
+        return a:a + a:b
+      endfunction
+
+      Assert Equals(Stream.empty().reduce(function('Id'), 42), 42)
+      Assert Equals(Stream.of(1,2,3,4,5).reduce(function('Plus'), 0), 15)
+
+      delfunction Plus
+    End
   End
 
   Describe .reduce_present()
@@ -979,6 +1001,16 @@ Describe Stream
 
     It reduces stream
       Assert Equals(Stream.of(1,2,3,4,5).reduce_present('v:val[0] + v:val[1]'), 15)
+    End
+
+    It reduces stream
+      function! Plus(a, b) abort
+        return a:a + a:b
+      endfunction
+
+      Assert Equals(Stream.of(1,2,3,4,5).reduce_present(function('Plus')), 15)
+
+      delfunction Plus
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1276,6 +1276,16 @@ Describe Stream
   End
 
   Describe .sorted()
+    Before all
+      function! Compare(a, b) abort
+        return a:a > a:b ? -1 : a:a ==# a:b ? 0 : 1
+      endfunction
+    End
+
+    After all
+      delfunction Compare
+    End
+
     It sorts elements in stream without comparator
       Assert Equals(Stream.empty().sorted().to_list(), [])
       Assert Equals(Stream.of(2,1,3).sorted().to_list(), [1,2,3])
@@ -1297,18 +1307,12 @@ Describe Stream
     End
 
     It sorts elements in stream with comparator by funcref
-      function! Compare(a, b) abort
-        return a:a > a:b ? -1 : a:a ==# a:b ? 0 : 1
-      endfunction
-
       Assert Equals(Stream.empty().sorted(function('Compare')).to_list(), [])
       Assert Equals(Stream.of(2,1,3).sorted(function('Compare')).to_list(), [3,2,1])
       Assert Equals(Stream.of(2,1,3,2,1).sorted(function('Compare')).to_list(), [3,2,2,1,1])
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').take(3).sorted(function('Compare')).to_list(),
       \ [3,2,1])
-
-      delfunction Compare
     End
 
     It sorts elements in stream with comparator by Data.Closure

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1195,6 +1195,9 @@ Describe Stream
       Assert Equals(Stream.of(3,1,2).distinct().to_list(), [3,1,2])
       Assert Equals(Stream.of(3,3,1,1,2).distinct().to_list(), [3,1,2])
       Assert Equals(Stream.of(3,1,2,1,2).distinct().to_list(), [3,1,2])
+      Assert Equals(
+      \ Stream.iterate(0, '(v:val + 1) % 3').distinct().limit(3).to_list(),
+      \ [0,1,2])
     End
 
     It dedupes elements in stream with stringifier
@@ -1269,12 +1272,6 @@ Describe Stream
       Assert Equals(
         \Stream.of({'value': 3}, {'value': 1}, {'value': 2}, {'value': 1}, {'value': 2}).distinct(value_of).to_list(),
         \[{'value': 3}, {'value': 1}, {'value': 2}])
-    End
-
-    It stops for infinite stream if downstream limited the number elements
-      Assert Equals(
-      \ Stream.iterate(0, '(v:val + 1) % 3').distinct().limit(6).to_list(),
-      \ [0,1,2])
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -3,6 +3,10 @@ Describe Stream
     let Stream = vital#vital#import('Stream')
     let Closure = vital#vital#import('Data.Closure')
 
+    let DISTINCT = 0x02
+    let SORTED = 0x04
+    let SIZED = 0x08
+
     function! Id(n) abort
       return a:n
     endfunction
@@ -21,26 +25,6 @@ Describe Stream
     delfunction Id
     delfunction Succ
     delfunction Answer
-  End
-
-  Describe .has_characteristics()
-    It checks if the stream has certain characteristic
-      let s = Stream.from_list([], Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
-      Assert True(s.has_characteristics(Stream.DISTINCT))
-      Assert True(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
-    End
-
-    It can check multiple flags at once
-      let s = Stream.from_list([], Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
-      Assert Equals(
-      \ s.has_characteristics([
-      \   Stream.DISTINCT,
-      \   Stream.SORTED,
-      \   Stream.SIZED]),
-      \ 1)
-      Assert False(Stream.of(1,2,3).has_characteristics([]))
-    End
   End
 
   Describe .of()
@@ -71,9 +55,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.of(1,2,3)
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -88,14 +72,10 @@ Describe Stream
     End
 
     It constructs stream of each character from String with characteristics
-      let s = Stream.chars("abc", 0)
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert False(s.has_characteristics(Stream.SIZED))
-      let s = Stream.chars("abc", Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
-      Assert True(s.has_characteristics(Stream.DISTINCT))
-      Assert True(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      let s = Stream.chars("abc")
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -123,14 +103,10 @@ Describe Stream
     End
 
     It constructs stream of each line from String with characteristics
-      let s = Stream.lines("abc", 0)
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert False(s.has_characteristics(Stream.SIZED))
-      let s = Stream.lines("abc", Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
-      Assert True(s.has_characteristics(Stream.DISTINCT))
-      Assert True(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      let s = Stream.lines("abc")
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -146,20 +122,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_list([1,2,3])
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
-    End
-
-    It constructs stream from List with characteristics
-      let s = Stream.from_list([1,2,3], 0)
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert False(s.has_characteristics(Stream.SIZED))
-      let s = Stream.from_list([1,2,3], Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
-      Assert True(s.has_characteristics(Stream.DISTINCT))
-      Assert True(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -189,20 +154,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_dict({"foo": 1, "bar": 3, "baz": 2})
-      Assert True(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
-    End
-
-    It constructs stream from Dictionary with characteristics
-      let s = Stream.from_list({"foo": 1}, 0)
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert False(s.has_characteristics(Stream.SIZED))
-      let s = Stream.from_list({"foo": 1}, Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
-      Assert True(s.has_characteristics(Stream.DISTINCT))
-      Assert True(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -214,9 +168,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.empty()
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -298,9 +252,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.range(1,10)
-      Assert True(s.has_characteristics(Stream.DISTINCT))
-      Assert True(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.__has_characteristic__(DISTINCT))
+      Assert True(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -334,9 +288,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert False(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert False(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -435,13 +389,13 @@ Describe Stream
     It combines stream from String with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3))
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
 
     It combines stream with 3 or more than streams
@@ -482,13 +436,13 @@ Describe Stream
     It combines stream with 3 or more than streams with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 
@@ -610,13 +564,13 @@ Describe Stream
 
     It sets SIZED characteristic
       let s = Stream.of(3,4,5,6,7).take(3)
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
       let s = Stream.iterate(1, 'v:val + 1').take(3)
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert False(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert False(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
 
     It must not reuse stream
@@ -1195,11 +1149,21 @@ Describe Stream
       Assert Equals(
         \Stream.of({'value': 3}, {'value': 1}, {'value': 2}, {'value': 1}, {'value': 2}).distinct('v:val.value').to_list(),
         \[{'value': 3}, {'value': 1}, {'value': 2}])
+
+      Assert Equals(
+        \Stream.range(1, 3).distinct('string(v:val)').to_list(),
+        \[1,2,3])
+      Assert Equals(
+        \Stream.range(1, 1/0).take(100).distinct('v:val % 5').to_list(),
+        \[1,2,3,4,5])
     End
 
     It dedupes elements in stream with stringifier by funcref
       function! ValueOf(v) abort
         return a:v.value
+      endfunction
+      function! Mod5(v) abort
+        return a:v % 5
       endfunction
 
       Assert Equals(Stream.empty().distinct(function('ValueOf')).to_list(), [])
@@ -1222,7 +1186,15 @@ Describe Stream
         \Stream.of({'value': 3}, {'value': 1}, {'value': 2}, {'value': 1}, {'value': 2}).distinct(function('ValueOf')).to_list(),
         \[{'value': 3}, {'value': 1}, {'value': 2}])
 
+      Assert Equals(
+        \Stream.range(1, 3).distinct(function('string')).to_list(),
+        \[1,2,3])
+      Assert Equals(
+        \Stream.range(1, 1/0).take(100).distinct(function('Mod5')).to_list(),
+        \[1,2,3,4,5])
+
       delfunction ValueOf
+      delfunction Mod5
     End
 
     It dedupes elements in stream with stringifier by Data.Closure
@@ -1247,18 +1219,25 @@ Describe Stream
       Assert Equals(
         \Stream.of({'value': 3}, {'value': 1}, {'value': 2}, {'value': 1}, {'value': 2}).distinct(value_of).to_list(),
         \[{'value': 3}, {'value': 1}, {'value': 2}])
+
+      Assert Equals(
+        \Stream.range(1, 3).distinct(Closure.from_funcname('string')).to_list(),
+        \[1,2,3])
+      Assert Equals(
+        \Stream.range(1, 1/0).take(100).distinct(Closure.from_expr('a:1 % 5')).to_list(),
+        \[1,2,3,4,5])
     End
   End
 
   Describe .sorted()
     Before all
-      function! Comp(a, b) abort
+      function! ByDesc(a, b) abort
         return a:a > a:b ? -1 : a:a ==# a:b ? 0 : 1
       endfunction
     End
 
     After all
-      delfunction Comp
+      delfunction ByDesc
     End
 
     It sorts elements in stream without comparator
@@ -1279,14 +1258,22 @@ Describe Stream
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').take(3).sorted(by_desc).to_list(),
       \ [3,2,1])
+
+      Assert Equals(
+      \ Stream.range(1, 3).sorted(by_desc).to_list(),
+      \ [3,2,1])
     End
 
     It sorts elements in stream with comparator by funcref
-      Assert Equals(Stream.empty().sorted(function('Comp')).to_list(), [])
-      Assert Equals(Stream.of(2,1,3).sorted(function('Comp')).to_list(), [3,2,1])
-      Assert Equals(Stream.of(2,1,3,2,1).sorted(function('Comp')).to_list(), [3,2,2,1,1])
+      Assert Equals(Stream.empty().sorted(function('ByDesc')).to_list(), [])
+      Assert Equals(Stream.of(2,1,3).sorted(function('ByDesc')).to_list(), [3,2,1])
+      Assert Equals(Stream.of(2,1,3,2,1).sorted(function('ByDesc')).to_list(), [3,2,2,1,1])
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(function('Comp')).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(function('ByDesc')).to_list(),
+      \ [3,2,1])
+
+      Assert Equals(
+      \ Stream.range(1, 3).sorted(function('ByDesc')).to_list(),
       \ [3,2,1])
     End
 
@@ -1298,13 +1285,17 @@ Describe Stream
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').take(3).sorted(by_desc).to_list(),
       \ [3,2,1])
+
+      Assert Equals(
+      \ Stream.range(1, 3).sorted(by_desc).to_list(),
+      \ [3,2,1])
     End
 
     It sets SORTED characteristic
       let s = Stream.of(1,2,3).sorted()
-      Assert False(s.has_characteristics(Stream.DISTINCT))
-      Assert True(s.has_characteristics(Stream.SORTED))
-      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert False(s.__has_characteristic__(DISTINCT))
+      Assert True(s.__has_characteristic__(SORTED))
+      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1,6 +1,25 @@
 Describe Stream
   Before all
     let Stream = vital#vital#new().import('Stream')
+
+    function! Id(n) abort
+      return a:n
+    endfunction
+    function! Succ(n) abort
+      return a:n + 1
+    endfunction
+    function! IsEven(n) abort
+      return a:n % 2 == 0
+    endfunction
+    function! Answer() abort
+      return 42
+    endfunction
+  End
+
+  After all
+    delfunction Id
+    delfunction Succ
+    delfunction Answer
   End
 
   Describe .has_characteristics()
@@ -247,6 +266,15 @@ Describe Stream
       \   [5,6,7])
     End
 
+    It constructs infinite stream by funcref
+      Assert Equals(
+      \   Stream.iterate(1, function('Id')).limit(3).to_list(),
+      \   [1,1,1])
+      Assert Equals(
+      \   Stream.iterate(5, function('Succ')).limit(3).to_list(),
+      \   [5,6,7])
+    End
+
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
       Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
@@ -262,6 +290,12 @@ Describe Stream
     It constructs infinite stream with function
       Assert Equals(
       \ Stream.generate('42').limit(5).to_list(),
+      \ [42, 42, 42, 42, 42])
+    End
+
+    It constructs infinite stream with function
+      Assert Equals(
+      \ Stream.generate(function('Answer')).limit(5).to_list(),
       \ [42, 42, 42, 42, 42])
     End
   End
@@ -539,6 +573,17 @@ Describe Stream
       unlet g:peek
     End
 
+    It peeks stream by funcref
+      let g:peek = []
+      function! Add(v) abort
+        let g:peek += [a:v]
+      endfunction
+      Assert Equals(Stream.of(1,2,3).peek(function('Add')).to_list(), [1,2,3])
+      Assert Equals(g:peek, [1,2,3])
+      unlet g:peek
+      delfunction Add
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -590,9 +635,29 @@ Describe Stream
 
   Describe .map()
     It maps stream
+      Assert Equals(Stream.empty().map('v:val + 1').to_list(), [])
+
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').map('v:val + 1').limit(3).to_list(),
       \ [2,3,4])
+    End
+
+    It maps stream by funcref
+      Assert Equals(Stream.empty().map(function('Succ')).to_list(), [])
+
+      Assert Equals(
+      \ Stream.iterate(1, 'v:val + 1').map(function('Succ')).limit(3).to_list(),
+      \ [2,3,4])
+    End
+
+    It maps stream by funcref
+      function! F(n) abort
+        return a:n + 1
+      endfunction
+      Assert Equals(
+      \ Stream.iterate(1, 'v:val + 1').map(function('F')).limit(3).to_list(),
+      \ [2,3,4])
+      delfunction F
     End
 
     It must not reuse stream
@@ -651,6 +716,21 @@ Describe Stream
         \[0, 4, 8])
     End
 
+    It flattens mapped stream by funcref
+      function! Repeat(n) abort
+        return repeat([a:n], a:n)
+      endfunction
+
+      Assert Equals(Stream.empty().flatmap(function('Repeat')).to_list(), [])
+
+      Assert Equals(
+        \Stream.iterate(0, function('Succ'))
+          \.flatmap(function('Repeat')).limit(6).to_list(),
+        \[1,2,2,3,3,3])
+
+      delfunction Repeat
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -674,8 +754,18 @@ Describe Stream
 
   Describe .filter()
     It filters stream
+      Assert Equals(Stream.empty().filter('v:val % 2 == 0').to_list(), [])
+
       Assert Equals(
       \ Stream.iterate(0, 'v:val + 1').filter('v:val % 2 == 0').limit(3).to_list(),
+      \ [0,2,4])
+    End
+
+    It filters stream by funcref
+      Assert Equals(Stream.empty().filter(function('IsEven')).to_list(), [])
+
+      Assert Equals(
+      \ Stream.iterate(0, 'v:val + 1').filter(function('IsEven')).limit(3).to_list(),
       \ [0,2,4])
     End
 
@@ -714,6 +804,25 @@ Describe Stream
       \ [1,2,3])
     End
 
+    It takes elements until element is matched by funcref
+      function! LessThan4(n) abort
+        return a:n < 4
+      endfunction
+
+      Assert Equals(Stream.empty().take_while(function('Id')).to_list(), [])
+      Assert Equals(
+      \ Stream.range(1, 10).take_while(function('LessThan4')).to_list(),
+      \ [1,2,3])
+      Assert Equals(
+      \ Stream.range(1, 10).take_while(function('LessThan4')).limit(2).to_list(),
+      \ [1,2])
+      Assert Equals(
+      \ Stream.iterate(1, function('Succ')).take_while(function('LessThan4')).to_list(),
+      \ [1,2,3])
+
+      delfunction LessThan4
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -746,6 +855,24 @@ Describe Stream
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').drop_while('v:val < 4').limit(2).to_list(),
       \ [4,5])
+    End
+
+    It drops elements until element is matched by funcref
+      function! LessThan4(n) abort
+        return a:n < 4
+      endfunction
+
+      Assert Equals(
+      \ Stream.empty().drop_while(function('Id')).to_list(),
+      \ [])
+      Assert Equals(
+      \ Stream.of(1,2,3,4,5).drop_while(function('LessThan4')).to_list(),
+      \ [4,5])
+      Assert Equals(
+      \ Stream.iterate(1, function('Succ')).drop_while(function('LessThan4')).limit(2).to_list(),
+      \ [4,5])
+
+      delfunction LessThan4
     End
 
     It must not reuse stream
@@ -806,6 +933,21 @@ Describe Stream
       \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(by_desc).to_list(),
       \ [3,2,1])
       unlet by_desc
+    End
+
+    It sorts elements by function in stream
+      function! ByDesc(a, b) abort
+        return a:a > a:b ? -1 : a:a ==# a:b ? 0 : 1
+      endfunction
+
+      Assert Equals(Stream.of().sorted(function('ByDesc')).to_list(), [])
+      Assert Equals(Stream.of(2,1,3).sorted(function('ByDesc')).to_list(), [3,2,1])
+      Assert Equals(Stream.of(2,1,3,2,1).sorted(function('ByDesc')).to_list(), [3,2,2,1,1])
+      Assert Equals(
+      \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(function('ByDesc')).to_list(),
+      \ [3,2,1])
+
+      delfunction ByDesc
     End
 
     It sets SORTED characteristic
@@ -875,8 +1017,18 @@ Describe Stream
       endtry
     End
 
-    It returns max value by function in stream
+    It returns max value in stream by string expression
       Assert Equals(Stream.of('aaa', 'bb', '').max_by('len(v:val)'), 'aaa')
+    End
+
+    It returns max value in stream by funcref
+      function! Len(v) abort
+        return len(a:v)
+      endfunction
+
+      Assert Equals(Stream.of('aaa', 'bb', '').max_by(function('Len')), 'aaa')
+
+      delfunction Len
     End
   End
 
@@ -915,8 +1067,18 @@ Describe Stream
       endtry
     End
 
-    It returns min value by function in stream
+    It returns min value in stream by string expression
       Assert Equals(Stream.of('aaa', 'bb', '').min_by('len(v:val)'), '')
+    End
+
+    It returns min value in stream by funcref
+      function! Len(v) abort
+        return len(a:v)
+      endfunction
+
+      Assert Equals(Stream.of('aaa', 'bb', '').min_by(function('Len')), '')
+
+      delfunction Len
     End
   End
 
@@ -959,6 +1121,10 @@ Describe Stream
     It returns the first element matching with given predicate function in stream
       Assert Equals(Stream.iterate(1, 'v:val + 1').find('v:val % 2 == 0'), 2)
     End
+
+    It returns the first element matching with given predicate function in stream by funcref
+      Assert Equals(Stream.iterate(1, 'v:val + 1').find(function('IsEven')), 2)
+    End
   End
 
   Describe .any_match()
@@ -966,6 +1132,22 @@ Describe Stream
       Assert Equals(Stream.empty().any_match('v:val'), 0)
       Assert Equals(Stream.of(1,2,3).any_match('v:val > 2'), 1)
       Assert Equals(Stream.of(1,2,3).any_match('v:val > 3'), 0)
+    End
+
+    It returns boolean value if any elements are matched in stream by funcref
+      function! GreaterThan2(n) abort
+        return a:n > 2
+      endfunction
+      function! GreaterThan3(n) abort
+        return a:n > 3
+      endfunction
+
+      Assert Equals(Stream.empty().any_match(function('Id')), 0)
+      Assert Equals(Stream.of(1,2,3).any_match(function('GreaterThan2')), 1)
+      Assert Equals(Stream.of(1,2,3).any_match(function('GreaterThan3')), 0)
+
+      delfunction GreaterThan2
+      delfunction GreaterThan3
     End
   End
 
@@ -975,6 +1157,22 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3).all_match('v:val > 0'), 1)
       Assert Equals(Stream.of(1,2,3).all_match('v:val > 1'), 0)
     End
+
+    It returns boolean value if all elements are matched in stream by funcref
+      function! GreaterThan0(n) abort
+        return a:n > 0
+      endfunction
+      function! GreaterThan1(n) abort
+        return a:n > 1
+      endfunction
+
+      Assert Equals(Stream.empty().all_match(function('Id')), 1)
+      Assert Equals(Stream.of(1,2,3).all_match(function('GreaterThan0')), 1)
+      Assert Equals(Stream.of(1,2,3).all_match(function('GreaterThan1')), 0)
+
+      delfunction GreaterThan0
+      delfunction GreaterThan1
+    End
   End
 
   Describe .none_match()
@@ -982,6 +1180,22 @@ Describe Stream
       Assert Equals(Stream.empty().none_match('v:val'), 1)
       Assert Equals(Stream.of(1,2,3).none_match('v:val > 3'), 1)
       Assert Equals(Stream.of(1,2,3).none_match('v:val > 2'), 0)
+    End
+
+    It returns boolean value if none elements are matched in stream by funcref
+      function! GreaterThan3(n) abort
+        return a:n > 3
+      endfunction
+      function! GreaterThan2(n) abort
+        return a:n > 2
+      endfunction
+
+      Assert Equals(Stream.empty().none_match(function('Id')), 1)
+      Assert Equals(Stream.of(1,2,3).none_match(function('GreaterThan3')), 1)
+      Assert Equals(Stream.of(1,2,3).none_match(function('GreaterThan2')), 0)
+
+      delfunction GreaterThan3
+      delfunction GreaterThan2
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -517,34 +517,64 @@ Describe Stream
     End
   End
 
-  " Describe .peek()
-  "   It peeks stream
-  "     let g:peek = []
-  "     call Stream.of(1,2,3).peek('let g:peek += [<VAL>]').to_list()
-  "     Assert Equals(g:peek, [1,2,3])
-  "     unlet g:peek
-  "   End
-  "
-  "   It must not reuse stream
-  "     try
-  "       let s = Stream.of(1,2,3,4,5)
-  "       call s.to_list()
-  "       call s.peek('echo')
-  "       Assert 1
-  "     catch
-  "       Assert 0
-  "     endtry
-  "     try
-  "       let s = Stream.of(1,2,3,4,5)
-  "       call s.to_list()
-  "       call s.peek('echo').to_list()
-  "       Assert 0
-  "     catch
-  "       Assert 1
-  "     endtry
-  "     unlet s
-  "   End
-  " End
+  Describe .peek()
+    It peeks stream
+      Skip "not implemented yet"
+      let g:peek = []
+      Assert Equals(Stream.of(1,2,3).peek('add(g:peek, v:val)').to_list(), [1,2,3])
+      Assert Equals(g:peek, [1,2,3])
+      unlet g:peek
+    End
+
+    It must not reuse stream
+      Skip "not implemented yet"
+      try
+        let s = Stream.of(1,2,3,4,5)
+        call s.to_list()
+        call s.peek('v:val')
+        Assert 1
+      catch
+        Assert 0
+      endtry
+      try
+        let s = Stream.of(1,2,3,4,5)
+        call s.to_list()
+        call s.peek('v:val').to_list()
+        Assert 0
+      catch
+        Assert 1
+      endtry
+      unlet s
+    End
+  End
+
+  Describe .foreach()
+    It iterates elements in stream
+      let g:foreach = []
+      Assert Equals(Stream.of(1,2,3).foreach('add(g:foreach, v:val)'), 0)
+      Assert Equals(g:foreach, [1,2,3])
+      unlet g:foreach
+    End
+
+    It must not reuse stream
+      try
+        let s = Stream.of(1,2,3,4,5)
+        call s.foreach('v:val')
+        Assert 1
+      catch
+        Assert 0
+      endtry
+      try
+        let s = Stream.of(1,2,3,4,5)
+        call s.foreach('v:val')
+        call s.foreach('v:val')
+        Assert 0
+      catch
+        Assert 1
+      endtry
+      unlet s
+    End
+  End
 
   Describe .map()
     It maps stream

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1069,8 +1069,18 @@ Describe Stream
   End
 
   Describe .reduce()
+    It raises exception for empty stream
+      try
+        call Stream.empty().reduce('v:val')
+        Assert 0
+      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
+        Assert 1
+      endtry
+    End
+
     It reduces stream
       Assert Equals(Stream.empty().reduce('v:val', 42), 42)
+      Assert Equals(Stream.of(1,2,3,4,5).reduce('v:val[0] + v:val[1]'), 15)
       Assert Equals(Stream.of(1,2,3,4,5).reduce('v:val[0] + v:val[1]', 0), 15)
     End
 
@@ -1080,6 +1090,7 @@ Describe Stream
       endfunction
 
       Assert Equals(Stream.empty().reduce(function('Id'), 42), 42)
+      Assert Equals(Stream.of(1,2,3,4,5).reduce(function('Plus')), 15)
       Assert Equals(Stream.of(1,2,3,4,5).reduce(function('Plus'), 0), 15)
 
       delfunction Plus
@@ -1087,36 +1098,8 @@ Describe Stream
 
     It reduces stream by Data.Closure
       Assert Equals(Stream.empty().reduce(Closure.from_expr('a:1'), 42), 42)
+      Assert Equals(Stream.of(1,2,3,4,5).reduce(Closure.from_operator('+')), 15)
       Assert Equals(Stream.of(1,2,3,4,5).reduce(Closure.from_operator('+'), 0), 15)
-    End
-  End
-
-  Describe .reduce_present()
-    It raises exception for empty stream
-      try
-        call Stream.empty().reduce_present('v:val')
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
-    End
-
-    It reduces stream
-      Assert Equals(Stream.of(1,2,3,4,5).reduce_present('v:val[0] + v:val[1]'), 15)
-    End
-
-    It reduces stream by funcref
-      function! Plus(a, b) abort
-        return a:a + a:b
-      endfunction
-
-      Assert Equals(Stream.of(1,2,3,4,5).reduce_present(function('Plus')), 15)
-
-      delfunction Plus
-    End
-
-    It reduces stream by Data.Closure
-      Assert Equals(Stream.of(1,2,3,4,5).reduce_present(Closure.from_operator('+')), 15)
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -310,12 +310,12 @@ Describe Stream
       \   [0,3,6])
     End
 
-    It constructs limited range when .limit() was specified
+    It constructs limited range when .take() was specified
       Assert Equals(
-      \   Stream.range(1, 1/0).limit(5).to_list(),
+      \   Stream.range(1, 1/0).take(5).to_list(),
       \   [1,2,3,4,5])
       Assert Equals(
-      \   Stream.range(5, 1/0).limit(5).to_list(),
+      \   Stream.range(5, 1/0).take(5).to_list(),
       \   [5,6,7,8,9])
     End
 
@@ -332,28 +332,28 @@ Describe Stream
   Describe .iterate()
     It constructs infinite stream with initial value and function
       Assert Equals(
-      \   Stream.iterate(1, 'v:val').limit(3).to_list(),
+      \   Stream.iterate(1, 'v:val').take(3).to_list(),
       \   [1,1,1])
       Assert Equals(
-      \   Stream.iterate(5, 'v:val + 1').limit(3).to_list(),
+      \   Stream.iterate(5, 'v:val + 1').take(3).to_list(),
       \   [5,6,7])
     End
 
     It constructs infinite stream by funcref
       Assert Equals(
-      \   Stream.iterate(1, function('Id')).limit(3).to_list(),
+      \   Stream.iterate(1, function('Id')).take(3).to_list(),
       \   [1,1,1])
       Assert Equals(
-      \   Stream.iterate(5, function('Succ')).limit(3).to_list(),
+      \   Stream.iterate(5, function('Succ')).take(3).to_list(),
       \   [5,6,7])
     End
 
     It constructs infinite stream by Data.Closure
       Assert Equals(
-      \   Stream.iterate(1, Closure.from_expr('a:1')).limit(3).to_list(),
+      \   Stream.iterate(1, Closure.from_expr('a:1')).take(3).to_list(),
       \   [1,1,1])
       Assert Equals(
-      \   Stream.iterate(5, Closure.from_expr('a:1 + 1')).limit(3).to_list(),
+      \   Stream.iterate(5, Closure.from_expr('a:1 + 1')).take(3).to_list(),
       \   [5,6,7])
     End
 
@@ -370,19 +370,19 @@ Describe Stream
   Describe .generate()
     It constructs infinite stream
       Assert Equals(
-      \ Stream.generate('42').limit(5).to_list(),
+      \ Stream.generate('42').take(5).to_list(),
       \ [42, 42, 42, 42, 42])
     End
 
     It constructs infinite stream by funcref
       Assert Equals(
-      \ Stream.generate(function('Answer')).limit(5).to_list(),
+      \ Stream.generate(function('Answer')).take(5).to_list(),
       \ [42, 42, 42, 42, 42])
     End
 
     It constructs infinite stream by Data.Closure
       Assert Equals(
-      \ Stream.generate(Closure.from_expr('42')).limit(5).to_list(),
+      \ Stream.generate(Closure.from_expr('42')).take(5).to_list(),
       \ [42, 42, 42, 42, 42])
     End
   End
@@ -449,7 +449,7 @@ Describe Stream
         \Stream.zip(
           \Stream.iterate(1, 'v:val + 1'),
           \Stream.iterate(-1, 'v:val - 1'))
-        \.limit(5).to_list(),
+        \.take(5).to_list(),
         \[[1,-1], [2,-2], [3,-3], [4,-4], [5,-5]])
     End
 
@@ -566,14 +566,14 @@ Describe Stream
         \Stream.concat(
           \Stream.iterate(1, 'v:val + 1'),
           \Stream.of('this stream cannot be merged...'))
-        \.limit(5).to_list(),
+        \.take(5).to_list(),
         \[1,2,3,4,5])
 
       Assert Equals(
         \Stream.concat(
           \Stream.of(1,2,3),
           \Stream.iterate(4, 'v:val + 1'))
-        \.limit(5).to_list(),
+        \.take(5).to_list(),
         \[1,2,3,4,5])
     End
 
@@ -613,37 +613,37 @@ Describe Stream
     End
   End
 
-  Describe .limit()
+  Describe .take()
     It raises negative number argument
       try
-        call Stream.of(1,2,3,4,5).limit(-1)
+        call Stream.of(1,2,3,4,5).take(-1)
         Assert 0
-      catch /vital: Stream: limit(n): n must be 0 or positive/
+      catch /vital: Stream: take(n): n must be 0 or positive/
         Assert 1
       endtry
       try
-        call Stream.of(1,2,3,4,5).limit(0)
+        call Stream.of(1,2,3,4,5).take(0)
         Assert 1
-      catch /vital: Stream: limit(n): n must be 0 or positive/
+      catch /vital: Stream: take(n): n must be 0 or positive/
         Assert 0
       endtry
     End
 
     It limits stream
-      Assert Equals(Stream.of(1,2,3,4,5).limit(0).to_list(), [])
-      Assert Equals(Stream.of(1,2,3,4,5).limit(3).to_list(), [1,2,3])
-      Assert Equals(Stream.of(3,4,5,6,7).limit(3).to_list(), [3,4,5])
-      Assert Equals(Stream.iterate(1, 'v:val + 1').limit(3).to_list(), [1,2,3])
+      Assert Equals(Stream.of(1,2,3,4,5).take(0).to_list(), [])
+      Assert Equals(Stream.of(1,2,3,4,5).take(3).to_list(), [1,2,3])
+      Assert Equals(Stream.of(3,4,5,6,7).take(3).to_list(), [3,4,5])
+      Assert Equals(Stream.iterate(1, 'v:val + 1').take(3).to_list(), [1,2,3])
     End
 
     It sets SIZED characteristic
-      let s = Stream.of(3,4,5,6,7).limit(3)
+      let s = Stream.of(3,4,5,6,7).take(3)
       Assert True(s.has_characteristics(Stream.ORDERED()))
       Assert False(s.has_characteristics(Stream.DISTINCT()))
       Assert False(s.has_characteristics(Stream.SORTED()))
       Assert True(s.has_characteristics(Stream.SIZED()))
       Assert True(s.has_characteristics(Stream.IMMUTABLE()))
-      let s = Stream.iterate(1, 'v:val + 1').limit(3)
+      let s = Stream.iterate(1, 'v:val + 1').take(3)
       Assert True(s.has_characteristics(Stream.ORDERED()))
       Assert False(s.has_characteristics(Stream.DISTINCT()))
       Assert False(s.has_characteristics(Stream.SORTED()))
@@ -655,7 +655,7 @@ Describe Stream
       try
         let s = Stream.of(1,2,3,4,5)
         call s.to_list()
-        call s.limit(3)
+        call s.take(3)
         Assert 1
       catch
         Assert 0
@@ -663,7 +663,7 @@ Describe Stream
       try
         let s = Stream.of(1,2,3,4,5)
         call s.to_list()
-        call s.limit(3).to_list()
+        call s.take(3).to_list()
         Assert 0
       catch
         Assert 1
@@ -671,34 +671,34 @@ Describe Stream
     End
   End
 
-  Describe .skip()
+  Describe .drop()
     It raises negative number argument
       try
-        call Stream.of(1,2,3,4,5).skip(-1)
+        call Stream.of(1,2,3,4,5).drop(-1)
         Assert 0
-      catch /vital: Stream: skip(n): n must be 0 or positive/
+      catch /vital: Stream: drop(n): n must be 0 or positive/
         Assert 1
       endtry
       try
-        call Stream.of(1,2,3,4,5).skip(0)
+        call Stream.of(1,2,3,4,5).drop(0)
         Assert 1
-      catch /vital: Stream: skip(n): n must be 0 or positive/
+      catch /vital: Stream: drop(n): n must be 0 or positive/
         Assert 0
       endtry
     End
 
     It limits stream
-      Assert Equals(Stream.of(1,2,3,4,5).skip(0).to_list(), [1,2,3,4,5])
-      Assert Equals(Stream.of(1,2,3,4,5).skip(3).to_list(), [4,5])
-      Assert Equals(Stream.of(3,4,5,6,7).skip(3).to_list(), [6,7])
-      Assert Equals(Stream.iterate(1, 'v:val + 1').skip(3).limit(3).to_list(), [4,5,6])
+      Assert Equals(Stream.of(1,2,3,4,5).drop(0).to_list(), [1,2,3,4,5])
+      Assert Equals(Stream.of(1,2,3,4,5).drop(3).to_list(), [4,5])
+      Assert Equals(Stream.of(3,4,5,6,7).drop(3).to_list(), [6,7])
+      Assert Equals(Stream.iterate(1, 'v:val + 1').drop(3).take(3).to_list(), [4,5,6])
     End
 
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
         call s.to_list()
-        call s.skip(3)
+        call s.drop(3)
         Assert 1
       catch
         Assert 0
@@ -706,7 +706,7 @@ Describe Stream
       try
         let s = Stream.of(1,2,3,4,5)
         call s.to_list()
-        call s.skip(3).to_list()
+        call s.drop(3).to_list()
         Assert 0
       catch
         Assert 1
@@ -817,7 +817,7 @@ Describe Stream
       Assert Equals(Stream.empty().map('v:val + 1').to_list(), [])
 
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').map('v:val + 1').limit(3).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').map('v:val + 1').take(3).to_list(),
       \ [2,3,4])
     End
 
@@ -825,7 +825,7 @@ Describe Stream
       Assert Equals(Stream.empty().map(function('Succ')).to_list(), [])
 
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').map(function('Succ')).limit(3).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').map(function('Succ')).take(3).to_list(),
       \ [2,3,4])
     End
 
@@ -833,7 +833,7 @@ Describe Stream
       Assert Equals(Stream.empty().map(Closure.from_expr('a:1 + 1')).to_list(), [])
 
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').map(Closure.from_expr('a:1 + 1')).limit(3).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').map(Closure.from_expr('a:1 + 1')).take(3).to_list(),
       \ [2,3,4])
     End
 
@@ -863,7 +863,7 @@ Describe Stream
 
       Assert Equals(
         \Stream.iterate(0, 'v:val + 1')
-          \.flatmap('repeat([v:val], v:val)').limit(6).to_list(),
+          \.flatmap('repeat([v:val], v:val)').take(6).to_list(),
         \[1,2,2,3,3,3])
 
       Assert Equals(
@@ -873,22 +873,22 @@ Describe Stream
 
       Assert Equals(
         \Stream.of(1,2,3)
-          \.flatmap('repeat([v:val], v:val)').limit(6).to_list(),
+          \.flatmap('repeat([v:val], v:val)').take(6).to_list(),
         \[1,2,2,3,3,3])
 
       Assert Equals(
         \Stream.of(1,2,3,4,5)
-          \.flatmap('repeat([v:val], v:val)').limit(6).to_list(),
+          \.flatmap('repeat([v:val], v:val)').take(6).to_list(),
         \[1,2,2,3,3,3])
 
       Assert Equals(
         \Stream.of(0,1,2,3,4,5)
-          \.flatmap('v:val % 2 == 0 ? [v:val * 2] : []').limit(3).to_list(),
+          \.flatmap('v:val % 2 == 0 ? [v:val * 2] : []').take(3).to_list(),
         \[0, 4, 8])
 
       Assert Equals(
         \Stream.iterate(0, 'v:val + 1')
-          \.flatmap('v:val % 2 == 0 ? [v:val * 2] : []').limit(3).to_list(),
+          \.flatmap('v:val % 2 == 0 ? [v:val * 2] : []').take(3).to_list(),
         \[0, 4, 8])
     End
 
@@ -901,7 +901,7 @@ Describe Stream
 
       Assert Equals(
         \Stream.iterate(0, function('Succ'))
-          \.flatmap(function('Repeat')).limit(6).to_list(),
+          \.flatmap(function('Repeat')).take(6).to_list(),
         \[1,2,2,3,3,3])
 
       delfunction Repeat
@@ -912,7 +912,7 @@ Describe Stream
 
       Assert Equals(
         \Stream.iterate(0, Closure.from_expr('a:1 + 1'))
-          \.flatmap(Closure.from_expr('repeat([a:1], a:1)')).limit(6).to_list(),
+          \.flatmap(Closure.from_expr('repeat([a:1], a:1)')).take(6).to_list(),
         \[1,2,2,3,3,3])
     End
 
@@ -980,15 +980,15 @@ Describe Stream
 
       " inifinite stream
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').slice_before(is_even).limit(3).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').slice_before(is_even).take(3).to_list(),
       \ [[1], [2,3], [4,5]])
 
       Assert Equals(
-      \ Stream.iterate(0, 'v:val + 1').slice_before(is_even).limit(3).to_list(),
+      \ Stream.iterate(0, 'v:val + 1').slice_before(is_even).take(3).to_list(),
       \ [[0,1], [2,3], [4,5]])
 
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').slice_before(is_even).limit(3).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').slice_before(is_even).take(3).to_list(),
       \ [[1], [2,3], [4,5]])
     End
 
@@ -1017,7 +1017,7 @@ Describe Stream
       Assert Equals(Stream.empty().filter('v:val % 2 == 0').to_list(), [])
 
       Assert Equals(
-      \ Stream.iterate(0, 'v:val + 1').filter('v:val % 2 == 0').limit(3).to_list(),
+      \ Stream.iterate(0, 'v:val + 1').filter('v:val % 2 == 0').take(3).to_list(),
       \ [0,2,4])
     End
 
@@ -1025,7 +1025,7 @@ Describe Stream
       Assert Equals(Stream.empty().filter(function('IsEven')).to_list(), [])
 
       Assert Equals(
-      \ Stream.iterate(0, 'v:val + 1').filter(function('IsEven')).limit(3).to_list(),
+      \ Stream.iterate(0, 'v:val + 1').filter(function('IsEven')).take(3).to_list(),
       \ [0,2,4])
     End
 
@@ -1033,7 +1033,7 @@ Describe Stream
       Assert Equals(Stream.empty().filter(Closure.from_expr('a:1 % 2 == 0')).to_list(), [])
 
       Assert Equals(
-      \ Stream.iterate(0, 'v:val + 1').filter(Closure.from_expr('a:1 % 2 == 0')).limit(3).to_list(),
+      \ Stream.iterate(0, 'v:val + 1').filter(Closure.from_expr('a:1 % 2 == 0')).take(3).to_list(),
       \ [0,2,4])
     End
 
@@ -1064,7 +1064,7 @@ Describe Stream
       \ Stream.range(1, 10).take_while('v:val < 4').to_list(),
       \ [1,2,3])
       Assert Equals(
-      \ Stream.range(1, 10).take_while('v:val < 4').limit(2).to_list(),
+      \ Stream.range(1, 10).take_while('v:val < 4').take(2).to_list(),
       \ [1,2])
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').take_while('v:val < 4').to_list(),
@@ -1081,7 +1081,7 @@ Describe Stream
       \ Stream.range(1, 10).take_while(function('LessThan4')).to_list(),
       \ [1,2,3])
       Assert Equals(
-      \ Stream.range(1, 10).take_while(function('LessThan4')).limit(2).to_list(),
+      \ Stream.range(1, 10).take_while(function('LessThan4')).take(2).to_list(),
       \ [1,2])
       Assert Equals(
       \ Stream.iterate(1, function('Succ')).take_while(function('LessThan4')).to_list(),
@@ -1096,7 +1096,7 @@ Describe Stream
       \ Stream.range(1, 10).take_while(Closure.from_expr('a:1 < 4')).to_list(),
       \ [1,2,3])
       Assert Equals(
-      \ Stream.range(1, 10).take_while(Closure.from_expr('a:1 < 4')).limit(2).to_list(),
+      \ Stream.range(1, 10).take_while(Closure.from_expr('a:1 < 4')).take(2).to_list(),
       \ [1,2])
       Assert Equals(
       \ Stream.iterate(1, Closure.from_expr('a:1 + 1')).take_while(Closure.from_expr('a:1 < 4')).to_list(),
@@ -1132,7 +1132,7 @@ Describe Stream
       \ Stream.of(1,2,3,4,5).drop_while('v:val < 4').to_list(),
       \ [4,5])
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').drop_while('v:val < 4').limit(2).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').drop_while('v:val < 4').take(2).to_list(),
       \ [4,5])
     End
 
@@ -1148,7 +1148,7 @@ Describe Stream
       \ Stream.of(1,2,3,4,5).drop_while(function('LessThan4')).to_list(),
       \ [4,5])
       Assert Equals(
-      \ Stream.iterate(1, function('Succ')).drop_while(function('LessThan4')).limit(2).to_list(),
+      \ Stream.iterate(1, function('Succ')).drop_while(function('LessThan4')).take(2).to_list(),
       \ [4,5])
 
       delfunction LessThan4
@@ -1162,7 +1162,7 @@ Describe Stream
       \ Stream.of(1,2,3,4,5).drop_while(Closure.from_expr('a:1 < 4')).to_list(),
       \ [4,5])
       Assert Equals(
-      \ Stream.iterate(1, Closure.from_expr('a:1 + 1')).drop_while(Closure.from_expr('a:1 < 4')).limit(2).to_list(),
+      \ Stream.iterate(1, Closure.from_expr('a:1 + 1')).drop_while(Closure.from_expr('a:1 < 4')).take(2).to_list(),
       \ [4,5])
     End
 
@@ -1196,7 +1196,7 @@ Describe Stream
       Assert Equals(Stream.of(3,3,1,1,2).distinct().to_list(), [3,1,2])
       Assert Equals(Stream.of(3,1,2,1,2).distinct().to_list(), [3,1,2])
       Assert Equals(
-      \ Stream.iterate(0, '(v:val + 1) % 3').distinct().limit(3).to_list(),
+      \ Stream.iterate(0, '(v:val + 1) % 3').distinct().take(3).to_list(),
       \ [0,1,2])
     End
 
@@ -1281,9 +1281,9 @@ Describe Stream
       Assert Equals(Stream.of(2,1,3).sorted().to_list(), [1,2,3])
       Assert Equals(Stream.of(2,1,3,2,1).sorted().to_list(), [1,1,2,2,3])
       Assert Equals(
-      \ Stream.iterate(3, 'v:val - 1').limit(3).sorted().to_list(),
+      \ Stream.iterate(3, 'v:val - 1').take(3).sorted().to_list(),
       \ [1,2,3])
-      Assert Equals(Stream.of(4,5,6,1,2,3).sorted().limit(3).to_list(), [1,2,3])
+      Assert Equals(Stream.of(4,5,6,1,2,3).sorted().take(3).to_list(), [1,2,3])
     End
 
     It sorts elements in stream with comparator
@@ -1292,7 +1292,7 @@ Describe Stream
       Assert Equals(Stream.of(2,1,3).sorted(by_desc).to_list(), [3,2,1])
       Assert Equals(Stream.of(2,1,3,2,1).sorted(by_desc).to_list(), [3,2,2,1,1])
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(by_desc).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(by_desc).to_list(),
       \ [3,2,1])
     End
 
@@ -1305,7 +1305,7 @@ Describe Stream
       Assert Equals(Stream.of(2,1,3).sorted(function('Compare')).to_list(), [3,2,1])
       Assert Equals(Stream.of(2,1,3,2,1).sorted(function('Compare')).to_list(), [3,2,2,1,1])
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(function('Compare')).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(function('Compare')).to_list(),
       \ [3,2,1])
 
       delfunction Compare
@@ -1317,7 +1317,7 @@ Describe Stream
       Assert Equals(Stream.of(2,1,3).sorted(by_desc).to_list(), [3,2,1])
       Assert Equals(Stream.of(2,1,3,2,1).sorted(by_desc).to_list(), [3,2,2,1,1])
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(by_desc).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(by_desc).to_list(),
       \ [3,2,1])
     End
 
@@ -1381,8 +1381,8 @@ Describe Stream
       Assert Equals(Stream.empty().sorted(by_desc).get_comparator(), by_desc)
       Assert Equals(Stream.of(1,2).sorted(by_desc).get_comparator(), by_desc)
 
-      Assert Equals(Stream.of(1,2).sorted(by_desc).limit(1).get_comparator(), by_desc)
-      Assert Equals(Stream.of(1,2).sorted(by_desc).skip(1).get_comparator(), by_desc)
+      Assert Equals(Stream.of(1,2).sorted(by_desc).take(1).get_comparator(), by_desc)
+      Assert Equals(Stream.of(1,2).sorted(by_desc).drop(1).get_comparator(), by_desc)
     End
   End
 
@@ -1546,7 +1546,7 @@ Describe Stream
 
     It returns the first element in stream
       Assert Equals(Stream.of('aaa', 'bb', '').first(), 'aaa')
-      Assert Equals(Stream.iterate(1, 'v:val + 1').filter('v:val % 2 == 0').limit(1).first(), 2)
+      Assert Equals(Stream.iterate(1, 'v:val + 1').filter('v:val % 2 == 0').take(1).first(), 2)
     End
   End
 
@@ -1978,7 +1978,7 @@ Describe Stream
         return a:times
       endfunction
 
-      Assert Equals(Stream.generator(generator).limit(5).to_list(), [0,1,2,3,4])
+      Assert Equals(Stream.generator(generator).take(5).to_list(), [0,1,2,3,4])
     End
   End
 End

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -244,7 +244,20 @@ Describe Stream
   End
 
   Describe .range()
+    It throws an exception for invalid arguments
+      try
+        call Stream.range(-2, 2, 0)
+        Assert 0
+      catch /vital: Stream: range(): stride is 0/
+        Assert 1
+      endtry
+    End
+
     It constructs stream from range
+      Assert Equals(
+      \   Stream.range(-2, 2).to_list(),
+      \   [-2,-1,0,1,2])
+
       Assert Equals(
       \   Stream.range(10, 3).to_list(),
       \   [])
@@ -260,6 +273,41 @@ Describe Stream
       Assert Equals(
       \   Stream.range(1, 4).to_list(),
       \   [1,2,3,4])
+    End
+
+    It can omit 2nd or 3rd argument
+      Assert Equals(
+      \   Stream.range(-2, 2, 2).to_list(),
+      \   [-2,0,2])
+
+      Assert Equals(
+      \   Stream.range(3).to_list(),
+      \   [0,1,2])
+      Assert Equals(
+      \   Stream.range(1).to_list(),
+      \   [0])
+      Assert Equals(
+      \   Stream.range(0).to_list(),
+      \   [])
+      Assert Equals(
+      \   Stream.range(-1).to_list(),
+      \   [])
+      Assert Equals(
+      \   Stream.range(-2).to_list(),
+      \   [])
+
+      Assert Equals(
+      \   Stream.range(0, 10, 2).to_list(),
+      \   [0,2,4,6,8,10])
+      Assert Equals(
+      \   Stream.range(0, 9, 2).to_list(),
+      \   [0,2,4,6,8])
+      Assert Equals(
+      \   Stream.range(0, 9, 3).to_list(),
+      \   [0,3,6,9])
+      Assert Equals(
+      \   Stream.range(0, 8, 3).to_list(),
+      \   [0,3,6])
     End
 
     It constructs limited range when .limit() was specified

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -3,14 +3,28 @@ Describe Stream
     let Stream = vital#vital#new().import('Stream')
   End
 
-  Describe .has_characteristic()
+  Describe .has_characteristics()
     It checks if the stream has certain characteristic
       let s = Stream.from_list([], Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
+      unlet s
+    End
+
+    It can check multiple flags at once
+      let s = Stream.from_list([], Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
+      Assert Equals(
+      \ s.has_characteristics([
+      \   Stream.ORDERED(),
+      \   Stream.DISTINCT(),
+      \   Stream.SORTED(),
+      \   Stream.SIZED(),
+      \   Stream.IMMUTABLE()]),
+      \ 1)
+      Assert Equals(Stream.of(1,2,3).has_characteristics([]), 0)
       unlet s
     End
   End
@@ -27,11 +41,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.of(1,2,3)
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -48,17 +62,17 @@ Describe Stream
 
     It constructs stream of each character from String with characteristics
       let s = Stream.chars("abc", 0)
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 0)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 0)
       let s = Stream.chars("abc", Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -77,17 +91,17 @@ Describe Stream
 
     It constructs stream of each line from String with characteristics
       let s = Stream.lines("abc", 0)
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 0)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 0)
       let s = Stream.lines("abc", Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -104,27 +118,27 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_list([1,2,3])
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
 
     It constructs stream from List with characteristics
       let s = Stream.from_list([1,2,3], 0)
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 0)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 0)
       let s = Stream.from_list([1,2,3], Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -145,27 +159,27 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_dict({"foo": 1, "bar": 3, "baz": 2})
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
 
     It constructs stream from Dictionary with characteristics
       let s = Stream.from_list({"foo": 1}, 0)
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 0)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 0)
       let s = Stream.from_list({"foo": 1}, Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -178,11 +192,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.empty()
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -214,11 +228,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.range(1,10)
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -235,11 +249,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -306,17 +320,17 @@ Describe Stream
     It constructs stream from String with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3))
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
 
@@ -342,17 +356,17 @@ Describe Stream
     It constructs stream with 3 or more than streams with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       unlet s
     End
   End
@@ -439,17 +453,17 @@ Describe Stream
 
     It sets SIZED characteristic
       let s = Stream.of(3,4,5,6,7).limit(3)
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
       let s = Stream.iterate(1, 'v:val + 1').limit(3)
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
     End
 
     It must not reuse stream
@@ -796,11 +810,11 @@ Describe Stream
 
     It sets SORTED characteristic
       let s = Stream.of(1,2,3).sorted()
-      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristic(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
+      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -304,6 +304,20 @@ Describe Stream
     It constructs infinite stream with function
       Assert Equals(
         \Stream.zip(
+          \Stream.empty(),
+          \Stream.empty())
+        \.to_list(),
+        \[])
+
+      Assert Equals(
+        \Stream.zip(
+          \Stream.empty(),
+          \Stream.of(1))
+        \.to_list(),
+        \[])
+
+      Assert Equals(
+        \Stream.zip(
           \Stream.of(1,2,3),
           \Stream.of(4,5,6))
         \.to_list(),
@@ -375,13 +389,29 @@ Describe Stream
           \[[1,4,7], [2,5,8], [3,6,9]])
 
       Assert Equals(
+          \Stream.of(1,2,3).zip(Stream.of(4,5,6), Stream.of(7,8,9))
+                \.to_list(),
+          \[[1,4,7], [2,5,8], [3,6,9]])
+
+      Assert Equals(
           \Stream.zip(Stream.of(1), Stream.of(4,5,6), Stream.of(7,8,9))
+                \.to_list(),
+          \[[1,4,7]])
+
+      Assert Equals(
+          \Stream.of(1).zip(Stream.of(4,5,6), Stream.of(7,8,9))
                 \.to_list(),
           \[[1,4,7]])
 
       Assert Equals(
           \Stream.zip(
               \Stream.iterate(1, 'v:val + 1'),
+              \Stream.of(4,5,6),
+              \Stream.of(7,8,9)).to_list(),
+          \[[1,4,7], [2,5,8], [3,6,9]])
+
+      Assert Equals(
+          \Stream.iterate(1, 'v:val + 1').zip(
               \Stream.of(4,5,6),
               \Stream.of(7,8,9)).to_list(),
           \[[1,4,7], [2,5,8], [3,6,9]])

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1,6 +1,7 @@
 Describe Stream
   Before all
     let Stream = vital#vital#import('Stream')
+    let Closure = vital#vital#import('Data.Closure')
 
     function! Id(n) abort
       return a:n
@@ -275,6 +276,15 @@ Describe Stream
       \   [5,6,7])
     End
 
+    It constructs infinite stream by Data.Closure
+      Assert Equals(
+      \   Stream.iterate(1, Closure.from_expr('a:1')).limit(3).to_list(),
+      \   [1,1,1])
+      Assert Equals(
+      \   Stream.iterate(5, Closure.from_expr('a:1 + 1')).limit(3).to_list(),
+      \   [5,6,7])
+    End
+
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
       Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
@@ -287,15 +297,21 @@ Describe Stream
   End
 
   Describe .generate()
-    It constructs infinite stream with function
+    It constructs infinite stream
       Assert Equals(
       \ Stream.generate('42').limit(5).to_list(),
       \ [42, 42, 42, 42, 42])
     End
 
-    It constructs infinite stream with function
+    It constructs infinite stream by funcref
       Assert Equals(
       \ Stream.generate(function('Answer')).limit(5).to_list(),
+      \ [42, 42, 42, 42, 42])
+    End
+
+    It constructs infinite stream by Data.Closure
+      Assert Equals(
+      \ Stream.generate(Closure.from_expr('42')).limit(5).to_list(),
       \ [42, 42, 42, 42, 42])
     End
   End
@@ -614,6 +630,13 @@ Describe Stream
       delfunction Add
     End
 
+    It peeks stream by Data.Closure
+      let g:peek = []
+      Assert Equals(Stream.of(1,2,3).peek(Closure.from_command('let g:peek += [a:1]')).to_list(), [1,2,3])
+      Assert Equals(g:peek, [1,2,3])
+      unlet g:peek
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -654,6 +677,13 @@ Describe Stream
       delfunction Add
     End
 
+    It peeks stream by Data.Closure
+      let g:foreach = []
+      Assert Equals(Stream.of(1,2,3).foreach(Closure.from_command('let g:foreach += [a:1]')), 0)
+      Assert Equals(g:foreach, [1,2,3])
+      unlet g:foreach
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -691,14 +721,12 @@ Describe Stream
       \ [2,3,4])
     End
 
-    It maps stream by funcref
-      function! F(n) abort
-        return a:n + 1
-      endfunction
+    It maps stream by Data.Closure
+      Assert Equals(Stream.empty().map(Closure.from_expr('a:1 + 1')).to_list(), [])
+
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').map(function('F')).limit(3).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').map(Closure.from_expr('a:1 + 1')).limit(3).to_list(),
       \ [2,3,4])
-      delfunction F
     End
 
     It must not reuse stream
@@ -772,6 +800,15 @@ Describe Stream
       delfunction Repeat
     End
 
+    It flattens mapped stream by Data.Closure
+      Assert Equals(Stream.empty().flatmap(Closure.from_expr('repeat([a:1], a:1)')).to_list(), [])
+
+      Assert Equals(
+        \Stream.iterate(0, Closure.from_expr('a:1 + 1'))
+          \.flatmap(Closure.from_expr('repeat([a:1], a:1)')).limit(6).to_list(),
+        \[1,2,2,3,3,3])
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -807,6 +844,14 @@ Describe Stream
 
       Assert Equals(
       \ Stream.iterate(0, 'v:val + 1').filter(function('IsEven')).limit(3).to_list(),
+      \ [0,2,4])
+    End
+
+    It filters stream by Data.Closure
+      Assert Equals(Stream.empty().filter(Closure.from_expr('a:1 % 2 == 0')).to_list(), [])
+
+      Assert Equals(
+      \ Stream.iterate(0, 'v:val + 1').filter(Closure.from_expr('a:1 % 2 == 0')).limit(3).to_list(),
       \ [0,2,4])
     End
 
@@ -864,6 +909,19 @@ Describe Stream
       delfunction LessThan4
     End
 
+    It takes elements until element is matched by Data.Closure
+      Assert Equals(Stream.empty().take_while(Closure.from_expr('a:1')).to_list(), [])
+      Assert Equals(
+      \ Stream.range(1, 10).take_while(Closure.from_expr('a:1 < 4')).to_list(),
+      \ [1,2,3])
+      Assert Equals(
+      \ Stream.range(1, 10).take_while(Closure.from_expr('a:1 < 4')).limit(2).to_list(),
+      \ [1,2])
+      Assert Equals(
+      \ Stream.iterate(1, Closure.from_expr('a:1 + 1')).take_while(Closure.from_expr('a:1 < 4')).to_list(),
+      \ [1,2,3])
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -916,6 +974,18 @@ Describe Stream
       delfunction LessThan4
     End
 
+    It drops elements until element is matched by Data.Closure
+      Assert Equals(
+      \ Stream.empty().drop_while(Closure.from_expr('a:1')).to_list(),
+      \ [])
+      Assert Equals(
+      \ Stream.of(1,2,3,4,5).drop_while(Closure.from_expr('a:1 < 4')).to_list(),
+      \ [4,5])
+      Assert Equals(
+      \ Stream.iterate(1, Closure.from_expr('a:1 + 1')).drop_while(Closure.from_expr('a:1 < 4')).limit(2).to_list(),
+      \ [4,5])
+    End
+
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -956,7 +1026,7 @@ Describe Stream
   End
 
   Describe .sorted()
-    It sorts elements in stream
+    It sorts elements in stream without comparator
       Assert Equals(Stream.of().sorted().to_list(), [])
       Assert Equals(Stream.of(2,1,3).sorted().to_list(), [1,2,3])
       Assert Equals(Stream.of(2,1,3,2,1).sorted().to_list(), [1,1,2,2,3])
@@ -966,7 +1036,7 @@ Describe Stream
       Assert Equals(Stream.of(4,5,6,1,2,3).sorted().limit(3).to_list(), [1,2,3])
     End
 
-    It sorts elements by function in stream
+    It sorts elements in stream with comparator
       let by_desc = 'v:val[0] > v:val[1] ? -1 : v:val[0] ==# v:val[1] ? 0 : 1'
       Assert Equals(Stream.of().sorted(by_desc).to_list(), [])
       Assert Equals(Stream.of(2,1,3).sorted(by_desc).to_list(), [3,2,1])
@@ -977,19 +1047,15 @@ Describe Stream
       unlet by_desc
     End
 
-    It sorts elements by function in stream
-      function! ByDesc(a, b) abort
-        return a:a > a:b ? -1 : a:a ==# a:b ? 0 : 1
-      endfunction
-
-      Assert Equals(Stream.of().sorted(function('ByDesc')).to_list(), [])
-      Assert Equals(Stream.of(2,1,3).sorted(function('ByDesc')).to_list(), [3,2,1])
-      Assert Equals(Stream.of(2,1,3,2,1).sorted(function('ByDesc')).to_list(), [3,2,2,1,1])
+    It sorts elements in stream with comparator by funcref
+      let by_desc = Closure.from_expr('a:1 > a:2 ? -1 : a:1 ==# a:2 ? 0 : 1')
+      Assert Equals(Stream.of().sorted(by_desc).to_list(), [])
+      Assert Equals(Stream.of(2,1,3).sorted(by_desc).to_list(), [3,2,1])
+      Assert Equals(Stream.of(2,1,3,2,1).sorted(by_desc).to_list(), [3,2,2,1,1])
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(function('ByDesc')).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(by_desc).to_list(),
       \ [3,2,1])
-
-      delfunction ByDesc
+      unlet by_desc
     End
 
     It sets SORTED characteristic
@@ -1008,7 +1074,7 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3,4,5).reduce('v:val[0] + v:val[1]', 0), 15)
     End
 
-    It reduces stream
+    It reduces stream by funcref
       function! Plus(a, b) abort
         return a:a + a:b
       endfunction
@@ -1017,6 +1083,11 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3,4,5).reduce(function('Plus'), 0), 15)
 
       delfunction Plus
+    End
+
+    It reduces stream by Data.Closure
+      Assert Equals(Stream.empty().reduce(Closure.from_expr('a:1'), 42), 42)
+      Assert Equals(Stream.of(1,2,3,4,5).reduce(Closure.from_operator('+'), 0), 15)
     End
   End
 
@@ -1034,7 +1105,7 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3,4,5).reduce_present('v:val[0] + v:val[1]'), 15)
     End
 
-    It reduces stream
+    It reduces stream by funcref
       function! Plus(a, b) abort
         return a:a + a:b
       endfunction
@@ -1042,6 +1113,10 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3,4,5).reduce_present(function('Plus')), 15)
 
       delfunction Plus
+    End
+
+    It reduces stream by Data.Closure
+      Assert Equals(Stream.of(1,2,3,4,5).reduce_present(Closure.from_operator('+')), 15)
     End
   End
 
@@ -1080,7 +1155,7 @@ Describe Stream
       endtry
     End
 
-    It returns max value in stream by string expression
+    It returns max value in stream
       Assert Equals(Stream.of('aaa', 'bb', '').max_by('len(v:val)'), 'aaa')
     End
 
@@ -1092,6 +1167,10 @@ Describe Stream
       Assert Equals(Stream.of('aaa', 'bb', '').max_by(function('Len')), 'aaa')
 
       delfunction Len
+    End
+
+    It returns max value in stream by Data.Closure
+      Assert Equals(Stream.of('aaa', 'bb', '').max_by(Closure.from_funcname('len')), 'aaa')
     End
   End
 
@@ -1130,7 +1209,7 @@ Describe Stream
       endtry
     End
 
-    It returns min value in stream by string expression
+    It returns min value in stream
       Assert Equals(Stream.of('aaa', 'bb', '').min_by('len(v:val)'), '')
     End
 
@@ -1142,6 +1221,10 @@ Describe Stream
       Assert Equals(Stream.of('aaa', 'bb', '').min_by(function('Len')), '')
 
       delfunction Len
+    End
+
+    It returns min value in stream by Data.Closure
+      Assert Equals(Stream.of('aaa', 'bb', '').min_by(Closure.from_funcname('len')), '')
     End
   End
 
@@ -1186,7 +1269,11 @@ Describe Stream
     End
 
     It returns the first element matching with given predicate function in stream by funcref
-      Assert Equals(Stream.iterate(1, 'v:val + 1').find(function('IsEven')), 2)
+      Assert Equals(Stream.iterate(1, function('Succ')).find(function('IsEven')), 2)
+    End
+
+    It returns the first element matching with given predicate function in stream by Data.Closure
+      Assert Equals(Stream.iterate(1, Closure.from_expr('a:1 + 1')).find(Closure.from_expr('a:1 % 2 == 0')), 2)
     End
   End
 
@@ -1212,6 +1299,12 @@ Describe Stream
       delfunction GreaterThan2
       delfunction GreaterThan3
     End
+
+    It returns boolean value if any elements are matched in stream by Data.Closure
+      Assert Equals(Stream.empty().any_match(Closure.from_expr('a:1')), 0)
+      Assert Equals(Stream.of(1,2,3).any_match(Closure.from_expr('a:1 > 2')), 1)
+      Assert Equals(Stream.of(1,2,3).any_match(Closure.from_expr('a:1 > 3')), 0)
+    End
   End
 
   Describe .all_match()
@@ -1235,6 +1328,12 @@ Describe Stream
 
       delfunction GreaterThan0
       delfunction GreaterThan1
+    End
+
+    It returns boolean value if all elements are matched in stream by Data.Closure
+      Assert Equals(Stream.empty().all_match(Closure.from_expr('a:1')), 1)
+      Assert Equals(Stream.of(1,2,3).all_match(Closure.from_expr('a:1 > 0')), 1)
+      Assert Equals(Stream.of(1,2,3).all_match(Closure.from_expr('a:1 > 1')), 0)
     End
   End
 
@@ -1260,6 +1359,12 @@ Describe Stream
       delfunction GreaterThan3
       delfunction GreaterThan2
     End
+
+    It returns boolean value if none elements are matched in stream by Data.Closure
+      Assert Equals(Stream.empty().none_match(Closure.from_expr('a:1')), 1)
+      Assert Equals(Stream.of(1,2,3).none_match(Closure.from_expr('a:1 > 3')), 1)
+      Assert Equals(Stream.of(1,2,3).none_match(Closure.from_expr('a:1 > 2')), 0)
+    End
   End
 
   Describe .string_join()
@@ -1275,7 +1380,7 @@ Describe Stream
   End
 
   Describe .group_by()
-    It groups stream by given func
+    It groups stream
       Assert Equals(Stream.of().group_by('v:val'), {})
       Assert Equals(Stream.of(1).group_by('v:val'), {'1': [1]})
       Assert Equals(Stream.of(1,2,3).group_by('v:val'), {'1': [1], '2': [2], '3': [3]})
@@ -1283,6 +1388,38 @@ Describe Stream
       Assert Equals(Stream.of('foo', 'bar', 'baz').group_by('v:val'), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
       Assert Equals(Stream.of('a', 'bb', 'ccc').group_by('len(v:val)'), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
       Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by('len(v:val)'), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+    End
+
+    It groups stream by funcref
+      function! Len(v) abort
+        return len(a:v)
+      endfunction
+
+      Assert Equals(Stream.of().group_by(function('Id')), {})
+      Assert Equals(Stream.of(1).group_by(function('Id')), {'1': [1]})
+      Assert Equals(Stream.of(1,2,3).group_by(function('Id')), {'1': [1], '2': [2], '3': [3]})
+      Assert Equals(Stream.of(1,2,3,2,1).group_by(function('Id')), {'1': [1,1], '2': [2,2], '3': [3]})
+      Assert Equals(Stream.of('foo', 'bar', 'baz').group_by(function('Id')), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
+      Assert Equals(Stream.of('a', 'bb', 'ccc').group_by(function('Len')), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
+      Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by(function('Len')), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+
+      delfunction Len
+    End
+
+    It groups stream by Data.Closure
+      let id = Closure.from_expr('a:1')
+      let len = Closure.from_funcname('len')
+
+      Assert Equals(Stream.of().group_by(id), {})
+      Assert Equals(Stream.of(1).group_by(id), {'1': [1]})
+      Assert Equals(Stream.of(1,2,3).group_by(id), {'1': [1], '2': [2], '3': [3]})
+      Assert Equals(Stream.of(1,2,3,2,1).group_by(id), {'1': [1,1], '2': [2,2], '3': [3]})
+      Assert Equals(Stream.of('foo', 'bar', 'baz').group_by(id), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
+      Assert Equals(Stream.of('a', 'bb', 'ccc').group_by(len), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
+      Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by(len), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+
+      unlet id
+      unlet len
     End
   End
 
@@ -1387,6 +1524,63 @@ Describe Stream
       delfunction Len
       delfunction List
       delfunction Plus
+    End
+
+    It converts elements to Dictionary in stream by Data.Closure
+      let id = Closure.from_expr('a:1')
+      let len = Closure.from_funcname('len')
+
+      Assert Equals(Stream.of().to_dict(id, id), {})
+      Assert Equals(Stream.of(1).to_dict(id, id), {'1': 1})
+      Assert Equals(Stream.of(1,2,3).to_dict(id, id), {'1': 1, '2': 2, '3': 3})
+      Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict(id, id), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
+      Assert Equals(Stream.of('a', 'bb', 'ccc').to_dict(len, id), {'1': 'a', '2': 'bb', '3': 'ccc'})
+
+      unlet id
+      unlet len
+    End
+
+    It converts elements to Dictionary in stream with merge function by Data.Closure
+      let id = Closure.from_expr('a:1')
+      let len = Closure.from_funcname('len')
+      let list = Closure.from_expr('[a:1]')
+      let plus = Closure.from_operator('+')
+
+      try
+        call Stream.of(1,2,3,2,1).to_dict(id, id)
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
+        Assert 1
+      endtry
+      try
+        Assert Equals(
+          \Stream.of(1,2,3,2,1)
+            \.to_dict(id, list, plus),
+          \{'1': [1,1], '2': [2,2], '3': [3]})
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
+        Assert 0
+      endtry
+
+      try
+        call Stream.of('a', 'bb', 'ccc', 'ddd').to_dict(len, id)
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
+        Assert 1
+      endtry
+      try
+        Assert Equals(
+          \Stream.of('a', 'bb', 'ccc', 'ddd')
+            \.to_dict(len, list),
+          \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
+        Assert 1
+      endtry
+
+      unlet id
+      unlet len
+      unlet list
+      unlet plus
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1066,6 +1066,80 @@ Describe Stream
       Assert Equals(Stream.of(3,1,2,1,2).distinct().to_list(), [3,1,2])
     End
 
+    It dedupes elements in stream with stringifier
+      Assert Equals(Stream.empty().distinct('v:val.value').to_list(), [])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 2}, {'value': 3}).distinct('v:val.value').to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 1}, {'value': 2}, {'value': 2}, {'value': 3}).distinct('v:val.value').to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 2}, {'value': 3}, {'value': 2}, {'value': 3}).distinct('v:val.value').to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 1}, {'value': 2}).distinct('v:val.value').to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 3}, {'value': 1}, {'value': 1}, {'value': 2}).distinct('v:val.value').to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 1}, {'value': 2}, {'value': 1}, {'value': 2}).distinct('v:val.value').to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+    End
+
+    It dedupes elements in stream with stringifier by funcref
+      function! ValueOf(v) abort
+        return a:v.value
+      endfunction
+
+      Assert Equals(Stream.empty().distinct(function('ValueOf')).to_list(), [])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 2}, {'value': 3}).distinct(function('ValueOf')).to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 1}, {'value': 2}, {'value': 2}, {'value': 3}).distinct(function('ValueOf')).to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 2}, {'value': 3}, {'value': 2}, {'value': 3}).distinct(function('ValueOf')).to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 1}, {'value': 2}).distinct(function('ValueOf')).to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 3}, {'value': 1}, {'value': 1}, {'value': 2}).distinct(function('ValueOf')).to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 1}, {'value': 2}, {'value': 1}, {'value': 2}).distinct(function('ValueOf')).to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+
+      delfunction ValueOf
+    End
+
+    It dedupes elements in stream with stringifier by Data.Closure
+      let value_of = Closure.from_expr('a:1.value')
+
+      Assert Equals(Stream.empty().distinct(value_of).to_list(), [])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 2}, {'value': 3}).distinct(value_of).to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 1}, {'value': 2}, {'value': 2}, {'value': 3}).distinct(value_of).to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 1}, {'value': 2}, {'value': 3}, {'value': 2}, {'value': 3}).distinct(value_of).to_list(),
+        \[{'value': 1}, {'value': 2}, {'value': 3}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 1}, {'value': 2}).distinct(value_of).to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 3}, {'value': 1}, {'value': 1}, {'value': 2}).distinct(value_of).to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+      Assert Equals(
+        \Stream.of({'value': 3}, {'value': 1}, {'value': 2}, {'value': 1}, {'value': 2}).distinct(value_of).to_list(),
+        \[{'value': 3}, {'value': 1}, {'value': 2}])
+    End
+
     It stops for infinite stream if downstream limited the number elements
       Assert Equals(
       \ Stream.iterate(0, '(v:val + 1) % 3').distinct().limit(6).to_list(),

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -26,12 +26,11 @@ Describe Stream
   Describe .has_characteristics()
     It checks if the stream has certain characteristic
       let s = Stream.from_list([], Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert True(s.has_characteristics(Stream.DISTINCT()))
+      Assert True(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
 
     It can check multiple flags at once
@@ -44,8 +43,7 @@ Describe Stream
       \   Stream.SIZED(),
       \   Stream.IMMUTABLE()]),
       \ 1)
-      Assert Equals(Stream.of(1,2,3).has_characteristics([]), 0)
-      unlet s
+      Assert False(Stream.of(1,2,3).has_characteristics([]))
     End
   End
 
@@ -66,14 +64,17 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3).to_list(), [1,2,3])
     End
 
+    It constructs heterogeneous stream from arguments
+      Assert Equals(Stream.of('foo', function('tr'), [], {}, 0.1).count(), 5)
+    End
+
     It creates stream with characteristics
       let s = Stream.of(1,2,3)
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -89,18 +90,17 @@ Describe Stream
 
     It constructs stream of each character from String with characteristics
       let s = Stream.chars("abc", 0)
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 0)
+      Assert False(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert False(s.has_characteristics(Stream.SIZED()))
+      Assert False(s.has_characteristics(Stream.IMMUTABLE()))
       let s = Stream.chars("abc", Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert True(s.has_characteristics(Stream.DISTINCT()))
+      Assert True(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -116,20 +116,30 @@ Describe Stream
       Assert Equals(Stream.lines("foo\nbar\n\n").to_list(), ['foo', 'bar', '', ''])
     End
 
+    It constructs stream of each line from String (\r\n)
+      Assert Equals(Stream.lines("").to_list(), [])
+      Assert Equals(Stream.lines("foo").to_list(), ['foo'])
+      Assert Equals(Stream.lines("foo\r\nbar").to_list(), ['foo', 'bar'])
+      Assert Equals(Stream.lines("foo\r\n\r\nbar").to_list(), ['foo', '', 'bar'])
+      Assert Equals(Stream.lines("\r\nfoo\r\nbar").to_list(), ['', 'foo', 'bar'])
+      Assert Equals(Stream.lines("\r\n\r\nfoo\r\nbar").to_list(), ['', '', 'foo', 'bar'])
+      Assert Equals(Stream.lines("foo\r\nbar\r\n").to_list(), ['foo', 'bar', ''])
+      Assert Equals(Stream.lines("foo\r\nbar\r\n\r\n").to_list(), ['foo', 'bar', '', ''])
+    End
+
     It constructs stream of each line from String with characteristics
       let s = Stream.lines("abc", 0)
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 0)
+      Assert False(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert False(s.has_characteristics(Stream.SIZED()))
+      Assert False(s.has_characteristics(Stream.IMMUTABLE()))
       let s = Stream.lines("abc", Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert True(s.has_characteristics(Stream.DISTINCT()))
+      Assert True(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -145,28 +155,26 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_list([1,2,3])
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
 
     It constructs stream from List with characteristics
       let s = Stream.from_list([1,2,3], 0)
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 0)
+      Assert False(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert False(s.has_characteristics(Stream.SIZED()))
+      Assert False(s.has_characteristics(Stream.IMMUTABLE()))
       let s = Stream.from_list([1,2,3], Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert True(s.has_characteristics(Stream.DISTINCT()))
+      Assert True(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -184,30 +192,38 @@ Describe Stream
       \ [["bar", 3], ["baz", 2], ["foo", 1]])
     End
 
+    It constructs heterogeneous stream from Dictionary
+      Assert Equals(Stream.from_dict(
+      \ {"foo": 42, "bar": 3.14, "baz": function('tr')}).count(),
+      \ 3)
+      Assert Equals(
+      \ sort(Stream.from_dict(
+      \ {"foo": 42, "bar": 3.14, "baz": function('tr')}).to_list()),
+      \ [['bar', 3.14], ['baz', function('tr')], ['foo', 42]])
+    End
+
     It creates stream with characteristics
       let s = Stream.from_dict({"foo": 1, "bar": 3, "baz": 2})
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert False(s.has_characteristics(Stream.ORDERED()))
+      Assert True(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
 
     It constructs stream from Dictionary with characteristics
       let s = Stream.from_list({"foo": 1}, 0)
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 0)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 0)
+      Assert False(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert False(s.has_characteristics(Stream.SIZED()))
+      Assert False(s.has_characteristics(Stream.IMMUTABLE()))
       let s = Stream.from_list({"foo": 1}, Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert True(s.has_characteristics(Stream.DISTINCT()))
+      Assert True(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -219,17 +235,19 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.empty()
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
   Describe .range()
     It constructs stream from range
+      Assert Equals(
+      \   Stream.range(10, 3).to_list(),
+      \   [])
       Assert Equals(
       \   Stream.range(1, 0).to_list(),
       \   [])
@@ -255,12 +273,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.range(1,10)
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 1)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert True(s.has_characteristics(Stream.DISTINCT()))
+      Assert True(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -294,12 +311,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 0)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert False(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -391,18 +407,17 @@ Describe Stream
     It constructs stream from String with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3))
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
 
     It constructs stream with 3 or more than streams
@@ -443,18 +458,17 @@ Describe Stream
     It constructs stream with 3 or more than streams with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
-      unlet s
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -569,17 +583,17 @@ Describe Stream
 
     It sets SIZED characteristic
       let s = Stream.of(3,4,5,6,7).limit(3)
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
       let s = Stream.iterate(1, 'v:val + 1').limit(3)
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 0)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert False(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
 
     It must not reuse stream
@@ -599,7 +613,6 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
@@ -643,7 +656,6 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
@@ -652,6 +664,13 @@ Describe Stream
       let g:peek = []
       Assert Equals(Stream.of(1,2,3).peek('add(g:peek, v:val)').to_list(), [1,2,3])
       Assert Equals(g:peek, [1,2,3])
+      unlet g:peek
+    End
+
+    It does not peek anything for empty stream
+      let g:peek = []
+      Assert Equals(Stream.empty().peek('add(g:peek, v:val)').to_list(), [])
+      Assert Equals(g:peek, [])
       unlet g:peek
     End
 
@@ -690,7 +709,6 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
@@ -736,7 +754,6 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
@@ -782,7 +799,6 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
@@ -862,7 +878,6 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
@@ -908,13 +923,12 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
   Describe .take_while()
     It takes elements until element is matched
-      Assert Equals(Stream.empty().take_while('v:val').to_list(), [])
+      Assert Equals(Stream.empty().take_while('v:val < 4').to_list(), [])
       Assert Equals(
       \ Stream.range(1, 10).take_while('v:val < 4').to_list(),
       \ [1,2,3])
@@ -931,7 +945,7 @@ Describe Stream
         return a:n < 4
       endfunction
 
-      Assert Equals(Stream.empty().take_while(function('Id')).to_list(), [])
+      Assert Equals(Stream.empty().take_while(function('LessThan4')).to_list(), [])
       Assert Equals(
       \ Stream.range(1, 10).take_while(function('LessThan4')).to_list(),
       \ [1,2,3])
@@ -946,7 +960,7 @@ Describe Stream
     End
 
     It takes elements until element is matched by Data.Closure
-      Assert Equals(Stream.empty().take_while(Closure.from_expr('a:1')).to_list(), [])
+      Assert Equals(Stream.empty().take_while(Closure.from_expr('a:1 < 4')).to_list(), [])
       Assert Equals(
       \ Stream.range(1, 10).take_while(Closure.from_expr('a:1 < 4')).to_list(),
       \ [1,2,3])
@@ -975,14 +989,13 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
   Describe .drop_while()
     It drops elements until element is matched
       Assert Equals(
-      \ Stream.empty().drop_while('v:val').to_list(),
+      \ Stream.empty().drop_while('v:val < 4').to_list(),
       \ [])
       Assert Equals(
       \ Stream.of(1,2,3,4,5).drop_while('v:val < 4').to_list(),
@@ -998,7 +1011,7 @@ Describe Stream
       endfunction
 
       Assert Equals(
-      \ Stream.empty().drop_while(function('Id')).to_list(),
+      \ Stream.empty().drop_while(function('LessThan4')).to_list(),
       \ [])
       Assert Equals(
       \ Stream.of(1,2,3,4,5).drop_while(function('LessThan4')).to_list(),
@@ -1012,7 +1025,7 @@ Describe Stream
 
     It drops elements until element is matched by Data.Closure
       Assert Equals(
-      \ Stream.empty().drop_while(Closure.from_expr('a:1')).to_list(),
+      \ Stream.empty().drop_while(Closure.from_expr('a:1 < 4')).to_list(),
       \ [])
       Assert Equals(
       \ Stream.of(1,2,3,4,5).drop_while(Closure.from_expr('a:1 < 4')).to_list(),
@@ -1039,7 +1052,6 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
@@ -1096,11 +1108,11 @@ Describe Stream
 
     It sets SORTED characteristic
       let s = Stream.of(1,2,3).sorted()
-      Assert Equals(s.has_characteristics(Stream.ORDERED()), 1)
-      Assert Equals(s.has_characteristics(Stream.DISTINCT()), 0)
-      Assert Equals(s.has_characteristics(Stream.SORTED()), 1)
-      Assert Equals(s.has_characteristics(Stream.SIZED()), 1)
-      Assert Equals(s.has_characteristics(Stream.IMMUTABLE()), 1)
+      Assert True(s.has_characteristics(Stream.ORDERED()))
+      Assert False(s.has_characteristics(Stream.DISTINCT()))
+      Assert True(s.has_characteristics(Stream.SORTED()))
+      Assert True(s.has_characteristics(Stream.SIZED()))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
     End
   End
 
@@ -1298,9 +1310,9 @@ Describe Stream
 
   Describe .any()
     It returns boolean value if any elements are matched in stream
-      Assert Equals(Stream.empty().any('v:val'), 0)
-      Assert Equals(Stream.of(1,2,3).any('v:val > 2'), 1)
-      Assert Equals(Stream.of(1,2,3).any('v:val > 3'), 0)
+      Assert False(Stream.empty().any('v:val'))
+      Assert True(Stream.of(1,2,3).any('v:val > 2'))
+      Assert False(Stream.of(1,2,3).any('v:val > 3'))
     End
 
     It returns boolean value if any elements are matched in stream by funcref
@@ -1311,26 +1323,26 @@ Describe Stream
         return a:n > 3
       endfunction
 
-      Assert Equals(Stream.empty().any(function('Id')), 0)
-      Assert Equals(Stream.of(1,2,3).any(function('GreaterThan2')), 1)
-      Assert Equals(Stream.of(1,2,3).any(function('GreaterThan3')), 0)
+      Assert False(Stream.empty().any(function('Id')))
+      Assert True(Stream.of(1,2,3).any(function('GreaterThan2')))
+      Assert False(Stream.of(1,2,3).any(function('GreaterThan3')))
 
       delfunction GreaterThan2
       delfunction GreaterThan3
     End
 
     It returns boolean value if any elements are matched in stream by Data.Closure
-      Assert Equals(Stream.empty().any(Closure.from_expr('a:1')), 0)
-      Assert Equals(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 2')), 1)
-      Assert Equals(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 3')), 0)
+      Assert False(Stream.empty().any(Closure.from_expr('a:1')))
+      Assert True(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 2')))
+      Assert False(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 3')))
     End
   End
 
   Describe .all()
     It returns boolean value if all elements are matched in stream
-      Assert Equals(Stream.empty().all('v:val'), 1)
-      Assert Equals(Stream.of(1,2,3).all('v:val > 0'), 1)
-      Assert Equals(Stream.of(1,2,3).all('v:val > 1'), 0)
+      Assert True(Stream.empty().all('v:val'))
+      Assert True(Stream.of(1,2,3).all('v:val > 0'))
+      Assert False(Stream.of(1,2,3).all('v:val > 1'))
     End
 
     It returns boolean value if all elements are matched in stream by funcref
@@ -1341,26 +1353,26 @@ Describe Stream
         return a:n > 1
       endfunction
 
-      Assert Equals(Stream.empty().all(function('Id')), 1)
-      Assert Equals(Stream.of(1,2,3).all(function('GreaterThan0')), 1)
-      Assert Equals(Stream.of(1,2,3).all(function('GreaterThan1')), 0)
+      Assert True(Stream.empty().all(function('Id')))
+      Assert True(Stream.of(1,2,3).all(function('GreaterThan0')))
+      Assert False(Stream.of(1,2,3).all(function('GreaterThan1')))
 
       delfunction GreaterThan0
       delfunction GreaterThan1
     End
 
     It returns boolean value if all elements are matched in stream by Data.Closure
-      Assert Equals(Stream.empty().all(Closure.from_expr('a:1')), 1)
-      Assert Equals(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 0')), 1)
-      Assert Equals(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 1')), 0)
+      Assert True(Stream.empty().all(Closure.from_expr('a:1')))
+      Assert True(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 0')))
+      Assert False(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 1')))
     End
   End
 
   Describe .none()
     It returns boolean value if none elements are matched in stream
-      Assert Equals(Stream.empty().none('v:val'), 1)
-      Assert Equals(Stream.of(1,2,3).none('v:val > 3'), 1)
-      Assert Equals(Stream.of(1,2,3).none('v:val > 2'), 0)
+      Assert True(Stream.empty().none('v:val'))
+      Assert True(Stream.of(1,2,3).none('v:val > 3'))
+      Assert False(Stream.of(1,2,3).none('v:val > 2'))
     End
 
     It returns boolean value if none elements are matched in stream by funcref
@@ -1371,18 +1383,18 @@ Describe Stream
         return a:n > 2
       endfunction
 
-      Assert Equals(Stream.empty().none(function('Id')), 1)
-      Assert Equals(Stream.of(1,2,3).none(function('GreaterThan3')), 1)
-      Assert Equals(Stream.of(1,2,3).none(function('GreaterThan2')), 0)
+      Assert True(Stream.empty().none(function('Id')))
+      Assert True(Stream.of(1,2,3).none(function('GreaterThan3')))
+      Assert False(Stream.of(1,2,3).none(function('GreaterThan2')))
 
       delfunction GreaterThan3
       delfunction GreaterThan2
     End
 
     It returns boolean value if none elements are matched in stream by Data.Closure
-      Assert Equals(Stream.empty().none(Closure.from_expr('a:1')), 1)
-      Assert Equals(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 3')), 1)
-      Assert Equals(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 2')), 0)
+      Assert True(Stream.empty().none(Closure.from_expr('a:1')))
+      Assert True(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 3')))
+      Assert False(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 2')))
     End
   End
 
@@ -1613,7 +1625,7 @@ Describe Stream
   Describe .average()
     It averages elements in stream
       try
-        Assert Equals(Stream.empty().average(), 0)
+        call Stream.empty().average()
         Assert 0
       catch /vital: Stream: average(): empty stream cannot be average()d/
         Assert 1
@@ -1664,7 +1676,6 @@ Describe Stream
       catch
         Assert 1
       endtry
-      unlet s
     End
   End
 
@@ -1679,7 +1690,6 @@ Describe Stream
       endfunction
 
       Assert Equals(Stream.generator(generator).to_list(), [0,1,2])
-      unlet generator
     End
 
     It supports interface of infinite generator function like Java's Spliterator
@@ -1689,7 +1699,6 @@ Describe Stream
       endfunction
 
       Assert Equals(Stream.generator(generator).limit(5).to_list(), [0,1,2,3,4])
-      unlet generator
     End
   End
 End

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -25,23 +25,23 @@ Describe Stream
 
   Describe .has_characteristics()
     It checks if the stream has certain characteristic
-      let s = Stream.from_list([], Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert True(s.has_characteristics(Stream.DISTINCT()))
-      Assert True(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      let s = Stream.from_list([], Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert True(s.has_characteristics(Stream.DISTINCT))
+      Assert True(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It can check multiple flags at once
-      let s = Stream.from_list([], Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
+      let s = Stream.from_list([], Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
       Assert Equals(
       \ s.has_characteristics([
-      \   Stream.ORDERED(),
-      \   Stream.DISTINCT(),
-      \   Stream.SORTED(),
-      \   Stream.SIZED(),
-      \   Stream.IMMUTABLE()]),
+      \   Stream.ORDERED,
+      \   Stream.DISTINCT,
+      \   Stream.SORTED,
+      \   Stream.SIZED,
+      \   Stream.IMMUTABLE]),
       \ 1)
       Assert False(Stream.of(1,2,3).has_characteristics([]))
     End
@@ -75,11 +75,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.of(1,2,3)
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -95,17 +95,17 @@ Describe Stream
 
     It constructs stream of each character from String with characteristics
       let s = Stream.chars("abc", 0)
-      Assert False(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert False(s.has_characteristics(Stream.SIZED()))
-      Assert False(s.has_characteristics(Stream.IMMUTABLE()))
-      let s = Stream.chars("abc", Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert True(s.has_characteristics(Stream.DISTINCT()))
-      Assert True(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert False(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert False(s.has_characteristics(Stream.SIZED))
+      Assert False(s.has_characteristics(Stream.IMMUTABLE))
+      let s = Stream.chars("abc", Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert True(s.has_characteristics(Stream.DISTINCT))
+      Assert True(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -134,17 +134,17 @@ Describe Stream
 
     It constructs stream of each line from String with characteristics
       let s = Stream.lines("abc", 0)
-      Assert False(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert False(s.has_characteristics(Stream.SIZED()))
-      Assert False(s.has_characteristics(Stream.IMMUTABLE()))
-      let s = Stream.lines("abc", Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert True(s.has_characteristics(Stream.DISTINCT()))
-      Assert True(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert False(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert False(s.has_characteristics(Stream.SIZED))
+      Assert False(s.has_characteristics(Stream.IMMUTABLE))
+      let s = Stream.lines("abc", Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert True(s.has_characteristics(Stream.DISTINCT))
+      Assert True(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -160,26 +160,26 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_list([1,2,3])
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It constructs stream from List with characteristics
       let s = Stream.from_list([1,2,3], 0)
-      Assert False(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert False(s.has_characteristics(Stream.SIZED()))
-      Assert False(s.has_characteristics(Stream.IMMUTABLE()))
-      let s = Stream.from_list([1,2,3], Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert True(s.has_characteristics(Stream.DISTINCT()))
-      Assert True(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert False(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert False(s.has_characteristics(Stream.SIZED))
+      Assert False(s.has_characteristics(Stream.IMMUTABLE))
+      let s = Stream.from_list([1,2,3], Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert True(s.has_characteristics(Stream.DISTINCT))
+      Assert True(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -209,26 +209,26 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_dict({"foo": 1, "bar": 3, "baz": 2})
-      Assert False(s.has_characteristics(Stream.ORDERED()))
-      Assert True(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert False(s.has_characteristics(Stream.ORDERED))
+      Assert True(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It constructs stream from Dictionary with characteristics
       let s = Stream.from_list({"foo": 1}, 0)
-      Assert False(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert False(s.has_characteristics(Stream.SIZED()))
-      Assert False(s.has_characteristics(Stream.IMMUTABLE()))
-      let s = Stream.from_list({"foo": 1}, Stream.ORDERED() + Stream.DISTINCT() + Stream.SORTED() + Stream.SIZED() + Stream.IMMUTABLE())
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert True(s.has_characteristics(Stream.DISTINCT()))
-      Assert True(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert False(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert False(s.has_characteristics(Stream.SIZED))
+      Assert False(s.has_characteristics(Stream.IMMUTABLE))
+      let s = Stream.from_list({"foo": 1}, Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert True(s.has_characteristics(Stream.DISTINCT))
+      Assert True(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -240,11 +240,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.empty()
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -326,11 +326,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.range(1,10)
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert True(s.has_characteristics(Stream.DISTINCT()))
-      Assert True(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert True(s.has_characteristics(Stream.DISTINCT))
+      Assert True(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -364,11 +364,11 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert False(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert False(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -467,17 +467,17 @@ Describe Stream
     It combines stream from String with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3))
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It combines stream with 3 or more than streams
@@ -518,17 +518,17 @@ Describe Stream
     It combines stream with 3 or more than streams with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -541,6 +541,13 @@ Describe Stream
       Assert Equals(
       \ Stream.of(4,5,6).zip_with_index().to_list(),
       \ [[0,4], [1,5], [2,6]])
+
+      if v:version >= 800
+        Assert Equals(
+        \Stream.of('foo', 'bar', 'baz')
+              \.zip_with_index().map({l -> join(l, ': ')}).to_list(),
+        \['0: foo', '1: bar', '2: baz'])
+      endif
     End
   End
 
@@ -643,17 +650,17 @@ Describe Stream
 
     It sets SIZED characteristic
       let s = Stream.of(3,4,5,6,7).take(3)
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
       let s = Stream.iterate(1, 'v:val + 1').take(3)
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert False(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert False(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It must not reuse stream
@@ -1339,11 +1346,11 @@ Describe Stream
 
     It sets SORTED characteristic
       let s = Stream.of(1,2,3).sorted()
-      Assert True(s.has_characteristics(Stream.ORDERED()))
-      Assert False(s.has_characteristics(Stream.DISTINCT()))
-      Assert True(s.has_characteristics(Stream.SORTED()))
-      Assert True(s.has_characteristics(Stream.SIZED()))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+      Assert True(s.has_characteristics(Stream.ORDERED))
+      Assert False(s.has_characteristics(Stream.DISTINCT))
+      Assert True(s.has_characteristics(Stream.SORTED))
+      Assert True(s.has_characteristics(Stream.SIZED))
+      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -2019,5 +2026,3 @@ Describe Stream
     End
   End
 End
-
-" vim: ft=vim

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -25,23 +25,19 @@ Describe Stream
 
   Describe .has_characteristics()
     It checks if the stream has certain characteristic
-      let s = Stream.from_list([], Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
-      Assert True(s.has_characteristics(Stream.ORDERED))
+      let s = Stream.from_list([], Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
       Assert True(s.has_characteristics(Stream.DISTINCT))
       Assert True(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It can check multiple flags at once
-      let s = Stream.from_list([], Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
+      let s = Stream.from_list([], Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
       Assert Equals(
       \ s.has_characteristics([
-      \   Stream.ORDERED,
       \   Stream.DISTINCT,
       \   Stream.SORTED,
-      \   Stream.SIZED,
-      \   Stream.IMMUTABLE]),
+      \   Stream.SIZED]),
       \ 1)
       Assert False(Stream.of(1,2,3).has_characteristics([]))
     End
@@ -75,11 +71,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.of(1,2,3)
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -95,17 +89,13 @@ Describe Stream
 
     It constructs stream of each character from String with characteristics
       let s = Stream.chars("abc", 0)
-      Assert False(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert False(s.has_characteristics(Stream.SIZED))
-      Assert False(s.has_characteristics(Stream.IMMUTABLE))
-      let s = Stream.chars("abc", Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
-      Assert True(s.has_characteristics(Stream.ORDERED))
+      let s = Stream.chars("abc", Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
       Assert True(s.has_characteristics(Stream.DISTINCT))
       Assert True(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -134,17 +124,13 @@ Describe Stream
 
     It constructs stream of each line from String with characteristics
       let s = Stream.lines("abc", 0)
-      Assert False(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert False(s.has_characteristics(Stream.SIZED))
-      Assert False(s.has_characteristics(Stream.IMMUTABLE))
-      let s = Stream.lines("abc", Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
-      Assert True(s.has_characteristics(Stream.ORDERED))
+      let s = Stream.lines("abc", Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
       Assert True(s.has_characteristics(Stream.DISTINCT))
       Assert True(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -160,26 +146,20 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_list([1,2,3])
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It constructs stream from List with characteristics
       let s = Stream.from_list([1,2,3], 0)
-      Assert False(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert False(s.has_characteristics(Stream.SIZED))
-      Assert False(s.has_characteristics(Stream.IMMUTABLE))
-      let s = Stream.from_list([1,2,3], Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
-      Assert True(s.has_characteristics(Stream.ORDERED))
+      let s = Stream.from_list([1,2,3], Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
       Assert True(s.has_characteristics(Stream.DISTINCT))
       Assert True(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -209,26 +189,20 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_dict({"foo": 1, "bar": 3, "baz": 2})
-      Assert False(s.has_characteristics(Stream.ORDERED))
       Assert True(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It constructs stream from Dictionary with characteristics
       let s = Stream.from_list({"foo": 1}, 0)
-      Assert False(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert False(s.has_characteristics(Stream.SIZED))
-      Assert False(s.has_characteristics(Stream.IMMUTABLE))
-      let s = Stream.from_list({"foo": 1}, Stream.ORDERED + Stream.DISTINCT + Stream.SORTED + Stream.SIZED + Stream.IMMUTABLE)
-      Assert True(s.has_characteristics(Stream.ORDERED))
+      let s = Stream.from_list({"foo": 1}, Stream.DISTINCT + Stream.SORTED + Stream.SIZED)
       Assert True(s.has_characteristics(Stream.DISTINCT))
       Assert True(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -240,11 +214,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.empty()
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -326,11 +298,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.range(1,10)
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert True(s.has_characteristics(Stream.DISTINCT))
       Assert True(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -364,11 +334,9 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert False(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -467,17 +435,13 @@ Describe Stream
     It combines stream from String with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3))
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It combines stream with 3 or more than streams
@@ -518,17 +482,13 @@ Describe Stream
     It combines stream with 3 or more than streams with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 
@@ -650,17 +610,13 @@ Describe Stream
 
     It sets SIZED characteristic
       let s = Stream.of(3,4,5,6,7).take(3)
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
       let s = Stream.iterate(1, 'v:val + 1').take(3)
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert False(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
 
     It must not reuse stream
@@ -1346,11 +1302,9 @@ Describe Stream
 
     It sets SORTED characteristic
       let s = Stream.of(1,2,3).sorted()
-      Assert True(s.has_characteristics(Stream.ORDERED))
       Assert False(s.has_characteristics(Stream.DISTINCT))
       Assert True(s.has_characteristics(Stream.SORTED))
       Assert True(s.has_characteristics(Stream.SIZED))
-      Assert True(s.has_characteristics(Stream.IMMUTABLE))
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -501,6 +501,35 @@ Describe Stream
         \[1,2,3,4,5])
     End
 
+    It constructs stream from 3 or more than streams
+      Assert Equals(
+        \Stream.concat(
+          \Stream.of(1),
+          \Stream.of(2),
+          \Stream.of(3))
+        \.to_list(),
+        \[1,2,3])
+
+      Assert Equals(
+        \Stream.concat(
+          \Stream.of(1),
+          \Stream.of(2),
+          \Stream.empty(),
+          \Stream.of(3))
+        \.to_list(),
+        \[1,2,3])
+    End
+
+    It constructs stream from 3 or more than streams (method version)
+      Assert Equals(
+        \Stream.of(1).concat(Stream.of(2), Stream.of(3)).to_list(),
+        \[1,2,3])
+
+      Assert Equals(
+        \Stream.of(1).concat(Stream.of(2), Stream.empty(), Stream.of(3)).to_list(),
+        \[1,2,3])
+    End
+
     It constructs infinite stream with function (method version)
       Assert Equals(
         \Stream.of(1,2,3).concat(Stream.of(4,5)).to_list(),

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1437,4 +1437,28 @@ Describe Stream
     End
   End
 
+  Describe .generator()
+    It supports interface of generator function like Java's Spliterator
+      let generator = {}
+      function! generator.yield(times, NONE) abort
+        if a:times >= 3
+          return a:NONE
+        endif
+        return a:times
+      endfunction
+
+      Assert Equals(Stream.generator(generator).to_list(), [0,1,2])
+      unlet generator
+    End
+
+    It supports interface of infinite generator function like Java's Spliterator
+      let generator = {}
+      function! generator.yield(times, NONE) abort
+        return a:times
+      endfunction
+
+      Assert Equals(Stream.generator(generator).limit(5).to_list(), [0,1,2,3,4])
+      unlet generator
+    End
+  End
 End

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -519,7 +519,6 @@ Describe Stream
 
   Describe .peek()
     It peeks stream
-      Skip "not implemented yet"
       let g:peek = []
       Assert Equals(Stream.of(1,2,3).peek('add(g:peek, v:val)').to_list(), [1,2,3])
       Assert Equals(g:peek, [1,2,3])
@@ -527,7 +526,6 @@ Describe Stream
     End
 
     It must not reuse stream
-      Skip "not implemented yet"
       try
         let s = Stream.of(1,2,3,4,5)
         call s.to_list()

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1231,6 +1231,18 @@ Describe Stream
     End
   End
 
+  Describe .string_join()
+    It sums elements in stream
+      Assert Equals(Stream.of().string_join(), '')
+      Assert Equals(Stream.of(1).string_join(), '1')
+      Assert Equals(Stream.of(1,2,3).string_join(), '1 2 3')
+      Assert Equals(Stream.of(1,2,3).string_join(','), '1,2,3')
+      Assert Equals(Stream.of('foo').string_join(), 'foo')
+      Assert Equals(Stream.of('foo', 'bar', 'baz').string_join(), 'foo bar baz')
+      Assert Equals(Stream.of('foo', 'bar', 'baz').string_join(','), 'foo,bar,baz')
+    End
+  End
+
   Describe .sum()
     It sums elements in stream
       Assert Equals(Stream.of().sum(), 0)

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1482,6 +1482,27 @@ Describe Stream
     End
   End
 
+  Describe .last()
+    It raises exception for empty stream
+      try
+        call Stream.empty().last()
+        Assert 0
+      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
+        Assert 1
+      endtry
+      try
+        Assert Equals(Stream.empty().last(42), 42)
+      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
+        Assert 0
+      endtry
+    End
+
+    It returns the last element in stream
+      Assert Equals(Stream.of('aaa', 'bb', '').last(), '')
+      Assert Equals(Stream.iterate(1, 'v:val + 1').filter('v:val % 2 == 0').take_while('v:val <= 10').last(), 10)
+    End
+  End
+
   Describe .find()
     It raises exception for empty stream
       try

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1289,11 +1289,11 @@ Describe Stream
     End
   End
 
-  Describe .any_match()
+  Describe .any()
     It returns boolean value if any elements are matched in stream
-      Assert Equals(Stream.empty().any_match('v:val'), 0)
-      Assert Equals(Stream.of(1,2,3).any_match('v:val > 2'), 1)
-      Assert Equals(Stream.of(1,2,3).any_match('v:val > 3'), 0)
+      Assert Equals(Stream.empty().any('v:val'), 0)
+      Assert Equals(Stream.of(1,2,3).any('v:val > 2'), 1)
+      Assert Equals(Stream.of(1,2,3).any('v:val > 3'), 0)
     End
 
     It returns boolean value if any elements are matched in stream by funcref
@@ -1304,26 +1304,26 @@ Describe Stream
         return a:n > 3
       endfunction
 
-      Assert Equals(Stream.empty().any_match(function('Id')), 0)
-      Assert Equals(Stream.of(1,2,3).any_match(function('GreaterThan2')), 1)
-      Assert Equals(Stream.of(1,2,3).any_match(function('GreaterThan3')), 0)
+      Assert Equals(Stream.empty().any(function('Id')), 0)
+      Assert Equals(Stream.of(1,2,3).any(function('GreaterThan2')), 1)
+      Assert Equals(Stream.of(1,2,3).any(function('GreaterThan3')), 0)
 
       delfunction GreaterThan2
       delfunction GreaterThan3
     End
 
     It returns boolean value if any elements are matched in stream by Data.Closure
-      Assert Equals(Stream.empty().any_match(Closure.from_expr('a:1')), 0)
-      Assert Equals(Stream.of(1,2,3).any_match(Closure.from_expr('a:1 > 2')), 1)
-      Assert Equals(Stream.of(1,2,3).any_match(Closure.from_expr('a:1 > 3')), 0)
+      Assert Equals(Stream.empty().any(Closure.from_expr('a:1')), 0)
+      Assert Equals(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 2')), 1)
+      Assert Equals(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 3')), 0)
     End
   End
 
-  Describe .all_match()
+  Describe .all()
     It returns boolean value if all elements are matched in stream
-      Assert Equals(Stream.empty().all_match('v:val'), 1)
-      Assert Equals(Stream.of(1,2,3).all_match('v:val > 0'), 1)
-      Assert Equals(Stream.of(1,2,3).all_match('v:val > 1'), 0)
+      Assert Equals(Stream.empty().all('v:val'), 1)
+      Assert Equals(Stream.of(1,2,3).all('v:val > 0'), 1)
+      Assert Equals(Stream.of(1,2,3).all('v:val > 1'), 0)
     End
 
     It returns boolean value if all elements are matched in stream by funcref
@@ -1334,26 +1334,26 @@ Describe Stream
         return a:n > 1
       endfunction
 
-      Assert Equals(Stream.empty().all_match(function('Id')), 1)
-      Assert Equals(Stream.of(1,2,3).all_match(function('GreaterThan0')), 1)
-      Assert Equals(Stream.of(1,2,3).all_match(function('GreaterThan1')), 0)
+      Assert Equals(Stream.empty().all(function('Id')), 1)
+      Assert Equals(Stream.of(1,2,3).all(function('GreaterThan0')), 1)
+      Assert Equals(Stream.of(1,2,3).all(function('GreaterThan1')), 0)
 
       delfunction GreaterThan0
       delfunction GreaterThan1
     End
 
     It returns boolean value if all elements are matched in stream by Data.Closure
-      Assert Equals(Stream.empty().all_match(Closure.from_expr('a:1')), 1)
-      Assert Equals(Stream.of(1,2,3).all_match(Closure.from_expr('a:1 > 0')), 1)
-      Assert Equals(Stream.of(1,2,3).all_match(Closure.from_expr('a:1 > 1')), 0)
+      Assert Equals(Stream.empty().all(Closure.from_expr('a:1')), 1)
+      Assert Equals(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 0')), 1)
+      Assert Equals(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 1')), 0)
     End
   End
 
-  Describe .none_match()
+  Describe .none()
     It returns boolean value if none elements are matched in stream
-      Assert Equals(Stream.empty().none_match('v:val'), 1)
-      Assert Equals(Stream.of(1,2,3).none_match('v:val > 3'), 1)
-      Assert Equals(Stream.of(1,2,3).none_match('v:val > 2'), 0)
+      Assert Equals(Stream.empty().none('v:val'), 1)
+      Assert Equals(Stream.of(1,2,3).none('v:val > 3'), 1)
+      Assert Equals(Stream.of(1,2,3).none('v:val > 2'), 0)
     End
 
     It returns boolean value if none elements are matched in stream by funcref
@@ -1364,18 +1364,18 @@ Describe Stream
         return a:n > 2
       endfunction
 
-      Assert Equals(Stream.empty().none_match(function('Id')), 1)
-      Assert Equals(Stream.of(1,2,3).none_match(function('GreaterThan3')), 1)
-      Assert Equals(Stream.of(1,2,3).none_match(function('GreaterThan2')), 0)
+      Assert Equals(Stream.empty().none(function('Id')), 1)
+      Assert Equals(Stream.of(1,2,3).none(function('GreaterThan3')), 1)
+      Assert Equals(Stream.of(1,2,3).none(function('GreaterThan2')), 0)
 
       delfunction GreaterThan3
       delfunction GreaterThan2
     End
 
     It returns boolean value if none elements are matched in stream by Data.Closure
-      Assert Equals(Stream.empty().none_match(Closure.from_expr('a:1')), 1)
-      Assert Equals(Stream.of(1,2,3).none_match(Closure.from_expr('a:1 > 3')), 1)
-      Assert Equals(Stream.of(1,2,3).none_match(Closure.from_expr('a:1 > 2')), 0)
+      Assert Equals(Stream.empty().none(Closure.from_expr('a:1')), 1)
+      Assert Equals(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 3')), 1)
+      Assert Equals(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 2')), 0)
     End
   End
 
@@ -1623,6 +1623,24 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3).count(), 3)
       Assert Equals(Stream.iterate(1, 'v:val + 1').count(), 1/0)
     End
+
+    It counts elements by predicate function in stream
+      Assert Equals(Stream.of().count('v:val'), 0)
+      Assert Equals(Stream.of(1,2,3).count('v:val % 2 == 0'), 1)
+      Assert Equals(Stream.iterate(1, 'v:val + 1').count('v:val % 2 == 0'), 1/0)
+    End
+
+    It counts elements by predicate function in stream by funcref
+      Assert Equals(Stream.of().count(function('Id')), 0)
+      Assert Equals(Stream.of(1,2,3).count(function('IsEven')), 1)
+      Assert Equals(Stream.iterate(1, 'v:val + 1').count(function('IsEven')), 1/0)
+    End
+
+    It counts elements by predicate function in stream by Data.Closure
+      Assert Equals(Stream.of().count(function('Id')), 0)
+      Assert Equals(Stream.of(1,2,3).count(Closure.from_expr('a:1 % 2 == 0')), 1)
+      Assert Equals(Stream.iterate(1, 'v:val + 1').count(Closure.from_expr('a:1 % 2 == 0')), 1/0)
+    End
   End
 
   Describe .to_list()
@@ -1668,3 +1686,5 @@ Describe Stream
     End
   End
 End
+
+" vim: ft=vim

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -719,6 +719,13 @@ Describe Stream
       let g:peek = []
       Assert Equals(Stream.of(1,2,3).peek('add(g:peek, v:val)').to_list(), [1,2,3])
       Assert Equals(g:peek, [1,2,3])
+
+      let g:peek = []
+      Assert Equals(
+              \Stream.of(1,2,3).peek('add(g:peek, v:val)')
+                              \.map('v:val * 2').to_list(),
+              \[2,4,6])
+      Assert Equals(g:peek, [1,2,3])
       unlet g:peek
     End
 
@@ -937,7 +944,7 @@ Describe Stream
   End
 
   Describe .slice_before()
-    It maps stream
+    It slices stream
       let is_even = 'v:val % 2 == 0'
       let is_multiple_of_3 = 'v:val % 3 == 0'
 
@@ -1400,7 +1407,7 @@ Describe Stream
       endtry
     End
 
-    It reduces stream
+    It accumulates stream
       Assert Equals(Stream.empty().reduce('v:val', 42), 42)
       Assert Equals(Stream.of(1).reduce('v:val[0] + v:val[1]'), 1)
       Assert Equals(Stream.of(1,2,3,4,5).reduce('v:val[0] + v:val[1]'), 15)
@@ -1408,7 +1415,7 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3).reduce('insert(v:val[0], v:val[1])', []), [3,2,1])
     End
 
-    It reduces stream by funcref
+    It accumulates stream by funcref
       function! Plus(a, b) abort
         return a:a + a:b
       endfunction
@@ -1422,7 +1429,7 @@ Describe Stream
       delfunction Plus
     End
 
-    It reduces stream by Data.Closure
+    It accumulates stream by Data.Closure
       Assert Equals(Stream.empty().reduce(Closure.from_expr('a:1'), 42), 42)
       Assert Equals(Stream.of(1).reduce(Closure.from_operator('+')), 1)
       Assert Equals(Stream.of(1,2,3,4,5).reduce(Closure.from_operator('+')), 15)
@@ -1610,13 +1617,13 @@ Describe Stream
   End
 
   Describe .any()
-    It returns boolean value if any elements are matched in stream
+    It returns true if any of elements are matched in stream
       Assert False(Stream.empty().any('v:val'))
       Assert True(Stream.of(1,2,3).any('v:val > 2'))
       Assert False(Stream.of(1,2,3).any('v:val > 3'))
     End
 
-    It returns boolean value if any elements are matched in stream by funcref
+    It returns true if any of elements are matched in stream by funcref
       function! GreaterThan2(n) abort
         return a:n > 2
       endfunction
@@ -1632,7 +1639,7 @@ Describe Stream
       delfunction GreaterThan3
     End
 
-    It returns boolean value if any elements are matched in stream by Data.Closure
+    It returns true if any of elements are matched in stream by Data.Closure
       Assert False(Stream.empty().any(Closure.from_expr('a:1')))
       Assert True(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 2')))
       Assert False(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 3')))
@@ -1640,13 +1647,13 @@ Describe Stream
   End
 
   Describe .all()
-    It returns boolean value if all elements are matched in stream
+    It returns true if all of elements are matched in stream
       Assert True(Stream.empty().all('v:val'))
       Assert True(Stream.of(1,2,3).all('v:val > 0'))
       Assert False(Stream.of(1,2,3).all('v:val > 1'))
     End
 
-    It returns boolean value if all elements are matched in stream by funcref
+    It returns true if all of elements are matched in stream by funcref
       function! GreaterThan0(n) abort
         return a:n > 0
       endfunction
@@ -1662,7 +1669,7 @@ Describe Stream
       delfunction GreaterThan1
     End
 
-    It returns boolean value if all elements are matched in stream by Data.Closure
+    It returns true if all of elements are matched in stream by Data.Closure
       Assert True(Stream.empty().all(Closure.from_expr('a:1')))
       Assert True(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 0')))
       Assert False(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 1')))
@@ -1670,13 +1677,13 @@ Describe Stream
   End
 
   Describe .none()
-    It returns boolean value if none elements are matched in stream
+    It returns true if none of elements are matched in stream
       Assert True(Stream.empty().none('v:val'))
       Assert True(Stream.of(1,2,3).none('v:val > 3'))
       Assert False(Stream.of(1,2,3).none('v:val > 2'))
     End
 
-    It returns boolean value if none elements are matched in stream by funcref
+    It returns true if none of elements are matched in stream by funcref
       function! GreaterThan3(n) abort
         return a:n > 3
       endfunction
@@ -1692,7 +1699,7 @@ Describe Stream
       delfunction GreaterThan2
     End
 
-    It returns boolean value if none elements are matched in stream by Data.Closure
+    It returns true if none of elements are matched in stream by Data.Closure
       Assert True(Stream.empty().none(Closure.from_expr('a:1')))
       Assert True(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 3')))
       Assert False(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 2')))
@@ -1720,11 +1727,17 @@ Describe Stream
       Assert Equals(Stream.of('foo', 'bar', 'baz').group_by('v:val'), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
       Assert Equals(Stream.of('a', 'bb', 'ccc').group_by('len(v:val)'), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
       Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by('len(v:val)'), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+      Assert Equals(
+        \Stream.of(1,2,3,4,5).group_by('v:val % 2 == 0 ? "even" : "odd"'),
+        \{'even': [2,4], 'odd': [1,3,5]})
     End
 
     It groups stream by funcref
       function! Len(v) abort
         return len(a:v)
+      endfunction
+      function! EvenOrOdd(n) abort
+        return a:n % 2 == 0 ? 'even' : 'odd'
       endfunction
 
       Assert Equals(Stream.empty().group_by(function('Id')), {})
@@ -1734,13 +1747,18 @@ Describe Stream
       Assert Equals(Stream.of('foo', 'bar', 'baz').group_by(function('Id')), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
       Assert Equals(Stream.of('a', 'bb', 'ccc').group_by(function('Len')), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
       Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by(function('Len')), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+      Assert Equals(
+        \Stream.of(1,2,3,4,5).group_by(function('EvenOrOdd')),
+        \{'even': [2,4], 'odd': [1,3,5]})
 
       delfunction Len
+      delfunction EvenOrOdd
     End
 
     It groups stream by Data.Closure
       let id = Closure.from_expr('a:1')
       let len = Closure.from_funcname('len')
+      let even_or_odd = Closure.from_expr('a:1 % 2 == 0 ? "even" : "odd"')
 
       Assert Equals(Stream.empty().group_by(id), {})
       Assert Equals(Stream.of(1).group_by(id), {'1': [1]})
@@ -1749,6 +1767,9 @@ Describe Stream
       Assert Equals(Stream.of('foo', 'bar', 'baz').group_by(id), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
       Assert Equals(Stream.of('a', 'bb', 'ccc').group_by(len), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
       Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by(len), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+      Assert Equals(
+        \Stream.of(1,2,3,4,5).group_by(even_or_odd),
+        \{'even': [2,4], 'odd': [1,3,5]})
     End
   End
 
@@ -1759,6 +1780,10 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3).to_dict('v:val', 'v:val'), {'1': 1, '2': 2, '3': 3})
       Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict('v:val', 'v:val'), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
       Assert Equals(Stream.of('a', 'bb', 'ccc').to_dict('len(v:val)', 'v:val'), {'1': 'a', '2': 'bb', '3': 'ccc'})
+      Assert Equals(Stream.of('a', 'bb', 'ccc').to_dict('len(v:val)', 'v:val'), {'1': 'a', '2': 'bb', '3': 'ccc'})
+	    Assert Equals(Stream.of(1,2,3,3)
+	                       \.to_dict('v:val', 'v:val', 'v:val[0] + v:val[1]'),
+	                 \{'1': 1, '2': 2, '3': 6})
     End
 
     It converts elements to Dictionary in stream with merge function
@@ -1786,11 +1811,10 @@ Describe Stream
       try
         Assert Equals(
           \Stream.of('a', 'bb', 'ccc', 'ddd')
-            \.to_dict('len(v:val)', '[v:val]'),
+            \.to_dict('len(v:val)', '[v:val]', 'v:val[0] + v:val[1]'),
           \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
-        Assert 0
       catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 1
+        Assert 0
       endtry
     End
 
@@ -1843,11 +1867,10 @@ Describe Stream
       try
         Assert Equals(
           \Stream.of('a', 'bb', 'ccc', 'ddd')
-            \.to_dict(function('Len'), function('List')),
+            \.to_dict(function('Len'), function('List'), function('Plus')),
           \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
-        Assert 0
       catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 1
+        Assert 0
       endtry
 
       delfunction Len
@@ -1896,11 +1919,10 @@ Describe Stream
       try
         Assert Equals(
           \Stream.of('a', 'bb', 'ccc', 'ddd')
-            \.to_dict(len, list),
+            \.to_dict(len, list, plus),
           \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
-        Assert 0
       catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 1
+        Assert 0
       endtry
     End
   End

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -62,6 +62,11 @@ Describe Stream
       Assert Equals(Stream.of(1).to_list(), [1])
       Assert Equals(Stream.of(1,2,3).count(), 3)
       Assert Equals(Stream.of(1,2,3).to_list(), [1,2,3])
+
+      Assert Equals(Stream.of(1,2,3,4).filter('v:val % 2 == 0').map('v:val * v:val').to_list(), [4,16])
+      if v:version >= 800
+        Assert Equals(Stream.of(1,2,3,4).filter({n -> n % 2 == 0}).map({n -> n * n}).to_list(), [4,16])
+      endif
     End
 
     It constructs heterogeneous stream from arguments

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1294,10 +1294,24 @@ Describe Stream
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(by_desc).to_list(),
       \ [3,2,1])
-      unlet by_desc
     End
 
     It sorts elements in stream with comparator by funcref
+      function! Compare(a, b) abort
+        return a:a > a:b ? -1 : a:a ==# a:b ? 0 : 1
+      endfunction
+
+      Assert Equals(Stream.empty().sorted(function('Compare')).to_list(), [])
+      Assert Equals(Stream.of(2,1,3).sorted(function('Compare')).to_list(), [3,2,1])
+      Assert Equals(Stream.of(2,1,3,2,1).sorted(function('Compare')).to_list(), [3,2,2,1,1])
+      Assert Equals(
+      \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(function('Compare')).to_list(),
+      \ [3,2,1])
+
+      delfunction Compare
+    End
+
+    It sorts elements in stream with comparator by Data.Closure
       let by_desc = Closure.from_expr('a:1 > a:2 ? -1 : a:1 ==# a:2 ? 0 : 1')
       Assert Equals(Stream.empty().sorted(by_desc).to_list(), [])
       Assert Equals(Stream.of(2,1,3).sorted(by_desc).to_list(), [3,2,1])
@@ -1305,7 +1319,6 @@ Describe Stream
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').limit(3).sorted(by_desc).to_list(),
       \ [3,2,1])
-      unlet by_desc
     End
 
     It sets SORTED characteristic
@@ -1315,6 +1328,61 @@ Describe Stream
       Assert True(s.has_characteristics(Stream.SORTED()))
       Assert True(s.has_characteristics(Stream.SIZED()))
       Assert True(s.has_characteristics(Stream.IMMUTABLE()))
+    End
+  End
+
+  Describe .get_comparator()
+    It raises exception if comparator is not defined
+      try
+        call Stream.empty().sorted().get_comparator()
+        Assert 0
+      catch /vital: Stream: get_comparator(): comparator not found and default argument was not given/
+        Assert 1
+      endtry
+      try
+        Assert Equals(Stream.empty().sorted().get_comparator(42), 42)
+      catch /vital: Stream: get_comparator(): comparator not found and default argument was not given/
+        Assert 0
+      endtry
+    End
+
+    It raises exception if SORTED flag is not set
+      try
+        call Stream.empty().get_comparator()
+        Assert 0
+      catch /vital: Stream: get_comparator(): comparator not found and default argument was not given/
+        Assert 1
+      endtry
+      try
+        Assert Equals(Stream.empty().get_comparator(42), 42)
+      catch /vital: Stream: get_comparator(): comparator not found and default argument was not given/
+        Assert 0
+      endtry
+
+      let by_desc = 'v:val[0] > v:val[1] ? -1 : v:val[0] ==# v:val[1] ? 0 : 1'
+
+      " map() clears SORTED flag
+      Assert Equals(Stream.of(1,2).sorted(by_desc).map('v:val').get_comparator('NONE'), 'NONE')
+
+      " flatmap() clears SORTED flag
+      Assert Equals(Stream.of(1,2).sorted(by_desc).flatmap('[v:val]').get_comparator('NONE'), 'NONE')
+
+      " concat() clears SORTED flag
+      Assert Equals(Stream.of(1,2).sorted(by_desc).concat(Stream.of(3,4)).get_comparator('NONE'), 'NONE')
+      Assert Equals(Stream.of(1,2).concat(Stream.of(3,4).sorted(by_desc)).get_comparator('NONE'), 'NONE')
+
+      " zip() clears SORTED flag
+      Assert Equals(Stream.of(1,2).sorted(by_desc).zip(Stream.of(3,4)).get_comparator('NONE'), 'NONE')
+      Assert Equals(Stream.of(1,2).zip(Stream.of(3,4).sorted(by_desc)).get_comparator('NONE'), 'NONE')
+    End
+
+    It finds a comparator from a upstream
+      let by_desc = 'v:val[0] > v:val[1] ? -1 : v:val[0] ==# v:val[1] ? 0 : 1'
+      Assert Equals(Stream.empty().sorted(by_desc).get_comparator(), by_desc)
+      Assert Equals(Stream.of(1,2).sorted(by_desc).get_comparator(), by_desc)
+
+      Assert Equals(Stream.of(1,2).sorted(by_desc).limit(1).get_comparator(), by_desc)
+      Assert Equals(Stream.of(1,2).sorted(by_desc).skip(1).get_comparator(), by_desc)
     End
   End
 
@@ -1671,9 +1739,6 @@ Describe Stream
       Assert Equals(Stream.of('foo', 'bar', 'baz').group_by(id), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
       Assert Equals(Stream.of('a', 'bb', 'ccc').group_by(len), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
       Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by(len), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
-
-      unlet id
-      unlet len
     End
   End
 
@@ -1789,9 +1854,6 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3).to_dict(id, id), {'1': 1, '2': 2, '3': 3})
       Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict(id, id), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
       Assert Equals(Stream.of('a', 'bb', 'ccc').to_dict(len, id), {'1': 'a', '2': 'bb', '3': 'ccc'})
-
-      unlet id
-      unlet len
     End
 
     It converts elements to Dictionary in stream with merge function by Data.Closure
@@ -1830,11 +1892,6 @@ Describe Stream
       catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
         Assert 1
       endtry
-
-      unlet id
-      unlet len
-      unlet list
-      unlet plus
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1461,24 +1461,24 @@ Describe Stream
     End
   End
 
-  Describe .find_first()
+  Describe .first()
     It raises exception for empty stream
       try
-        call Stream.empty().find_first()
+        call Stream.empty().first()
         Assert 0
       catch /vital: Stream: \w\+(): stream is empty and default value was not given/
         Assert 1
       endtry
       try
-        Assert Equals(Stream.empty().find_first(42), 42)
+        Assert Equals(Stream.empty().first(42), 42)
       catch /vital: Stream: \w\+(): stream is empty and default value was not given/
         Assert 0
       endtry
     End
 
     It returns the first element in stream
-      Assert Equals(Stream.of('aaa', 'bb', '').find_first(), 'aaa')
-      Assert Equals(Stream.iterate(1, 'v:val + 1').filter('v:val % 2 == 0').limit(1).find_first(), 2)
+      Assert Equals(Stream.of('aaa', 'bb', '').first(), 'aaa')
+      Assert Equals(Stream.iterate(1, 'v:val + 1').filter('v:val % 2 == 0').limit(1).first(), 2)
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -50,9 +50,16 @@ Describe Stream
   End
 
   Describe .of()
+    It raises exception for empty arguments
+      try
+        call Stream.of()
+        Assert 0
+      catch
+        Assert 1
+      endtry
+    End
+
     It constructs stream from arguments
-      Assert Equals(Stream.of().count(), 0)
-      Assert Equals(Stream.of().to_list(), [])
       Assert Equals(Stream.of(1).count(), 1)
       Assert Equals(Stream.of(1).to_list(), [1])
       Assert Equals(Stream.of(1,2,3).count(), 3)
@@ -206,8 +213,8 @@ Describe Stream
 
   Describe .empty()
     It constructs empty stream
-      Assert Equals(Stream.empty().count(), Stream.of().count())
-      Assert Equals(Stream.empty().to_list(), Stream.of().to_list())
+      Assert Equals(Stream.empty().count(), 0)
+      Assert Equals(Stream.empty().to_list(), [])
     End
 
     It creates stream with characteristics
@@ -356,13 +363,13 @@ Describe Stream
       Assert Equals(
         \Stream.zip(
           \Stream.of(1),
-          \Stream.of())
+          \Stream.empty())
         \.to_list(),
         \[])
 
       Assert Equals(
         \Stream.zip(
-          \Stream.of(),
+          \Stream.empty(),
           \Stream.of(1))
         \.to_list(),
         \[])
@@ -475,13 +482,13 @@ Describe Stream
       Assert Equals(
         \Stream.concat(
           \Stream.of(1,2,3),
-          \Stream.of())
+          \Stream.empty())
         \.to_list(),
         \[1,2,3])
 
       Assert Equals(
         \Stream.concat(
-          \Stream.of(),
+          \Stream.empty(),
           \Stream.of(4,5))
         \.to_list(),
         \[4,5])
@@ -1038,7 +1045,7 @@ Describe Stream
 
   Describe .distinct()
     It dedupes elements in stream
-      Assert Equals(Stream.of().distinct().to_list(), [])
+      Assert Equals(Stream.empty().distinct().to_list(), [])
       Assert Equals(Stream.of(1,2,3).distinct().to_list(), [1,2,3])
       Assert Equals(Stream.of(1,1,2,2,3).distinct().to_list(), [1,2,3])
       Assert Equals(Stream.of(1,2,3,2,3).distinct().to_list(), [1,2,3])
@@ -1056,7 +1063,7 @@ Describe Stream
 
   Describe .sorted()
     It sorts elements in stream without comparator
-      Assert Equals(Stream.of().sorted().to_list(), [])
+      Assert Equals(Stream.empty().sorted().to_list(), [])
       Assert Equals(Stream.of(2,1,3).sorted().to_list(), [1,2,3])
       Assert Equals(Stream.of(2,1,3,2,1).sorted().to_list(), [1,1,2,2,3])
       Assert Equals(
@@ -1067,7 +1074,7 @@ Describe Stream
 
     It sorts elements in stream with comparator
       let by_desc = 'v:val[0] > v:val[1] ? -1 : v:val[0] ==# v:val[1] ? 0 : 1'
-      Assert Equals(Stream.of().sorted(by_desc).to_list(), [])
+      Assert Equals(Stream.empty().sorted(by_desc).to_list(), [])
       Assert Equals(Stream.of(2,1,3).sorted(by_desc).to_list(), [3,2,1])
       Assert Equals(Stream.of(2,1,3,2,1).sorted(by_desc).to_list(), [3,2,2,1,1])
       Assert Equals(
@@ -1078,7 +1085,7 @@ Describe Stream
 
     It sorts elements in stream with comparator by funcref
       let by_desc = Closure.from_expr('a:1 > a:2 ? -1 : a:1 ==# a:2 ? 0 : 1')
-      Assert Equals(Stream.of().sorted(by_desc).to_list(), [])
+      Assert Equals(Stream.empty().sorted(by_desc).to_list(), [])
       Assert Equals(Stream.of(2,1,3).sorted(by_desc).to_list(), [3,2,1])
       Assert Equals(Stream.of(2,1,3,2,1).sorted(by_desc).to_list(), [3,2,2,1,1])
       Assert Equals(
@@ -1381,7 +1388,7 @@ Describe Stream
 
   Describe .string_join()
     It joins elements in stream
-      Assert Equals(Stream.of().string_join(), '')
+      Assert Equals(Stream.empty().string_join(), '')
       Assert Equals(Stream.of(1).string_join(), '1')
       Assert Equals(Stream.of(1,2,3).string_join(), '1 2 3')
       Assert Equals(Stream.of(1,2,3).string_join(','), '1,2,3')
@@ -1393,7 +1400,7 @@ Describe Stream
 
   Describe .group_by()
     It groups stream
-      Assert Equals(Stream.of().group_by('v:val'), {})
+      Assert Equals(Stream.empty().group_by('v:val'), {})
       Assert Equals(Stream.of(1).group_by('v:val'), {'1': [1]})
       Assert Equals(Stream.of(1,2,3).group_by('v:val'), {'1': [1], '2': [2], '3': [3]})
       Assert Equals(Stream.of(1,2,3,2,1).group_by('v:val'), {'1': [1,1], '2': [2,2], '3': [3]})
@@ -1407,7 +1414,7 @@ Describe Stream
         return len(a:v)
       endfunction
 
-      Assert Equals(Stream.of().group_by(function('Id')), {})
+      Assert Equals(Stream.empty().group_by(function('Id')), {})
       Assert Equals(Stream.of(1).group_by(function('Id')), {'1': [1]})
       Assert Equals(Stream.of(1,2,3).group_by(function('Id')), {'1': [1], '2': [2], '3': [3]})
       Assert Equals(Stream.of(1,2,3,2,1).group_by(function('Id')), {'1': [1,1], '2': [2,2], '3': [3]})
@@ -1422,7 +1429,7 @@ Describe Stream
       let id = Closure.from_expr('a:1')
       let len = Closure.from_funcname('len')
 
-      Assert Equals(Stream.of().group_by(id), {})
+      Assert Equals(Stream.empty().group_by(id), {})
       Assert Equals(Stream.of(1).group_by(id), {'1': [1]})
       Assert Equals(Stream.of(1,2,3).group_by(id), {'1': [1], '2': [2], '3': [3]})
       Assert Equals(Stream.of(1,2,3,2,1).group_by(id), {'1': [1,1], '2': [2,2], '3': [3]})
@@ -1437,7 +1444,7 @@ Describe Stream
 
   Describe .to_dict()
     It converts elements to Dictionary in stream
-      Assert Equals(Stream.of().to_dict('v:val', 'v:val'), {})
+      Assert Equals(Stream.empty().to_dict('v:val', 'v:val'), {})
       Assert Equals(Stream.of(1).to_dict('v:val', 'v:val'), {'1': 1})
       Assert Equals(Stream.of(1,2,3).to_dict('v:val', 'v:val'), {'1': 1, '2': 2, '3': 3})
       Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict('v:val', 'v:val'), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
@@ -1482,7 +1489,7 @@ Describe Stream
         return len(a:v)
       endfunction
 
-      Assert Equals(Stream.of().to_dict(function('Id'), function('Id')), {})
+      Assert Equals(Stream.empty().to_dict(function('Id'), function('Id')), {})
       Assert Equals(Stream.of(1).to_dict(function('Id'), function('Id')), {'1': 1})
       Assert Equals(Stream.of(1,2,3).to_dict(function('Id'), function('Id')), {'1': 1, '2': 2, '3': 3})
       Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict(function('Id'), function('Id')), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
@@ -1542,7 +1549,7 @@ Describe Stream
       let id = Closure.from_expr('a:1')
       let len = Closure.from_funcname('len')
 
-      Assert Equals(Stream.of().to_dict(id, id), {})
+      Assert Equals(Stream.empty().to_dict(id, id), {})
       Assert Equals(Stream.of(1).to_dict(id, id), {'1': 1})
       Assert Equals(Stream.of(1,2,3).to_dict(id, id), {'1': 1, '2': 2, '3': 3})
       Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict(id, id), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
@@ -1598,7 +1605,7 @@ Describe Stream
 
   Describe .sum()
     It sums elements in stream
-      Assert Equals(Stream.of().sum(), 0)
+      Assert Equals(Stream.empty().sum(), 0)
       Assert Equals(Stream.of(1,2,3).sum(), 6)
     End
   End
@@ -1606,7 +1613,7 @@ Describe Stream
   Describe .average()
     It averages elements in stream
       try
-        Assert Equals(Stream.of().average(), 0)
+        Assert Equals(Stream.empty().average(), 0)
         Assert 0
       catch /vital: Stream: average(): empty stream cannot be average()d/
         Assert 1
@@ -1619,25 +1626,25 @@ Describe Stream
 
   Describe .count()
     It counts elements in stream
-      Assert Equals(Stream.of().count(), 0)
+      Assert Equals(Stream.empty().count(), 0)
       Assert Equals(Stream.of(1,2,3).count(), 3)
       Assert Equals(Stream.iterate(1, 'v:val + 1').count(), 1/0)
     End
 
     It counts elements by predicate function in stream
-      Assert Equals(Stream.of().count('v:val'), 0)
+      Assert Equals(Stream.empty().count('v:val'), 0)
       Assert Equals(Stream.of(1,2,3).count('v:val % 2 == 0'), 1)
       Assert Equals(Stream.iterate(1, 'v:val + 1').count('v:val % 2 == 0'), 1/0)
     End
 
     It counts elements by predicate function in stream by funcref
-      Assert Equals(Stream.of().count(function('Id')), 0)
+      Assert Equals(Stream.empty().count(function('Id')), 0)
       Assert Equals(Stream.of(1,2,3).count(function('IsEven')), 1)
       Assert Equals(Stream.iterate(1, 'v:val + 1').count(function('IsEven')), 1/0)
     End
 
     It counts elements by predicate function in stream by Data.Closure
-      Assert Equals(Stream.of().count(function('Id')), 0)
+      Assert Equals(Stream.empty().count(function('Id')), 0)
       Assert Equals(Stream.of(1,2,3).count(Closure.from_expr('a:1 % 2 == 0')), 1)
       Assert Equals(Stream.iterate(1, 'v:val + 1').count(Closure.from_expr('a:1 % 2 == 0')), 1/0)
     End

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1263,7 +1263,7 @@ Describe Stream
   End
 
   Describe .string_join()
-    It sums elements in stream
+    It joins elements in stream
       Assert Equals(Stream.of().string_join(), '')
       Assert Equals(Stream.of(1).string_join(), '1')
       Assert Equals(Stream.of(1,2,3).string_join(), '1 2 3')
@@ -1275,7 +1275,7 @@ Describe Stream
   End
 
   Describe .group_by()
-    It sums elements in stream
+    It groups stream by given func
       Assert Equals(Stream.of().group_by('v:val'), {})
       Assert Equals(Stream.of(1).group_by('v:val'), {'1': [1]})
       Assert Equals(Stream.of(1,2,3).group_by('v:val'), {'1': [1], '2': [2], '3': [3]})
@@ -1283,6 +1283,110 @@ Describe Stream
       Assert Equals(Stream.of('foo', 'bar', 'baz').group_by('v:val'), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
       Assert Equals(Stream.of('a', 'bb', 'ccc').group_by('len(v:val)'), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
       Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by('len(v:val)'), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+    End
+  End
+
+  Describe .to_dict()
+    It converts elements to Dictionary in stream
+      Assert Equals(Stream.of().to_dict('v:val', 'v:val'), {})
+      Assert Equals(Stream.of(1).to_dict('v:val', 'v:val'), {'1': 1})
+      Assert Equals(Stream.of(1,2,3).to_dict('v:val', 'v:val'), {'1': 1, '2': 2, '3': 3})
+      Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict('v:val', 'v:val'), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
+      Assert Equals(Stream.of('a', 'bb', 'ccc').to_dict('len(v:val)', 'v:val'), {'1': 'a', '2': 'bb', '3': 'ccc'})
+    End
+
+    It converts elements to Dictionary in stream with merge function
+      try
+        call Stream.of(1,2,3,2,1).to_dict('v:val', 'v:val')
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
+        Assert 1
+      endtry
+      try
+        Assert Equals(
+          \Stream.of(1,2,3,2,1)
+            \.to_dict('v:val', '[v:val]', 'v:val[0] + v:val[1]'),
+          \{'1': [1,1], '2': [2,2], '3': [3]})
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
+        Assert 0
+      endtry
+
+      try
+        call Stream.of('a', 'bb', 'ccc', 'ddd').to_dict('len(v:val)', 'v:val')
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
+        Assert 1
+      endtry
+      try
+        Assert Equals(
+          \Stream.of('a', 'bb', 'ccc', 'ddd')
+            \.to_dict('len(v:val)', '[v:val]'),
+          \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
+        Assert 1
+      endtry
+    End
+
+    It converts elements to Dictionary in stream by funcref
+      function! Len(v) abort
+        return len(a:v)
+      endfunction
+
+      Assert Equals(Stream.of().to_dict(function('Id'), function('Id')), {})
+      Assert Equals(Stream.of(1).to_dict(function('Id'), function('Id')), {'1': 1})
+      Assert Equals(Stream.of(1,2,3).to_dict(function('Id'), function('Id')), {'1': 1, '2': 2, '3': 3})
+      Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict(function('Id'), function('Id')), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
+      Assert Equals(Stream.of('a', 'bb', 'ccc').to_dict(function('Len'), function('Id')), {'1': 'a', '2': 'bb', '3': 'ccc'})
+
+      delfunction Len
+    End
+
+    It converts elements to Dictionary in stream with merge function by funcref
+      function! Len(v) abort
+        return len(a:v)
+      endfunction
+      function! List(v) abort
+        return [a:v]
+      endfunction
+      function! Plus(a, b) abort
+        return a:a + a:b
+      endfunction
+
+      try
+        call Stream.of(1,2,3,2,1).to_dict(function('Id'), function('Id'))
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
+        Assert 1
+      endtry
+      try
+        Assert Equals(
+          \Stream.of(1,2,3,2,1)
+            \.to_dict(function('Id'), function('List'), function('Plus')),
+          \{'1': [1,1], '2': [2,2], '3': [3]})
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
+        Assert 0
+      endtry
+
+      try
+        call Stream.of('a', 'bb', 'ccc', 'ddd').to_dict(function('Len'), function('Id'))
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
+        Assert 1
+      endtry
+      try
+        Assert Equals(
+          \Stream.of('a', 'bb', 'ccc', 'ddd')
+            \.to_dict(function('Len'), function('List')),
+          \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+        Assert 0
+      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
+        Assert 1
+      endtry
+
+      delfunction Len
+      delfunction List
+      delfunction Plus
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1274,6 +1274,18 @@ Describe Stream
     End
   End
 
+  Describe .group_by()
+    It sums elements in stream
+      Assert Equals(Stream.of().group_by('v:val'), {})
+      Assert Equals(Stream.of(1).group_by('v:val'), {'1': [1]})
+      Assert Equals(Stream.of(1,2,3).group_by('v:val'), {'1': [1], '2': [2], '3': [3]})
+      Assert Equals(Stream.of(1,2,3,2,1).group_by('v:val'), {'1': [1,1], '2': [2,2], '3': [3]})
+      Assert Equals(Stream.of('foo', 'bar', 'baz').group_by('v:val'), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
+      Assert Equals(Stream.of('a', 'bb', 'ccc').group_by('len(v:val)'), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
+      Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by('len(v:val)'), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
+    End
+  End
+
   Describe .sum()
     It sums elements in stream
       Assert Equals(Stream.of().sum(), 0)

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -305,7 +305,49 @@ Describe Stream
 
     It constructs stream from String with characteristics
       " Use or() for SIZED flag. Use and() for other flags
+      let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6))
+      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3))
+      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      unlet s
+    End
+
+    It constructs stream with 3 or more than streams
+      Assert Equals(
+          \Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
+                \.to_list(),
+          \[[1,4,7], [2,5,8], [3,6,9]])
+
+      Assert Equals(
+          \Stream.zip(Stream.of(1), Stream.of(4,5,6), Stream.of(7,8,9))
+                \.to_list(),
+          \[[1,4,7]])
+
+      Assert Equals(
+          \Stream.zip(
+              \Stream.iterate(1, 'v:val + 1'),
+              \Stream.of(4,5,6),
+              \Stream.of(7,8,9)).to_list(),
+          \[[1,4,7], [2,5,8], [3,6,9]])
+    End
+
+    It constructs stream with 3 or more than streams with characteristics
+      " Use or() for SIZED flag. Use and() for other flags
+      let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
+      Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
+      Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
+      Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
+      Assert Equals(s.has_characteristic(Stream.SIZED()), 1)
+      Assert Equals(s.has_characteristic(Stream.IMMUTABLE()), 1)
+      let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3), Stream.of(4,5,6))
       Assert Equals(s.has_characteristic(Stream.ORDERED()), 1)
       Assert Equals(s.has_characteristic(Stream.DISTINCT()), 0)
       Assert Equals(s.has_characteristic(Stream.SORTED()), 0)
@@ -474,6 +516,35 @@ Describe Stream
       unlet s
     End
   End
+
+  " Describe .peek()
+  "   It peeks stream
+  "     let g:peek = []
+  "     call Stream.of(1,2,3).peek('let g:peek += [<VAL>]').to_list()
+  "     Assert Equals(g:peek, [1,2,3])
+  "     unlet g:peek
+  "   End
+  "
+  "   It must not reuse stream
+  "     try
+  "       let s = Stream.of(1,2,3,4,5)
+  "       call s.to_list()
+  "       call s.peek('echo')
+  "       Assert 1
+  "     catch
+  "       Assert 0
+  "     endtry
+  "     try
+  "       let s = Stream.of(1,2,3,4,5)
+  "       call s.to_list()
+  "       call s.peek('echo').to_list()
+  "       Assert 0
+  "     catch
+  "       Assert 1
+  "     endtry
+  "     unlet s
+  "   End
+  " End
 
   Describe .map()
     It maps stream

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -963,6 +963,7 @@ Describe Stream
       Assert Equals(
       \ Stream.iterate(3, 'v:val - 1').limit(3).sorted().to_list(),
       \ [1,2,3])
+      Assert Equals(Stream.of(4,5,6,1,2,3).sorted().limit(3).to_list(), [1,2,3])
     End
 
     It sorts elements by function in stream

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -2,8 +2,6 @@ Describe Stream
   Before all
     let Stream = vital#vital#import('Stream')
 
-    let DISTINCT = 0x02
-    let SORTED = 0x04
     let SIZED = 0x08
 
     function! Id(n) abort
@@ -54,8 +52,6 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.of(1,2,3)
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
   End
@@ -72,8 +68,6 @@ Describe Stream
 
     It constructs stream of each character from String with characteristics
       let s = Stream.chars("abc")
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
   End
@@ -103,8 +97,6 @@ Describe Stream
 
     It constructs stream of each line from String with characteristics
       let s = Stream.lines("abc")
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
   End
@@ -121,8 +113,6 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_list([1,2,3])
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
   End
@@ -153,8 +143,6 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.from_dict({"foo": 1, "bar": 3, "baz": 2})
-      Assert True(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
   End
@@ -167,8 +155,6 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.empty()
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
   End
@@ -251,8 +237,6 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.range(1,10)
-      Assert True(s.__has_characteristic__(DISTINCT))
-      Assert True(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
   End
@@ -278,8 +262,6 @@ Describe Stream
 
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert False(s.__has_characteristic__(SIZED))
     End
   End
@@ -373,12 +355,8 @@ Describe Stream
     It combines stream from String with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3))
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
 
@@ -420,12 +398,8 @@ Describe Stream
     It combines stream with 3 or more than streams with characteristics
       " Use or() for SIZED flag. Use and() for other flags
       let s = Stream.zip(Stream.of(1,2,3), Stream.of(4,5,6), Stream.of(7,8,9))
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
       let s = Stream.zip(Stream.iterate(0, 'v:val + 1'), Stream.of(1,2,3), Stream.of(4,5,6))
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
   End
@@ -548,12 +522,8 @@ Describe Stream
 
     It sets SIZED characteristic
       let s = Stream.of(3,4,5,6,7).take(3)
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
       let s = Stream.iterate(1, 'v:val + 1').take(3)
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert False(s.__has_characteristic__(SORTED))
       Assert True(s.__has_characteristic__(SIZED))
     End
 
@@ -1195,13 +1165,6 @@ Describe Stream
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').take(3).sorted(function('ByDesc')).to_list(),
       \ [3,2,1])
-    End
-
-    It sets SORTED characteristic
-      let s = Stream.of(1,2,3).sorted()
-      Assert False(s.__has_characteristic__(DISTINCT))
-      Assert True(s.__has_characteristic__(SORTED))
-      Assert True(s.__has_characteristic__(SIZED))
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1,7 +1,6 @@
 Describe Stream
   Before all
     let Stream = vital#vital#import('Stream')
-    let Closure = vital#vital#import('Data.Closure')
 
     let DISTINCT = 0x02
     let SORTED = 0x04
@@ -277,15 +276,6 @@ Describe Stream
       \   [5,6,7])
     End
 
-    It constructs infinite stream by Data.Closure
-      Assert Equals(
-      \   Stream.iterate(1, Closure.from_expr('a:1')).take(3).to_list(),
-      \   [1,1,1])
-      Assert Equals(
-      \   Stream.iterate(5, Closure.from_expr('a:1 + 1')).take(3).to_list(),
-      \   [5,6,7])
-    End
-
     It creates stream with characteristics
       let s = Stream.iterate(1, 'v:val + 1')
       Assert False(s.__has_characteristic__(DISTINCT))
@@ -304,12 +294,6 @@ Describe Stream
     It constructs infinite stream by funcref
       Assert Equals(
       \ Stream.generate(function('Answer')).take(5).to_list(),
-      \ [42, 42, 42, 42, 42])
-    End
-
-    It constructs infinite stream by Data.Closure
-      Assert Equals(
-      \ Stream.generate(Closure.from_expr('42')).take(5).to_list(),
       \ [42, 42, 42, 42, 42])
     End
   End
@@ -669,13 +653,6 @@ Describe Stream
       delfunction Add
     End
 
-    It peeks stream by Data.Closure
-      let g:peek = []
-      Assert Equals(Stream.of(1,2,3).peek(Closure.from_command('let g:peek += [a:1]')).to_list(), [1,2,3])
-      Assert Equals(g:peek, [1,2,3])
-      unlet g:peek
-    End
-
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -715,13 +692,6 @@ Describe Stream
       delfunction Add
     End
 
-    It peeks stream by Data.Closure
-      let g:foreach = []
-      Assert Equals(Stream.of(1,2,3).foreach(Closure.from_command('let g:foreach += [a:1]')), 0)
-      Assert Equals(g:foreach, [1,2,3])
-      unlet g:foreach
-    End
-
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -755,14 +725,6 @@ Describe Stream
 
       Assert Equals(
       \ Stream.iterate(1, 'v:val + 1').map(function('Succ')).take(3).to_list(),
-      \ [2,3,4])
-    End
-
-    It maps stream by Data.Closure
-      Assert Equals(Stream.empty().map(Closure.from_expr('a:1 + 1')).to_list(), [])
-
-      Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').map(Closure.from_expr('a:1 + 1')).take(3).to_list(),
       \ [2,3,4])
     End
 
@@ -834,15 +796,6 @@ Describe Stream
         \[1,2,2,3,3,3])
 
       delfunction Repeat
-    End
-
-    It flattens mapped stream by Data.Closure
-      Assert Equals(Stream.empty().flatmap(Closure.from_expr('repeat([a:1], a:1)')).to_list(), [])
-
-      Assert Equals(
-        \Stream.iterate(0, Closure.from_expr('a:1 + 1'))
-          \.flatmap(Closure.from_expr('repeat([a:1], a:1)')).take(6).to_list(),
-        \[1,2,2,3,3,3])
     End
 
     It must not reuse stream
@@ -958,14 +911,6 @@ Describe Stream
       \ [0,2,4])
     End
 
-    It filters stream by Data.Closure
-      Assert Equals(Stream.empty().filter(Closure.from_expr('a:1 % 2 == 0')).to_list(), [])
-
-      Assert Equals(
-      \ Stream.iterate(0, 'v:val + 1').filter(Closure.from_expr('a:1 % 2 == 0')).take(3).to_list(),
-      \ [0,2,4])
-    End
-
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -1019,19 +964,6 @@ Describe Stream
       delfunction LessThan4
     End
 
-    It takes elements until element is matched by Data.Closure
-      Assert Equals(Stream.empty().take_while(Closure.from_expr('a:1 < 4')).to_list(), [])
-      Assert Equals(
-      \ Stream.range(1, 10).take_while(Closure.from_expr('a:1 < 4')).to_list(),
-      \ [1,2,3])
-      Assert Equals(
-      \ Stream.range(1, 10).take_while(Closure.from_expr('a:1 < 4')).take(2).to_list(),
-      \ [1,2])
-      Assert Equals(
-      \ Stream.iterate(1, Closure.from_expr('a:1 + 1')).take_while(Closure.from_expr('a:1 < 4')).to_list(),
-      \ [1,2,3])
-    End
-
     It must not reuse stream
       try
         let s = Stream.of(1,2,3,4,5)
@@ -1081,18 +1013,6 @@ Describe Stream
       \ [4,5])
 
       delfunction LessThan4
-    End
-
-    It drops elements until element is matched by Data.Closure
-      Assert Equals(
-      \ Stream.empty().drop_while(Closure.from_expr('a:1 < 4')).to_list(),
-      \ [])
-      Assert Equals(
-      \ Stream.of(1,2,3,4,5).drop_while(Closure.from_expr('a:1 < 4')).to_list(),
-      \ [4,5])
-      Assert Equals(
-      \ Stream.iterate(1, Closure.from_expr('a:1 + 1')).drop_while(Closure.from_expr('a:1 < 4')).take(2).to_list(),
-      \ [4,5])
     End
 
     It must not reuse stream
@@ -1154,6 +1074,12 @@ Describe Stream
         \Stream.range(1, 3).distinct('string(v:val)').to_list(),
         \[1,2,3])
       Assert Equals(
+        \Stream.range(1, 10).distinct('v:val % 5').to_list(),
+        \[1,2,3,4,5])
+      Assert Equals(
+        \Stream.iterate(1, 'v:val + 1').take(100).distinct('v:val % 5').to_list(),
+        \[1,2,3,4,5])
+      Assert Equals(
         \Stream.range(1, 1/0).take(100).distinct('v:val % 5').to_list(),
         \[1,2,3,4,5])
     End
@@ -1193,39 +1119,21 @@ Describe Stream
         \Stream.range(1, 1/0).take(100).distinct(function('Mod5')).to_list(),
         \[1,2,3,4,5])
 
-      delfunction ValueOf
-      delfunction Mod5
-    End
-
-    It dedupes elements in stream with stringifier by Data.Closure
-      let value_of = Closure.from_expr('a:1.value')
-
-      Assert Equals(Stream.empty().distinct(value_of).to_list(), [])
       Assert Equals(
-        \Stream.of({'value': 1}, {'value': 2}, {'value': 3}).distinct(value_of).to_list(),
-        \[{'value': 1}, {'value': 2}, {'value': 3}])
-      Assert Equals(
-        \Stream.of({'value': 1}, {'value': 1}, {'value': 2}, {'value': 2}, {'value': 3}).distinct(value_of).to_list(),
-        \[{'value': 1}, {'value': 2}, {'value': 3}])
-      Assert Equals(
-        \Stream.of({'value': 1}, {'value': 2}, {'value': 3}, {'value': 2}, {'value': 3}).distinct(value_of).to_list(),
-        \[{'value': 1}, {'value': 2}, {'value': 3}])
-      Assert Equals(
-        \Stream.of({'value': 3}, {'value': 1}, {'value': 2}).distinct(value_of).to_list(),
-        \[{'value': 3}, {'value': 1}, {'value': 2}])
-      Assert Equals(
-        \Stream.of({'value': 3}, {'value': 3}, {'value': 1}, {'value': 1}, {'value': 2}).distinct(value_of).to_list(),
-        \[{'value': 3}, {'value': 1}, {'value': 2}])
-      Assert Equals(
-        \Stream.of({'value': 3}, {'value': 1}, {'value': 2}, {'value': 1}, {'value': 2}).distinct(value_of).to_list(),
-        \[{'value': 3}, {'value': 1}, {'value': 2}])
-
-      Assert Equals(
-        \Stream.range(1, 3).distinct(Closure.from_funcname('string')).to_list(),
+        \Stream.range(1, 3).distinct(function('string')).to_list(),
         \[1,2,3])
       Assert Equals(
-        \Stream.range(1, 1/0).take(100).distinct(Closure.from_expr('a:1 % 5')).to_list(),
+        \Stream.range(1, 10).distinct(function('Mod5')).to_list(),
         \[1,2,3,4,5])
+      Assert Equals(
+        \Stream.iterate(1, function('Succ')).take(100).distinct(function('Mod5')).to_list(),
+        \[1,2,3,4,5])
+      Assert Equals(
+        \Stream.range(1, 1/0).take(100).distinct(function('Mod5')).to_list(),
+        \[1,2,3,4,5])
+
+      delfunction ValueOf
+      delfunction Mod5
     End
   End
 
@@ -1262,6 +1170,12 @@ Describe Stream
       Assert Equals(
       \ Stream.range(1, 3).sorted(by_desc).to_list(),
       \ [3,2,1])
+      Assert Equals(
+      \ Stream.range(1, 1/0).take(3).sorted(by_desc).to_list(),
+      \ [3,2,1])
+      Assert Equals(
+      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(by_desc).to_list(),
+      \ [3,2,1])
     End
 
     It sorts elements in stream with comparator by funcref
@@ -1275,19 +1189,11 @@ Describe Stream
       Assert Equals(
       \ Stream.range(1, 3).sorted(function('ByDesc')).to_list(),
       \ [3,2,1])
-    End
-
-    It sorts elements in stream with comparator by Data.Closure
-      let by_desc = Closure.from_expr('a:1 > a:2 ? -1 : a:1 ==# a:2 ? 0 : 1')
-      Assert Equals(Stream.empty().sorted(by_desc).to_list(), [])
-      Assert Equals(Stream.of(2,1,3).sorted(by_desc).to_list(), [3,2,1])
-      Assert Equals(Stream.of(2,1,3,2,1).sorted(by_desc).to_list(), [3,2,2,1,1])
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(by_desc).to_list(),
+      \ Stream.range(1, 1/0).take(3).sorted(function('ByDesc')).to_list(),
       \ [3,2,1])
-
       Assert Equals(
-      \ Stream.range(1, 3).sorted(by_desc).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(function('ByDesc')).to_list(),
       \ [3,2,1])
     End
 
@@ -1385,34 +1291,6 @@ Describe Stream
 
       delfunction Plus
     End
-
-    It accumulates stream by Data.Closure
-      Assert Equals(Stream.empty().reduce(Closure.from_expr('a:1'), 42), 42)
-      Assert Equals(Stream.of(1).reduce(Closure.from_operator('+')), 1)
-      Assert Equals(Stream.of(1,2,3,4,5).reduce(Closure.from_operator('+')), 15)
-      Assert Equals(Stream.of(1,2,3,4,5).reduce(Closure.from_operator('+'), 0), 15)
-      Assert Equals(Stream.of(1,2,3).reduce(Closure.from_funcname('insert'), []), [3,2,1])
-    End
-  End
-
-  Describe .max()
-    It raises exception for empty stream
-      try
-        call Stream.empty().max()
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().max(42), 42)
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 0
-      endtry
-    End
-
-    It returns max value in stream
-      Assert Equals(Stream.of(1,2,3,4,5).max(), 5)
-    End
   End
 
   Describe .max_by()
@@ -1443,30 +1321,6 @@ Describe Stream
 
       delfunction Len
     End
-
-    It returns max value in stream by Data.Closure
-      Assert Equals(Stream.of('aaa', 'bb', '').max_by(Closure.from_funcname('len')), 'aaa')
-    End
-  End
-
-  Describe .min()
-    It raises exception for empty stream
-      try
-        call Stream.empty().min()
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().min(42), 42)
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 0
-      endtry
-    End
-
-    It returns min value in stream
-      Assert Equals(Stream.of(1,2,3,4,5).min(), 1)
-    End
   End
 
   Describe .min_by()
@@ -1496,10 +1350,6 @@ Describe Stream
       Assert Equals(Stream.of('aaa', 'bb', '').min_by(function('Len')), '')
 
       delfunction Len
-    End
-
-    It returns min value in stream by Data.Closure
-      Assert Equals(Stream.of('aaa', 'bb', '').min_by(Closure.from_funcname('len')), '')
     End
   End
 
@@ -1567,10 +1417,6 @@ Describe Stream
     It returns the first element matching with given predicate function in stream by funcref
       Assert Equals(Stream.iterate(1, function('Succ')).find(function('IsEven')), 2)
     End
-
-    It returns the first element matching with given predicate function in stream by Data.Closure
-      Assert Equals(Stream.iterate(1, Closure.from_expr('a:1 + 1')).find(Closure.from_expr('a:1 % 2 == 0')), 2)
-    End
   End
 
   Describe .any()
@@ -1594,12 +1440,6 @@ Describe Stream
 
       delfunction GreaterThan2
       delfunction GreaterThan3
-    End
-
-    It returns true if any of elements are matched in stream by Data.Closure
-      Assert False(Stream.empty().any(Closure.from_expr('a:1')))
-      Assert True(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 2')))
-      Assert False(Stream.of(1,2,3).any(Closure.from_expr('a:1 > 3')))
     End
   End
 
@@ -1625,12 +1465,6 @@ Describe Stream
       delfunction GreaterThan0
       delfunction GreaterThan1
     End
-
-    It returns true if all of elements are matched in stream by Data.Closure
-      Assert True(Stream.empty().all(Closure.from_expr('a:1')))
-      Assert True(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 0')))
-      Assert False(Stream.of(1,2,3).all(Closure.from_expr('a:1 > 1')))
-    End
   End
 
   Describe .none()
@@ -1654,12 +1488,6 @@ Describe Stream
 
       delfunction GreaterThan3
       delfunction GreaterThan2
-    End
-
-    It returns true if none of elements are matched in stream by Data.Closure
-      Assert True(Stream.empty().none(Closure.from_expr('a:1')))
-      Assert True(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 3')))
-      Assert False(Stream.of(1,2,3).none(Closure.from_expr('a:1 > 2')))
     End
   End
 
@@ -1710,23 +1538,6 @@ Describe Stream
 
       delfunction Len
       delfunction EvenOrOdd
-    End
-
-    It groups stream by Data.Closure
-      let id = Closure.from_expr('a:1')
-      let len = Closure.from_funcname('len')
-      let even_or_odd = Closure.from_expr('a:1 % 2 == 0 ? "even" : "odd"')
-
-      Assert Equals(Stream.empty().group_by(id), {})
-      Assert Equals(Stream.of(1).group_by(id), {'1': [1]})
-      Assert Equals(Stream.of(1,2,3).group_by(id), {'1': [1], '2': [2], '3': [3]})
-      Assert Equals(Stream.of(1,2,3,2,1).group_by(id), {'1': [1,1], '2': [2,2], '3': [3]})
-      Assert Equals(Stream.of('foo', 'bar', 'baz').group_by(id), {'foo': ['foo'], 'bar': ['bar'], 'baz': ['baz']})
-      Assert Equals(Stream.of('a', 'bb', 'ccc').group_by(len), {'1': ['a'], '2': ['bb'], '3': ['ccc']})
-      Assert Equals(Stream.of('a', 'bb', 'ccc', 'ddd').group_by(len), {'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
-      Assert Equals(
-        \Stream.of(1,2,3,4,5).group_by(even_or_odd),
-        \{'even': [2,4], 'odd': [1,3,5]})
     End
   End
 
@@ -1834,54 +1645,6 @@ Describe Stream
       delfunction List
       delfunction Plus
     End
-
-    It converts elements to Dictionary in stream by Data.Closure
-      let id = Closure.from_expr('a:1')
-      let len = Closure.from_funcname('len')
-
-      Assert Equals(Stream.empty().to_dict(id, id), {})
-      Assert Equals(Stream.of(1).to_dict(id, id), {'1': 1})
-      Assert Equals(Stream.of(1,2,3).to_dict(id, id), {'1': 1, '2': 2, '3': 3})
-      Assert Equals(Stream.of('foo', 'bar', 'baz').to_dict(id, id), {'foo': 'foo', 'bar': 'bar', 'baz': 'baz'})
-      Assert Equals(Stream.of('a', 'bb', 'ccc').to_dict(len, id), {'1': 'a', '2': 'bb', '3': 'ccc'})
-    End
-
-    It converts elements to Dictionary in stream with merge function by Data.Closure
-      let id = Closure.from_expr('a:1')
-      let len = Closure.from_funcname('len')
-      let list = Closure.from_expr('[a:1]')
-      let plus = Closure.from_operator('+')
-
-      try
-        call Stream.of(1,2,3,2,1).to_dict(id, id)
-        Assert 0
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
-        Assert 1
-      endtry
-      try
-        Assert Equals(
-          \Stream.of(1,2,3,2,1)
-            \.to_dict(id, list, plus),
-          \{'1': [1,1], '2': [2,2], '3': [3]})
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '2')/
-        Assert 0
-      endtry
-
-      try
-        call Stream.of('a', 'bb', 'ccc', 'ddd').to_dict(len, id)
-        Assert 0
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 1
-      endtry
-      try
-        Assert Equals(
-          \Stream.of('a', 'bb', 'ccc', 'ddd')
-            \.to_dict(len, list, plus),
-          \{'1': ['a'], '2': ['bb'], '3': ['ccc', 'ddd']})
-      catch /vital: Stream: to_dict(): duplicated elements exist in stream (key: '3')/
-        Assert 0
-      endtry
-    End
   End
 
   Describe .sum()
@@ -1922,12 +1685,6 @@ Describe Stream
       Assert Equals(Stream.empty().count(function('Id')), 0)
       Assert Equals(Stream.of(1,2,3).count(function('IsEven')), 1)
       Assert Equals(Stream.iterate(1, 'v:val + 1').count(function('IsEven')), 1/0)
-    End
-
-    It counts elements by predicate function in stream by Data.Closure
-      Assert Equals(Stream.empty().count(function('Id')), 0)
-      Assert Equals(Stream.of(1,2,3).count(Closure.from_expr('a:1 % 2 == 0')), 1)
-      Assert Equals(Stream.iterate(1, 'v:val + 1').count(Closure.from_expr('a:1 % 2 == 0')), 1/0)
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1,6 +1,6 @@
 Describe Stream
   Before all
-    let Stream = vital#vital#new().import('Stream')
+    let Stream = vital#vital#import('Stream')
 
     function! Id(n) abort
       return a:n

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1205,61 +1205,6 @@ Describe Stream
     End
   End
 
-  Describe .get_comparator()
-    It raises exception if comparator is not defined
-      try
-        call Stream.empty().sorted().get_comparator()
-        Assert 0
-      catch /vital: Stream: get_comparator(): comparator not found and default argument was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().sorted().get_comparator(42), 42)
-      catch /vital: Stream: get_comparator(): comparator not found and default argument was not given/
-        Assert 0
-      endtry
-    End
-
-    It raises exception if SORTED flag is not set
-      try
-        call Stream.empty().get_comparator()
-        Assert 0
-      catch /vital: Stream: get_comparator(): comparator not found and default argument was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().get_comparator(42), 42)
-      catch /vital: Stream: get_comparator(): comparator not found and default argument was not given/
-        Assert 0
-      endtry
-
-      let by_desc = 'v:val[0] > v:val[1] ? -1 : v:val[0] ==# v:val[1] ? 0 : 1'
-
-      " map() clears SORTED flag
-      Assert Equals(Stream.of(1,2).sorted(by_desc).map('v:val').get_comparator('NONE'), 'NONE')
-
-      " flatmap() clears SORTED flag
-      Assert Equals(Stream.of(1,2).sorted(by_desc).flatmap('[v:val]').get_comparator('NONE'), 'NONE')
-
-      " concat() clears SORTED flag
-      Assert Equals(Stream.of(1,2).sorted(by_desc).concat(Stream.of(3,4)).get_comparator('NONE'), 'NONE')
-      Assert Equals(Stream.of(1,2).concat(Stream.of(3,4).sorted(by_desc)).get_comparator('NONE'), 'NONE')
-
-      " zip() clears SORTED flag
-      Assert Equals(Stream.of(1,2).sorted(by_desc).zip(Stream.of(3,4)).get_comparator('NONE'), 'NONE')
-      Assert Equals(Stream.of(1,2).zip(Stream.of(3,4).sorted(by_desc)).get_comparator('NONE'), 'NONE')
-    End
-
-    It finds a comparator from a upstream
-      let by_desc = 'v:val[0] > v:val[1] ? -1 : v:val[0] ==# v:val[1] ? 0 : 1'
-      Assert Equals(Stream.empty().sorted(by_desc).get_comparator(), by_desc)
-      Assert Equals(Stream.of(1,2).sorted(by_desc).get_comparator(), by_desc)
-
-      Assert Equals(Stream.of(1,2).sorted(by_desc).take(1).get_comparator(), by_desc)
-      Assert Equals(Stream.of(1,2).sorted(by_desc).drop(1).get_comparator(), by_desc)
-    End
-  End
-
   Describe .reduce()
     It raises exception for empty stream
       try
@@ -1290,66 +1235,6 @@ Describe Stream
       Assert Equals(Stream.of(1,2,3).reduce(function('insert'), []), [3,2,1])
 
       delfunction Plus
-    End
-  End
-
-  Describe .max_by()
-    It raises exception for empty stream
-      try
-        call Stream.empty().max_by('v:val')
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().max_by('v:val', 42), 42)
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 0
-      endtry
-    End
-
-    It returns max value in stream
-      Assert Equals(Stream.of('aaa', 'bb', '').max_by('len(v:val)'), 'aaa')
-    End
-
-    It returns max value in stream by funcref
-      function! Len(v) abort
-        return len(a:v)
-      endfunction
-
-      Assert Equals(Stream.of('aaa', 'bb', '').max_by(function('Len')), 'aaa')
-
-      delfunction Len
-    End
-  End
-
-  Describe .min_by()
-    It raises exception for empty stream
-      try
-        call Stream.empty().min_by('v:val')
-        Assert 0
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 1
-      endtry
-      try
-        Assert Equals(Stream.empty().min_by('v:val', 42), 42)
-      catch /vital: Stream: \w\+(): stream is empty and default value was not given/
-        Assert 0
-      endtry
-    End
-
-    It returns min value in stream
-      Assert Equals(Stream.of('aaa', 'bb', '').min_by('len(v:val)'), '')
-    End
-
-    It returns min value in stream by funcref
-      function! Len(v) abort
-        return len(a:v)
-      endfunction
-
-      Assert Equals(Stream.of('aaa', 'bb', '').min_by(function('Len')), '')
-
-      delfunction Len
     End
   End
 
@@ -1488,18 +1373,6 @@ Describe Stream
 
       delfunction GreaterThan3
       delfunction GreaterThan2
-    End
-  End
-
-  Describe .string_join()
-    It joins elements in stream
-      Assert Equals(Stream.empty().string_join(), '')
-      Assert Equals(Stream.of(1).string_join(), '1')
-      Assert Equals(Stream.of(1,2,3).string_join(), '1 2 3')
-      Assert Equals(Stream.of(1,2,3).string_join(','), '1,2,3')
-      Assert Equals(Stream.of('foo').string_join(), 'foo')
-      Assert Equals(Stream.of('foo', 'bar', 'baz').string_join(), 'foo bar baz')
-      Assert Equals(Stream.of('foo', 'bar', 'baz').string_join(','), 'foo,bar,baz')
     End
   End
 
@@ -1644,27 +1517,6 @@ Describe Stream
       delfunction Len
       delfunction List
       delfunction Plus
-    End
-  End
-
-  Describe .sum()
-    It sums elements in stream
-      Assert Equals(Stream.empty().sum(), 0)
-      Assert Equals(Stream.of(1,2,3).sum(), 6)
-    End
-  End
-
-  Describe .average()
-    It averages elements in stream
-      try
-        call Stream.empty().average()
-        Assert 0
-      catch /vital: Stream: average(): empty stream cannot be average()d/
-        Assert 1
-      endtry
-      Assert Equals(Stream.of(2).average(), 2)
-      Assert Equals(Stream.of(1,2,3).average(), 2)
-      Assert Equals(Stream.of(-5,0,5).average(), 0)
     End
   End
 

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -881,6 +881,82 @@ Describe Stream
     End
   End
 
+  Describe .slice_before()
+    It maps stream
+      let is_even = 'v:val % 2 == 0'
+      let is_multiple_of_3 = 'v:val % 3 == 0'
+
+      " empty stream
+      Assert Equals(Stream.empty().slice_before(is_even).to_list(), [])
+
+      " finite stream (is_even)
+      Assert Equals(
+      \ Stream.of(0,1,2,3,4,5).slice_before(is_even).to_list(),
+      \ [[0,1], [2,3], [4,5]])
+
+      Assert Equals(
+      \ Stream.of(1,2,3,4,5).slice_before(is_even).to_list(),
+      \ [[1], [2,3], [4,5]])
+
+      Assert Equals(
+      \ Stream.of(0,1,2,3,4).slice_before(is_even).to_list(),
+      \ [[0,1], [2,3], [4]])
+
+      Assert Equals(
+      \ Stream.of(1,2,3,4).slice_before(is_even).to_list(),
+      \ [[1], [2,3], [4]])
+
+      " finite stream (is_multiple_of_3)
+      Assert Equals(
+      \ Stream.of(0,1,2,3,4,5).slice_before(is_multiple_of_3).to_list(),
+      \ [[0,1,2], [3,4,5]])
+
+      Assert Equals(
+      \ Stream.of(1,2,3,4,5).slice_before(is_multiple_of_3).to_list(),
+      \ [[1,2], [3,4,5]])
+
+      Assert Equals(
+      \ Stream.of(0,1,2,3,4).slice_before(is_multiple_of_3).to_list(),
+      \ [[0,1,2], [3,4]])
+
+      Assert Equals(
+      \ Stream.of(1,2,3,4).slice_before(is_multiple_of_3).to_list(),
+      \ [[1,2], [3,4]])
+
+      " inifinite stream
+      Assert Equals(
+      \ Stream.iterate(1, 'v:val + 1').slice_before(is_even).limit(3).to_list(),
+      \ [[1], [2,3], [4,5]])
+
+      Assert Equals(
+      \ Stream.iterate(0, 'v:val + 1').slice_before(is_even).limit(3).to_list(),
+      \ [[0,1], [2,3], [4,5]])
+
+      Assert Equals(
+      \ Stream.iterate(1, 'v:val + 1').slice_before(is_even).limit(3).to_list(),
+      \ [[1], [2,3], [4,5]])
+    End
+
+    It must not reuse stream
+      try
+        let s = Stream.of(1,2,3,4,5)
+        call s.to_list()
+        call s.slice_before('v:val')
+        Assert 1
+      catch
+        Assert 0
+      endtry
+      try
+        let s = Stream.of(1,2,3,4,5)
+        call s.to_list()
+        call s.slice_before('v:val').to_list()
+        Assert 0
+      catch
+        Assert 1
+      endtry
+    End
+  End
+
   Describe .filter()
     It filters stream
       Assert Equals(Stream.empty().filter('v:val % 2 == 0').to_list(), [])

--- a/test/Stream.vimspec
+++ b/test/Stream.vimspec
@@ -1277,13 +1277,13 @@ Describe Stream
 
   Describe .sorted()
     Before all
-      function! Compare(a, b) abort
+      function! Comp(a, b) abort
         return a:a > a:b ? -1 : a:a ==# a:b ? 0 : 1
       endfunction
     End
 
     After all
-      delfunction Compare
+      delfunction Comp
     End
 
     It sorts elements in stream without comparator
@@ -1307,11 +1307,11 @@ Describe Stream
     End
 
     It sorts elements in stream with comparator by funcref
-      Assert Equals(Stream.empty().sorted(function('Compare')).to_list(), [])
-      Assert Equals(Stream.of(2,1,3).sorted(function('Compare')).to_list(), [3,2,1])
-      Assert Equals(Stream.of(2,1,3,2,1).sorted(function('Compare')).to_list(), [3,2,2,1,1])
+      Assert Equals(Stream.empty().sorted(function('Comp')).to_list(), [])
+      Assert Equals(Stream.of(2,1,3).sorted(function('Comp')).to_list(), [3,2,1])
+      Assert Equals(Stream.of(2,1,3,2,1).sorted(function('Comp')).to_list(), [3,2,2,1,1])
       Assert Equals(
-      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(function('Compare')).to_list(),
+      \ Stream.iterate(1, 'v:val + 1').take(3).sorted(function('Comp')).to_list(),
       \ [3,2,1])
     End
 


### PR DESCRIPTION
Add 'Stream' module, that the API is made to resemble Java 8 Stream API.

# Purpose

This module provides:

* **Laziness** like Data.LazyList
* **chaining** like [underscore.vim](https://github.com/haya14busa/underscore.vim)
* Functional interface focusing what you want than how you solve a problem
  * Stream module builds execution plan instead of you
* An interface of stream generation function like Java's Spliterator.
  See generator() document
* A higher-order functions that support string expression, funcref, Data.Closure
  * String expression: `s:Stream.of(1,2,3).map('v:val * 2')`
  * Funcref (lambda): `s:Stream.of(1,2,3).map({n -> n * 2})`
  * Data.Closure: `s:Stream.of(1,2,3).map(s:Closure.from_expr('a:1 * 2'))`

# Example

https://gist.github.com/tyru/d48ad6f7e5b0db45f187606b10b6f42b

```viml
" Random generator (linear congruential generators)
function! s:make_rand() abort
  let seed = reltime()[1]
  let max = float2nr(pow(2, 31) - 1)
  " rand generates random numbers.
  " skip(): the first number seems too small...
  " map(): limits to 0.0 <= val <= 1.0
  " distinct(): gets rid of the same second decimal place of numbers
  return s:Stream.iterate(seed, '(48271 * v:val) % '.max)
                \.skip(1)
                \.map('v:val / '.max.'.0')
                \.distinct('float2nr(round(v:val * 100))')
endfunction

" echo 20 random numbers
for d in s:make_rand().limit(20).to_list()
  echo d
endfor
```

# Limitation

A stream is not reusable as same as Java Stream API.
This limitation enables internal optimization in the point of view of immutability.

```viml
" This throws 'vital: Stream: stream has already been operated upon or closed'
let s = Stream.of([1,2,3,4,5])
call s.map('v:val + 1').to_list()
call s.map('v:val + 1').to_list()
```

# TODO

- Support interface of iterator function like Java's `Spliterator`
  - ~Add `Stream.iterator(dict)` and `dict` is Dictionary which has:~
    - ~`dict.has_next(times)`~
    - ~`dict.next(times)`~
    - `Stream.generator(dict)` is simpler version
  - [x] Add `Stream.generator(dict)` and `dict` is Dictionary which has:
    - `dict.yield(times, NONE)`: returns `NONE` if no more values. otherwise returns a value of stream
- higher-order functions like Stream.map(), Stream.filter() takes String (expression containing v:val), Funcref, Data.Closure
  - [x] iterate(init, func)
  - [x] generate(func)
  - [x] Stream.peek(func)
  - [x] Stream.map(func)
  - [x] Stream.flatmap(func)
  - [x] Stream.filter(func)
  - [x] Stream.slice_before(func)
  - [x] Stream.foreach(func)
  - [x] Stream.take_while(func)
  - [x] Stream.drop_while(func)
  - [x] Stream.sorted([comparator])
  - [x] Stream.reduce(func [, init])
  - [x] Stream.max_by(func [, default])
  - [x] Stream.min_by(func [, default])
  - [x] Stream.find(func [, default])
  - [x] Stream.any(func)
  - [x] Stream.all(func)
  - [x] Stream.none(func)
  - [x] Stream.to_dict(key_mapper, value_mapper [, mergefunc])
  - [x] Stream.group_by(func)
- ~Use Data.Optional in some methods~ Throw exception in some methods if stream is empty and default argument was not given
  - [x] Stream.max([default])
  - [x] Stream.max_by(func [, default])
  - [x] Stream.min([default])
  - [x] Stream.min_by(func [, default])
  - [x] Stream.first([default])
  - [x] Stream.last([default])
  - [x] Stream.find(func [, default])
  - [x] Stream.get_comparator([default])
- ~Throw exception if upstream is infinite stream~ It cannot determine if infinite stream stops! 22be22deac4dba4903fb593cc8c0b7c4b56fdcea
  - sorted([comparator])
  - to_list()
  - collect()
  - reduce(func [, init])
  - average()
  - sum()
  - max()
  - max_by()
  - min()
  - min_by()
  - ~count([func])~
    - It returns 1/0
  - ~foreach()~
    - In general, users may want to do a process with side-effects when calling foreach(), or may want infinite loop.

## Functions

- [x] of(list)
- [x] chars(str [, characteristics])
- [x] lines(str [, characteristics])
- [x] from_list(list [, characteristics])
- [x] from_dict(dict [, characteristics])
- [x] empty()
- [x] zip(stream1, stream2, ...)
- [x] concat(stream1, stream2, ...)
- [x] iterate(init, func)
- [x] generate(func)
- ~range(start_inclusive, end_exclusive)~
- ~range_closed(start_inclusive, end_inclusive)~
- [x] range({expr} [, {max} [, {stride}]])
  - same as Vim script's `range()`

## Methods

- [x] Stream.has_characteristics(characteristics)
- [x] Stream.get_comparator([default])

- [x] Stream.zip(stream, ...)
- [x] Stream.zip_with_index()
- [x] Stream.concat(stream, ...)
- [x] Stream.peek(func)
- [x] Stream.map(func)
- [x] Stream.flatmap(func)
- [x] Stream.filter(func)
- [x] Stream.slice_before(func)
- [x] Stream.foreach(func)
- [x] Stream.skip(n)
- [x] Stream.limit(n)
- [x] Stream.take_while(func)
- [x] Stream.drop_while(func)
- [x] Stream.distinct([stringifier])
- [x] Stream.sorted([comparator])

- [x] Stream.to_list()
- [x] Stream.count([func])
- ~Stream.collect(collector)~
  - maybe unnecessary because there are `to_list()`, `foreach()`, or any other terminal operations
- ~Stream.collect(supplier, accumulator)~
  - maybe unnecessary because Vim script does not have so many data types like Java containers
- [x] Stream.reduce(func [, init])
- [x] Stream.average()
- [x] Stream.sum()
- [x] Stream.max([default])
- [x] Stream.max_by(func [, default])
- [x] Stream.min([default])
- [x] Stream.min_by(func [, default])
- [x] Stream.first([default])
- Stream.find_any([default])
  - same as first() in this module because Vim script does not have thread
- [x] Stream.find(func [, default])
  - same as `filter(func).limit(1).first(default)`
- [x] Stream.last([default])
- [x] Stream.any(func)
- [x] Stream.all(func)
- [x] Stream.none(func)

- ~Collectors.to_list()~
  - unnecessary. because Stream has already Stream.to_list().
- ~Collectors.to_dict(key_mapper, value_mapper [, mergefunc])~
- [x] Stream.to_dict(key_mapper, value_mapper [, mergefunc])
  - if stream is 'DISTINCT', duplication check is not performed
- ~Collectors.joining([sep])~
- [x] Stream.string_join([sep])
  - ~if no sep was given, joined by empty string~
  - if no sep was given, joined by " " (one whitespace) as well as Vim script's `join()`)
- ~Collectors.partitioning_by(func)~
- Stream.partition_by(func)
  - maybe unnecessary because Stream.group_by(func) is generalized version?
- ~Collectors.grouping_by(func)~
- [x] Stream.group_by(func)

# TODO (not implemented in this PR)

## Functions

- from_channel(channel [, characteristics])

## Methods

- Comparator.comparing(prop, is_func)
- Comparator.comparing(prop, is_func).thenComparing(prop, is_func)
- Comparator.comparing(prop, is_func).reverse()