### PR TITLE
Add Validator.Args module

### DIFF
--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -53,7 +53,7 @@ function! s:of(prefix) abort
     endif
     let self._asserts[a:no - 1] = {
     \ 'funclist': type(a:funclist) is s:TYPE.LIST ? a:funclist : [a:funclist],
-    \ 'msg': get(a:000, 0, 'the ' . a:no . 'th argument''s assertion failed')
+    \ 'msg': get(a:000, 0, 'the ' . a:no . 'th argument''s assertion was failed')
     \}
     return self
   endfunction

--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -32,12 +32,16 @@ function! s:_vital_created(module) abort
 endfunction
 
 
-function! s:of(prefix) abort
+function! s:of(prefix, ...) abort
   if type(a:prefix) isnot s:TYPE.STRING
     throw 'vital: Validator.Args: of(): expected String argument ' .
     \     'but got ' . s:TYPES[type(a:prefix)]
   endif
-  let validator = {'_prefix': a:prefix, '_asserts': {}}
+  let validator = {
+  \ '_prefix': a:prefix,
+  \ '_asserts': {},
+  \ '_enable': !!get(a:000, 0, 1),
+  \}
   function! validator.type(...) abort
     call s:_check_type_args(a:000)
     for index in keys(self._asserts)
@@ -58,6 +62,9 @@ function! s:of(prefix) abort
     return self
   endfunction
   function! validator.validate(args) abort
+    if !self._enable
+      return a:args
+    endif
     if type(a:args) isnot s:TYPE.LIST
       throw 'vital: Validator.Args: Validator.validate(): expected List argument ' .
       \     'but got ' . s:TYPES[type(a:args)]

--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -34,7 +34,7 @@ endfunction
 
 function! s:of(prefix) abort
   if type(a:prefix) isnot s:TYPE.STRING
-    throw 'Validator.Args: of(): expected String argument ' .
+    throw 'vital: Validator.Args: of(): expected String argument ' .
     \     'but got ' . s:TYPES[type(a:prefix)]
   endif
   let validator = {'_prefix': a:prefix, '_asserts': {}}
@@ -59,7 +59,7 @@ function! s:of(prefix) abort
   endfunction
   function! validator.validate(args) abort
     if type(a:args) isnot s:TYPE.LIST
-      throw 'Validator.Args: Validator.validate(): expected List argument ' .
+      throw 'vital: Validator.Args: Validator.validate(): expected List argument ' .
       \     'but got ' . s:TYPES[type(a:args)]
     endif
     if has_key(self, '_types')
@@ -78,7 +78,7 @@ function! s:_check_type_args(args) abort
     if a:args[i] is s:TYPE.OPTARG
       let optarg += 1
       if optarg > 1
-        throw 'Validator.Args: Validator.type(): multiple OPTARG were given'
+        throw 'vital: Validator.Args: Validator.type(): multiple OPTARG were given'
       endif
     endif
     if !(type(a:args[i]) is s:TYPE.NUMBER &&
@@ -88,7 +88,7 @@ function! s:_check_type_args(args) abort
     \     empty(filter(copy(a:args[i]),
     \                  'type(v:val) isnot s:TYPE.NUMBER || ' .
     \                  'v:val < s:TYPE.NUMBER || v:val > s:TYPE.CHANNEL')))
-      throw 'Validator.Args: Validator.type(): expected type or union types ' .
+      throw 'vital: Validator.Args: Validator.type(): expected type or union types ' .
       \     'but got ' . s:TYPES[type(a:args[i])]
     endif
   endfor
@@ -97,7 +97,7 @@ endfunction
 function! s:_check_assert_args(args) abort
   let no = a:args[0]
   if no <= 0
-    throw 'Validator.Args: Validator.assert(): ' .
+    throw 'vital: Validator.Args: Validator.assert(): ' .
     \     'the first argument number was not positive'
   endif
 endfunction
@@ -110,7 +110,7 @@ function! s:_check_out_of_range(no, types) abort
     else
       let arity = len(a:types)
     endif
-    throw 'Validator.Args: Validator.assert(): ' .
+    throw 'vital: Validator.Args: Validator.assert(): ' .
     \     'the first argument number was out of range ' .
     \     '(type() defines ' . arity . ' arguments)'
   endif

--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -21,21 +21,23 @@ let s:TYPE.ANY = range(s:TYPE.NUMBER, s:TYPE.CHANNEL)
 let s:TYPE.OPTARG = []
 lockvar! s:TYPE
 
-let s:TYPES = ['Number', 'String', 'Funcref', 'List', 'Dictionary', 'Float']
-if v:version >=# 800
-  let s:TYPES += ['Bool', 'None', 'Job', 'Channel']
-endif
-lockvar! s:TYPES
+function! s:_vital_loaded(V) abort
+  let s:T = a:V.import('Vim.Type')
+endfunction
 
 function! s:_vital_created(module) abort
   let a:module.TYPE = s:TYPE
 endfunction
 
+function! s:_vital_depends() abort
+  return ['Vim.Type']
+endfunction
+
 
 function! s:of(prefix, ...) abort
   if type(a:prefix) isnot s:TYPE.STRING
-    throw 'vital: Validator.Args: of(): expected String argument ' .
-    \     'but got ' . s:TYPES[type(a:prefix)]
+    throw 'vital: Validator.Args: of(): expected ' . s:T.type_names[s:TYPE.STRING] .
+    \     ' argument but got ' . s:T.type_names[type(a:prefix)]
   endif
   let validator = {
   \ '_prefix': a:prefix,
@@ -66,8 +68,8 @@ function! s:of(prefix, ...) abort
       return a:args
     endif
     if type(a:args) isnot s:TYPE.LIST
-      throw 'vital: Validator.Args: Validator.validate(): expected List argument ' .
-      \     'but got ' . s:TYPES[type(a:args)]
+      throw 'vital: Validator.Args: Validator.validate(): expected ' . s:T.type_names[s:TYPE.LIST] .
+      \     ' argument but got ' . s:T.type_names[type(a:args)]
     endif
     if has_key(self, '_types')
       call s:_validate_arg_types(a:args, self._types, self._prefix)
@@ -97,7 +99,7 @@ function! s:_check_type_args(args) abort
     \                  'type(v:val) isnot s:TYPE.NUMBER || ' .
     \                  'v:val < s:TYPE.NUMBER || v:val > s:TYPE.CHANNEL')))
       throw 'vital: Validator.Args: Validator.type(): expected type or union types ' .
-      \     'but got ' . s:TYPES[type(a:args[i])]
+      \     'but got ' . s:T.type_names[type(a:args[i])]
     endif
   endfor
 endfunction
@@ -159,10 +161,10 @@ function! s:_validate_type(value, expected_type, prefix, ...) abort
       if a:0
         return a:1
       endif
-      let expected = join(map(copy(a:expected_type), 's:TYPES[v:val]'), ' or ')
+      let expected = join(map(copy(a:expected_type), 's:T.type_names[v:val]'), ' or ')
       throw a:prefix . ': invalid type arguments were given ' .
       \     '(expected: ' . expected .
-      \     ', got: ' . s:TYPES[type(a:value)] . ')'
+      \     ', got: ' . s:T.type_names[type(a:value)] . ')'
     endif
     return
   endif
@@ -171,8 +173,8 @@ function! s:_validate_type(value, expected_type, prefix, ...) abort
       return a:1
     endif
     throw a:prefix . ': invalid type arguments were given ' .
-    \     '(expected: ' . s:TYPES[a:expected_type] .
-    \     ', got: ' . s:TYPES[type(a:value)] . ')'
+    \     '(expected: ' . s:T.type_names[a:expected_type] .
+    \     ', got: ' . s:T.type_names[type(a:value)] . ')'
   endif
   return a:value
 endfunction

--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -68,6 +68,7 @@ function! s:of(prefix) abort
     if !empty(self._asserts)
       call s:_validate_arg_assert(a:args, self._asserts, self._prefix)
     endif
+    return a:args
   endfunction
   return validator
 endfunction

--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -1,0 +1,151 @@
+" Arguments validation library
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+let s:NONE = []
+lockvar! s:NONE
+
+let s:TYPE = {}
+let s:TYPE.NUMBER = 0
+let s:TYPE.STRING = 1
+let s:TYPE.FUNC = 2
+let s:TYPE.LIST = 3
+let s:TYPE.DICT = 4
+let s:TYPE.FLOAT = 5
+let s:TYPE.BOOL = 6
+let s:TYPE.NONE = 7
+let s:TYPE.JOB = 8
+let s:TYPE.CHANNEL = 9
+let s:TYPE.ANY = range(s:TYPE.NUMBER, s:TYPE.CHANNEL)
+let s:TYPE.OPTARG = []
+lockvar! s:TYPE
+
+let s:TYPES = ['Number', 'String', 'Funcref', 'List', 'Dictionary', 'Float']
+if v:version >=# 800
+  let s:TYPES += ['Bool', 'None', 'Job', 'Channel']
+endif
+lockvar! s:TYPES
+
+function! s:_vital_created(module) abort
+  let a:module.TYPE = s:TYPE
+endfunction
+
+
+function! s:of(prefix) abort
+  if type(a:prefix) isnot s:TYPE.STRING
+    throw 'Validator.Args: of(): expected String argument ' .
+    \     'but got ' . s:TYPES[type(a:prefix)]
+  endif
+  let validator = {'_prefix': a:prefix, '_asserts': {}}
+  function! validator.type(...) abort
+    if len(filter(copy(a:000), 'v:val is s:TYPE.OPTARG')) >= 2
+      throw 'Validator.Args: multiple OPTARG were given'
+    endif
+    let self._types = a:000
+    return self
+  endfunction
+  function! validator.assert(no, funclist, ...) abort
+    let self._asserts[a:no - 1] = {
+    \ 'funclist': type(a:funclist) is s:TYPE.LIST ? a:funclist : [a:funclist],
+    \ 'msg': get(a:000, 0, 'the ' . a:no . 'th argument''s assertion failed')
+    \}
+    return self
+  endfunction
+  function! validator.validate(args) abort
+    if type(a:args) isnot s:TYPE.LIST
+      throw 'Validator.Args: Validator.validate(): expected List argument ' .
+      \     'but got ' . s:TYPES[type(a:args)]
+    endif
+    if has_key(self, '_types')
+      call s:_validate_arg_types(a:args, self._types, self._prefix)
+    endif
+    if !empty(self._asserts)
+      call s:_validate_arg_assert(a:args, self._asserts, self._prefix)
+    endif
+  endfunction
+  return validator
+endfunction
+
+function! s:_validate_arg_types(args, types, prefix) abort
+  let optarg = 0
+  let typelen = len(a:types)
+  let argslen = len(a:args)
+  let i = 0
+  while i < argslen
+    if i + optarg >= typelen
+      if optarg && a:types[-1] is s:TYPE.OPTARG
+        break
+      else
+        throw a:prefix . ': too many arguments'
+      endif
+    endif
+    if a:types[i + optarg] is s:TYPE.OPTARG
+      let optarg += 1
+      continue
+    endif
+    call s:_validate_type(
+    \ a:args[i], a:types[i + optarg], a:prefix
+    \)
+    let i += 1
+  endwhile
+  if !optarg && i < typelen && a:types[i] isnot s:TYPE.OPTARG
+    throw a:prefix . ': too few arguments'
+  endif
+endfunction
+
+function! s:_validate_type(value, expected_type, prefix, ...) abort
+  if type(a:expected_type) is s:TYPE.LIST
+    let matched = filter(copy(a:expected_type),
+    \     's:_validate_type(a:value, v:val, a:prefix, s:NONE) isnot s:NONE')
+    if empty(matched)
+      if a:0
+        return a:1
+      endif
+      let expected = join(map(copy(a:expected_type), 's:TYPES[v:val]'), ' or ')
+      throw a:prefix . ': invalid type arguments were given ' .
+      \     '(expected: ' . expected .
+      \     ', got: ' . s:TYPES[type(a:value)] . ')'
+    endif
+    return
+  endif
+  if type(a:value) isnot a:expected_type
+    if a:0
+      return a:1
+    endif
+    throw a:prefix . ': invalid type arguments were given ' .
+    \     '(expected: ' . s:TYPES[a:expected_type] .
+    \     ', got: ' . s:TYPES[type(a:value)] . ')'
+  endif
+  return a:value
+endfunction
+
+function! s:_validate_arg_assert(args, asserts, prefix) abort
+  for i in range(len(a:args))
+    if has_key(a:asserts, i)
+      call s:_validate_assert(
+      \       a:args[i], a:asserts[i].funclist, a:asserts[i].msg, a:prefix)
+    endif
+  endfor
+endfunction
+
+function! s:_validate_assert(value, funclist, msg, prefix) abort
+  let matched = filter(copy(a:funclist), 's:_call1(v:val, a:value)')
+  if empty(matched)
+    throw a:prefix . ': ' . a:msg
+  endif
+endfunction
+
+function! s:_call1(f, arg) abort
+  if type(a:f) is s:TYPE.FUNC
+    return call(a:f, [a:arg])
+  else
+    return map([a:arg], a:f)[0]
+  endif
+endfunction
+
+
+let &cpo = s:save_cpo
+unlet s:save_cpo
+
+" vim:set et ts=2 sts=2 sw=2 tw=0:

--- a/doc/vital/Validator/Args.txt
+++ b/doc/vital/Validator/Args.txt
@@ -108,7 +108,7 @@ INTERFACE				*Vital.Validator.Args-interface*
 ------------------------------------------------------------------------------
 FUNCTIONS				*Vital.Validator.Args-functions*
 
-of({prefix} [, {enable}])				*Vital.Validator.Args.empty()*
+of({prefix} [, {enable}])				*Vital.Validator.Args.of()*
 	Creates validator of a function. {prefix} is a prefix of a thrown
 	exception message. see |Vital.Validator.Args-exceptions| for the
 	examples of thrown exception messages.

--- a/doc/vital/Validator/Args.txt
+++ b/doc/vital/Validator/Args.txt
@@ -1,0 +1,204 @@
+*vital/Validator/Args.txt*	Arguments validation library
+
+Maintainer: tyru <tyru.exe@gmail.com>
+
+==============================================================================
+CONTENTS				*Vital.Validator.Args-contents*
+
+INTRODUCTION			|Vital.Validator.Args-introduction|
+EXAMPLES			|Vital.Validator.Args-examples|
+INTERFACE			|Vital.Validator.Args-interface|
+  FUNCTIONS			  |Vital.Validator.Args-functions|
+  TYPES				  |Vital.Validator.Args-types|
+VALIDATOR OBJECT		|Vital.Validator.Args-Validator-object|
+
+==============================================================================
+INTRODUCTION				*Vital.Validator.Args-introduction*
+
+*Vital.Validator.Args* is a library to validate arity / types / contents of
+function's arguments. This library separates concerns about invalid arity,
+types, and values.
+
+==============================================================================
+EXAMPLES				*Vital.Validator.Args-examples*
+
+type()				*Vital.Validator.Args-example-type*
+------
+>
+	let s:Validator = vital#{plugin-name}#import('Validator.Args')
+	let s:TYPE = s:Validator.TYPE
+
+	" s:func1() receives one number argument
+	let s:func1_args =
+	\ s:Validator.of('func1()')
+	            \.type(s:TYPE.NUMBER)
+	function! s:func1(...) abort
+	  " validate() throws an exception when:
+	  " * arity is not 1
+	  " * if the first argument is not a number
+	  let [n] = s:func1_args.validate(a:000)
+	  echo 'n is a number: ' . n
+	endfunction
+
+	" s:func2() receives two number and string arguments
+	let s:func2_args =
+	\ s:Validator.of('func2()')
+	            \.type(s:TYPE.NUMBER, s:TYPE.STRING)
+<
+type(): Union types		*Vital.Validator.Args-example-union-types*
+-------------------
+>
+	" s:func3() receives one number or float argument
+	let s:func3_args =
+	\ s:Validator.of('func3()')
+	            \.type([s:TYPE.NUMBER, s:TYPE.FLOAT])
+<
+			*Vital.Validator.Args-example-optional-arguments*
+type(): Optional arguments
+--------------------------
+>
+	" s:func4() receives one string argument and zero or more optional arguments
+	" (NOTE: if the last type is OPTARG, skip the rest arguments validations)
+	let s:func4_args =
+	\ s:Validator.of('func4()')
+	            \.type(s:TYPE.STRING, s:TYPE.OPTARG)
+
+	" if you want to check also the optional arguments, specify the types
+	" after OPTARG (s:func5() receives exact 1-2 argument(s): Number [, Number])
+	let s:func5_args =
+	\ s:Validator.of('func5()')
+	            \.type(s:TYPE.NUMBER, s:TYPE.OPTARG, s:TYPE.NUMBER)
+<
+type(): Any type		*Vital.Validator.Args-example-any-type*
+----------------
+>
+	" s:func6() receives one arbitrary type argument
+	let s:func6_args =
+	\ s:Validator.of('func6()')
+	            \.type(s:TYPE.ANY)
+<
+assert()			*Vital.Validator.Args-example-assert*
+--------
+>
+	" s:func7() receives one positive number argument
+	" (type() validations were done before assert() validations
+	"  regardless of invoked order)
+	let s:func7_args =
+	\ s:Validator.of('func7()')
+	            \.type(s:TYPE.NUMBER)
+	            \.assert(1, 'v:val > 0',
+	            \  'the first argument should be a positive number')
+	function! s:func7(...) abort
+	  " validate() throws an exception when:
+	  " * arity is not 1
+	  " * if the first argument is not a number
+	  " * if the first argument is not a positive number
+	  let [n] = s:func7_args.validate(a:000)
+	  echo 'n is a positive number: ' . n
+	endfunction
+	
+	" Here is an example of Vim script's built-in function range()
+	let s:range_args = validator.of('vital: Stream: range()')
+	                           \.type(T.NUMBER, T.OPTARG, T.NUMBER, T.NUMBER)
+	                           \.assert(3, 'v:val !=# 0', 'stride is zero')
+<
+==============================================================================
+INTERFACE				*Vital.Validator.Args-interface*
+
+------------------------------------------------------------------------------
+FUNCTIONS				*Vital.Validator.Args-functions*
+
+of({prefix})					*Vital.Validator.Args.empty()*
+	Creates validator of a function. {prefix} is a prefix of a thrown
+	exception message. see |Vital.Validator.Args-exceptions| for the
+	examples of thrown exception messages.
+
+------------------------------------------------------------------------------
+TYPES				*Vital.Validator.Args-types*
+
+TYPE.NUMBER		*Vital.Validator.Args-type-NUMBER*
+	A |Number| argument.
+
+TYPE.STRING		*Vital.Validator.Args-type-String*
+	A |String| argument.
+
+TYPE.FUNC		*Vital.Validator.Args-type-FUNC*
+	A |Funcref| argument.
+
+TYPE.LIST		*Vital.Validator.Args-type-LIST*
+	A |List| argument.
+
+TYPE.DICT		*Vital.Validator.Args-type-DICT*
+	A |Dictionary| argument.
+
+TYPE.FLOAT		*Vital.Validator.Args-type-FLOAT*
+	A |Float| argument.
+
+TYPE.BOOL		*Vital.Validator.Args-type-BOOL*
+	A Boolean argument (|v:true| or |v:false|).
+
+TYPE.NONE		*Vital.Validator.Args-type-NONE*
+	A None argument (|v:null| or |v:none|).
+
+TYPE.JOB		*Vital.Validator.Args-type-JOB*
+	A |Job| argument.
+
+TYPE.CHANNEL		*Vital.Validator.Args-type-CHANNEL*
+	A |Channel| argument.
+
+TYPE.ANY		*Vital.Validator.Args-type-ANY*
+	An arbitrary type argument.
+
+TYPE.OPTARG		*Vital.Validator.Args-type-OPTARG*
+	An optional argument (Vim script's "..." in :function arguments).
+	If the last type is OPTARG, skip validation of rest arguments.
+	But if any type(s) were given after OPTARG, check the type(s) and arity.
+
+==============================================================================
+VALIDATOR OBJECT			*Vital.Validator.Args-Validator-object*
+
+Validator.type([{type} ...])		*Vital.Validator.Args-Validator.type()*
+	Specify types of arguments.
+
+	See |Vital.Validator.Args-types| for all available types.
+	See |Vital.Validator.Args-example-type| for examples.
+
+					*Vital.Validator.Args-Validator.assert()*
+Validator.assert({nth}, {assert} [, {msg}])
+	Specify assertions of arguments.
+
+	{nth} is 1-origin number which specifies the number of argument.
+
+	{assert} is a |Funcref| or |String| which is a function to receive a
+	value of each argument.
+
+	{msg} is a exception message.
+	Default value is: `"the " . nth . "th argument's assertion failed"`
+
+	See |Vital.Validator.Args-example-assert| for examples.
+
+Validator.validate({args})		*Vital.Validator.Args-Validator.validate()*
+	Validates given arguments {args} and throw an exception if the given
+	arguments don't match with defined arguments. {args} is a |List| of
+	arguments. A thrown exception format is: `{prefix}: {msg}`
+
+	See |Vital.Validator.Args-example-assert| for examples.
+
+					*Vital.Validator.Args-exceptions*
+	This method throws an exception when:
+
+	* Arity is different with type()'s arguments:
+	  `func(): too few arguments` or
+	  `func(): too many arguments`
+
+	* Any types of function arguments and type()'s arguments
+	  are different:
+	  `func(): invalid type arguments were given (expected: String, got: Number)`
+
+	* assert()'s {assert} argument doesn't match with the given argument:
+	  `func(): the {nth}th argument's assertion was failed`
+	  or, assert()'s {msg} was given:
+	  `func(): {msg}`
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital/Validator/Args.txt
+++ b/doc/vital/Validator/Args.txt
@@ -131,7 +131,7 @@ TYPES				*Vital.Validator.Args-types*
 TYPE.NUMBER		*Vital.Validator.Args-type-NUMBER*
 	A |Number| argument.
 
-TYPE.STRING		*Vital.Validator.Args-type-String*
+TYPE.STRING		*Vital.Validator.Args-type-STRING*
 	A |String| argument.
 
 TYPE.FUNC		*Vital.Validator.Args-type-FUNC*

--- a/doc/vital/Validator/Args.txt
+++ b/doc/vital/Validator/Args.txt
@@ -108,11 +108,23 @@ INTERFACE				*Vital.Validator.Args-interface*
 ------------------------------------------------------------------------------
 FUNCTIONS				*Vital.Validator.Args-functions*
 
-of({prefix})					*Vital.Validator.Args.empty()*
+of({prefix} [, {enable}])				*Vital.Validator.Args.empty()*
 	Creates validator of a function. {prefix} is a prefix of a thrown
 	exception message. see |Vital.Validator.Args-exceptions| for the
 	examples of thrown exception messages.
+	If {enable} was given and zero, this module does not perform any
+	validations. It is useful to switch in debug/production environment.
+>
+	" Validates arguments if 'g:myplugin#enable_debug' is non-zero.
+	" Otherwise this does not validate arguments.
+	let func_args = s:Validator.of('func()', g:myplugin#enable_debug)
+	                          \.type(s:TYPE.NUMBER)
+	function! s:func(...) abort
+	  let [n] = s:func_args.validate(a:000)
 
+	  " ...
+	endfunction
+<
 ------------------------------------------------------------------------------
 TYPES				*Vital.Validator.Args-types*
 

--- a/doc/vital/Validator/Args.txt
+++ b/doc/vital/Validator/Args.txt
@@ -205,7 +205,7 @@ Validator.validate({args})		*Vital.Validator.Args-Validator.validate()*
 
 	* Any types of function arguments and type()'s arguments
 	  are different:
-	  `func(): invalid type arguments were given (expected: String, got: Number)`
+	  `func(): invalid type arguments were given (expected: string, got: number)`
 
 	* assert()'s {assert} argument doesn't match with the given argument:
 	  `func(): the {nth}th argument's assertion was failed`

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -174,7 +174,7 @@ function! s:suite.__of__()
     \ A.of('test()').assert(1, 'type(v:val) is type('''') && v:val != ''''',
                    \           'the first argument should be non empty string')
                    \.validate([''])
-    Throws /^test(): the 1th argument's assertion failed/
+    Throws /^test(): the 1th argument's assertion was failed/
     \ A.of('test()').assert(1, 'type(v:val) is type('''') && v:val != ''''')
                    \.validate([''])
     call
@@ -201,7 +201,7 @@ function! s:suite.__of__()
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.validate([''])
-    Throws /^test(): the 1th argument's assertion failed/
+    Throws /^test(): the 1th argument's assertion was failed/
     \ A.of('test()').type(T.STRING)
                    \.assert(1, 'v:val != ''''')
                    \.validate([''])

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -33,6 +33,23 @@ function! s:suite.__of__()
     endif
   endfunction
 
+  function! of.of_should_not_validate_if_disabled() abort
+    let [A, T] = [s:A, s:T]
+
+    " disabled
+    let v = A.of('func()', 0).type(T.STRING)
+    try
+      Assert Equals(v.validate([42]), [42])
+    catch
+      Assert 0, 'should not throw'
+    endtry
+
+    " enabled
+    let v = A.of('func()', 1).type(T.STRING)
+    Throws /^func(): invalid type arguments were given (expected: String, got: Number)/
+    \ v.validate([42])
+  endfunction
+
   function! of.no_check()
     let A = s:A
     call A.of('test()').validate([])

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -1,0 +1,148 @@
+scriptencoding utf-8
+
+let s:suite = themis#suite('Validator.Args')
+let s:assert = themis#helper('assert')
+
+function! s:suite.before()
+  let s:A = vital#vital#import('Validator.Args')
+  let s:T = s:A.TYPE
+endfunction
+
+function! s:suite.__of__()
+  let of = themis#suite('of')
+
+  function! of.of_should_throw_if_it_received_non_string_value() abort
+    let [A, T] = [s:A, s:T]
+    Throws /^Validator.Args: of(): expected String argument but got Number/
+    \ A.of(42)
+    call A.of('')
+    Throws /^Validator.Args: of(): expected String argument but got Funcref/
+    \ A.of(function('function'))
+    Throws /^Validator.Args: of(): expected String argument but got List/
+    \ A.of([42])
+    Throws /^Validator.Args: of(): expected String argument but got Dictionary/
+    \ A.of({})
+    Throws /^Validator.Args: of(): expected String argument but got Float/
+    \ A.of(3.14)
+    if v:version >= 800
+      Throws /^Validator.Args: of(): expected String argument but got Bool/
+      \ A.of(v:false)
+      Throws /^Validator.Args: of(): expected String argument but got None/
+      \ A.of(v:null)
+      " TODO: job, channel
+    endif
+  endfunction
+
+  function! of.no_check()
+    let A = s:A
+    call A.of('test()').validate([])
+    call A.of('test()').validate([1])
+    call A.of('test()').validate([1,'foo'])
+  endfunction
+
+  function! of.union_types()
+    let [A, T] = [s:A, s:T]
+    Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Number)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([42])
+    call A.of('test()').type([T.STRING, T.FUNC]).validate([''])
+    call A.of('test()').type([T.STRING, T.FUNC]).validate([function('function')])
+    Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: List)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([[]])
+    Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Dictionary)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([{}])
+    Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Float)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([3.14])
+    if v:version >= 800
+      Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Bool)/
+      \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:false])
+      Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: None)/
+      \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:null])
+      " TODO: job, channel
+    endif
+  endfunction
+
+  function! of.any_type() abort
+    let [A, T] = [s:A, s:T]
+    call A.of('test()').type(T.ANY).validate([42])
+    call A.of('test()').type(T.ANY).validate([''])
+    call A.of('test()').type(T.ANY).validate([function('function')])
+    call A.of('test()').type(T.ANY).validate([[]])
+    call A.of('test()').type(T.ANY).validate([{}])
+    call A.of('test()').type(T.ANY).validate([3.14])
+    if v:version >= 800
+      call A.of('test()').type(T.ANY).validate([v:false])
+      call A.of('test()').type(T.ANY).validate([v:null])
+      " TODO: job, channel
+    endif
+  endfunction
+
+  function! of.wrong_types_and_correct_types()
+    let [A, T] = [s:A, s:T]
+    Throws /^test(): invalid type arguments were given (expected: String, got: Number)/
+    \ A.of('test()').type(T.STRING).validate([42])
+    call A.of('test()').type(T.STRING).validate([''])
+    Throws /^test(): invalid type arguments were given (expected: String, got: Funcref)/
+    \ A.of('test()').type(T.STRING).validate([function('function')])
+    Throws /^test(): invalid type arguments were given (expected: String, got: List)/
+    \ A.of('test()').type(T.STRING).validate([[]])
+    Throws /^test(): invalid type arguments were given (expected: String, got: Dictionary)/
+    \ A.of('test()').type(T.STRING).validate([{}])
+    Throws /^test(): invalid type arguments were given (expected: String, got: Float)/
+    \ A.of('test()').type(T.STRING).validate([3.14])
+    if v:version >= 800
+      Throws /^test(): invalid type arguments were given (expected: String, got: Bool)/
+      \ A.of('test()').type(T.STRING).validate([v:false])
+      Throws /^test(): invalid type arguments were given (expected: String, got: None)/
+      \ A.of('test()').type(T.STRING).validate([v:null])
+      " TODO: job, channel
+    endif
+  endfunction
+
+  function! of.validate_should_throw_if_it_received_non_list_value() abort
+    let [A, T] = [s:A, s:T]
+    Throws /^Validator.Args: Validator.validate(): expected List argument but got Number/
+    \ A.of('test()').type(T.ANY).validate(42)
+    Throws /^Validator.Args: Validator.validate(): expected List argument but got String/
+    \ A.of('test()').type(T.ANY).validate('')
+    Throws /^Validator.Args: Validator.validate(): expected List argument but got Funcref/
+    \ A.of('test()').type(T.ANY).validate(function('function'))
+    call A.of('test()').type(T.ANY).validate([42])
+    Throws /^Validator.Args: Validator.validate(): expected List argument but got Dictionary/
+    \ A.of('test()').type(T.ANY).validate({})
+    Throws /^Validator.Args: Validator.validate(): expected List argument but got Float/
+    \ A.of('test()').type(T.ANY).validate(3.14)
+    if v:version >= 800
+      Throws /^Validator.Args: Validator.validate(): expected List argument but got Bool/
+      \ A.of('test()').type(T.ANY).validate(v:false)
+      Throws /^Validator.Args: Validator.validate(): expected List argument but got None/
+      \ A.of('test()').type(T.ANY).validate(v:null)
+      " TODO: job, channel
+    endif
+  endfunction
+
+  function! of.arity_is_correct() abort
+    let [A, T] = [s:A, s:T]
+    call A.of('test()').type(T.STRING).validate(['foo'])
+    call A.of('test()').type(T.STRING, T.OPTARG, T.STRING)
+                        \.validate(['foo', 'bar'])
+    call A.of('test()').type(T.STRING, T.OPTARG, T.STRING, T.STRING)
+                        \.validate(['foo', 'bar'])
+    " if the last type is OPTARG, skip validation of rest arguments
+    call A.of('test()').type(T.STRING, T.OPTARG).validate(['foo'])
+    call A.of('test()').type(T.STRING, T.OPTARG).validate(['foo', 'bar'])
+    call A.of('test()').type(T.STRING, T.OPTARG).validate(['foo', 'bar', 'baz'])
+  endfunction
+
+  function! of.arity_is_wrong() abort
+    let [A, T] = [s:A, s:T]
+    Throws /^test(): too few arguments/
+    \ A.of('test()').type(T.STRING, T.OPTARG).validate([])
+    Throws /^test(): too few arguments/
+    \ A.of('test()').type(T.STRING).validate([])
+    Throws /^test(): too many arguments/
+    \ A.of('test()').type(T.STRING).validate(['foo', 'bar'])
+    Throws /^test(): too many arguments/
+    \ A.of('test()').type(T.STRING, T.OPTARG, T.STRING)
+                    \.validate(['foo', 'bar', 'baz'])
+  endfunction
+endfunction

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -24,13 +24,11 @@ function! s:suite.__of__()
     \ A.of({})
     Throws /^vital: Validator.Args: of(): expected string argument but got float/
     \ A.of(3.14)
-    if v:version >= 800
-      Throws /^vital: Validator.Args: of(): expected string argument but got bool/
-      \ A.of(v:false)
-      Throws /^vital: Validator.Args: of(): expected string argument but got none/
-      \ A.of(v:null)
-      " TODO: job, channel
-    endif
+    Throws /^vital: Validator.Args: of(): expected string argument but got bool/
+    \ A.of(v:false)
+    Throws /^vital: Validator.Args: of(): expected string argument but got none/
+    \ A.of(v:null)
+    " TODO: job, channel
   endfunction
 
   function! of.of_should_not_validate_if_disabled() abort
@@ -78,13 +76,11 @@ function! s:suite.__of__()
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([{}])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: float)/
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([3.14])
-    if v:version >= 800
-      Throws /^test(): invalid type arguments were given (expected: string or func, got: bool)/
-      \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:false])
-      Throws /^test(): invalid type arguments were given (expected: string or func, got: none)/
-      \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:null])
-      " TODO: job, channel
-    endif
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: bool)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:false])
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: none)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:null])
+    " TODO: job, channel
   endfunction
 
   function! of.any_type() abort
@@ -95,11 +91,9 @@ function! s:suite.__of__()
     call A.of('test()').type(T.ANY).validate([[]])
     call A.of('test()').type(T.ANY).validate([{}])
     call A.of('test()').type(T.ANY).validate([3.14])
-    if v:version >= 800
-      call A.of('test()').type(T.ANY).validate([v:false])
-      call A.of('test()').type(T.ANY).validate([v:null])
-      " TODO: job, channel
-    endif
+    call A.of('test()').type(T.ANY).validate([v:false])
+    call A.of('test()').type(T.ANY).validate([v:null])
+    " TODO: job, channel
   endfunction
 
   function! of.wrong_types_and_correct_types()
@@ -115,13 +109,11 @@ function! s:suite.__of__()
     \ A.of('test()').type(T.STRING).validate([{}])
     Throws /^test(): invalid type arguments were given (expected: string, got: float)/
     \ A.of('test()').type(T.STRING).validate([3.14])
-    if v:version >= 800
-      Throws /^test(): invalid type arguments were given (expected: string, got: bool)/
-      \ A.of('test()').type(T.STRING).validate([v:false])
-      Throws /^test(): invalid type arguments were given (expected: string, got: none)/
-      \ A.of('test()').type(T.STRING).validate([v:null])
-      " TODO: job, channel
-    endif
+    Throws /^test(): invalid type arguments were given (expected: string, got: bool)/
+    \ A.of('test()').type(T.STRING).validate([v:false])
+    Throws /^test(): invalid type arguments were given (expected: string, got: none)/
+    \ A.of('test()').type(T.STRING).validate([v:null])
+    " TODO: job, channel
   endfunction
 
   function! of.validate_should_throw_if_it_received_non_list_value() abort
@@ -137,13 +129,11 @@ function! s:suite.__of__()
     \ A.of('test()').type(T.ANY).validate({})
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got float/
     \ A.of('test()').type(T.ANY).validate(3.14)
-    if v:version >= 800
-      Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got bool/
-      \ A.of('test()').type(T.ANY).validate(v:false)
-      Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got none/
-      \ A.of('test()').type(T.ANY).validate(v:null)
-      " TODO: job, channel
-    endif
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got bool/
+    \ A.of('test()').type(T.ANY).validate(v:false)
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got none/
+    \ A.of('test()').type(T.ANY).validate(v:null)
+    " TODO: job, channel
   endfunction
 
   function! of.arity_is_correct() abort

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -13,21 +13,21 @@ function! s:suite.__of__()
 
   function! of.of_should_throw_if_it_received_non_string_value() abort
     let [A, T] = [s:A, s:T]
-    Throws /^vital: Validator.Args: of(): expected String argument but got Number/
+    Throws /^vital: Validator.Args: of(): expected string argument but got number/
     \ A.of(42)
     call A.of('')
-    Throws /^vital: Validator.Args: of(): expected String argument but got Funcref/
+    Throws /^vital: Validator.Args: of(): expected string argument but got func/
     \ A.of(function('function'))
-    Throws /^vital: Validator.Args: of(): expected String argument but got List/
+    Throws /^vital: Validator.Args: of(): expected string argument but got list/
     \ A.of([42])
-    Throws /^vital: Validator.Args: of(): expected String argument but got Dictionary/
+    Throws /^vital: Validator.Args: of(): expected string argument but got dict/
     \ A.of({})
-    Throws /^vital: Validator.Args: of(): expected String argument but got Float/
+    Throws /^vital: Validator.Args: of(): expected string argument but got float/
     \ A.of(3.14)
     if v:version >= 800
-      Throws /^vital: Validator.Args: of(): expected String argument but got Bool/
+      Throws /^vital: Validator.Args: of(): expected string argument but got bool/
       \ A.of(v:false)
-      Throws /^vital: Validator.Args: of(): expected String argument but got None/
+      Throws /^vital: Validator.Args: of(): expected string argument but got none/
       \ A.of(v:null)
       " TODO: job, channel
     endif
@@ -46,7 +46,7 @@ function! s:suite.__of__()
 
     " enabled
     let v = A.of('func()', 1).type(T.STRING)
-    Throws /^func(): invalid type arguments were given (expected: String, got: Number)/
+    Throws /^func(): invalid type arguments were given (expected: string, got: number)/
     \ v.validate([42])
   endfunction
 
@@ -68,20 +68,20 @@ function! s:suite.__of__()
 
   function! of.union_types()
     let [A, T] = [s:A, s:T]
-    Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Number)/
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: number)/
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([42])
     call A.of('test()').type([T.STRING, T.FUNC]).validate([''])
     call A.of('test()').type([T.STRING, T.FUNC]).validate([function('function')])
-    Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: List)/
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: list)/
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([[]])
-    Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Dictionary)/
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: dict)/
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([{}])
-    Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Float)/
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: float)/
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([3.14])
     if v:version >= 800
-      Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Bool)/
+      Throws /^test(): invalid type arguments were given (expected: string or func, got: bool)/
       \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:false])
-      Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: None)/
+      Throws /^test(): invalid type arguments were given (expected: string or func, got: none)/
       \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:null])
       " TODO: job, channel
     endif
@@ -104,21 +104,21 @@ function! s:suite.__of__()
 
   function! of.wrong_types_and_correct_types()
     let [A, T] = [s:A, s:T]
-    Throws /^test(): invalid type arguments were given (expected: String, got: Number)/
+    Throws /^test(): invalid type arguments were given (expected: string, got: number)/
     \ A.of('test()').type(T.STRING).validate([42])
     call A.of('test()').type(T.STRING).validate([''])
-    Throws /^test(): invalid type arguments were given (expected: String, got: Funcref)/
+    Throws /^test(): invalid type arguments were given (expected: string, got: func)/
     \ A.of('test()').type(T.STRING).validate([function('function')])
-    Throws /^test(): invalid type arguments were given (expected: String, got: List)/
+    Throws /^test(): invalid type arguments were given (expected: string, got: list)/
     \ A.of('test()').type(T.STRING).validate([[]])
-    Throws /^test(): invalid type arguments were given (expected: String, got: Dictionary)/
+    Throws /^test(): invalid type arguments were given (expected: string, got: dict)/
     \ A.of('test()').type(T.STRING).validate([{}])
-    Throws /^test(): invalid type arguments were given (expected: String, got: Float)/
+    Throws /^test(): invalid type arguments were given (expected: string, got: float)/
     \ A.of('test()').type(T.STRING).validate([3.14])
     if v:version >= 800
-      Throws /^test(): invalid type arguments were given (expected: String, got: Bool)/
+      Throws /^test(): invalid type arguments were given (expected: string, got: bool)/
       \ A.of('test()').type(T.STRING).validate([v:false])
-      Throws /^test(): invalid type arguments were given (expected: String, got: None)/
+      Throws /^test(): invalid type arguments were given (expected: string, got: none)/
       \ A.of('test()').type(T.STRING).validate([v:null])
       " TODO: job, channel
     endif
@@ -126,21 +126,21 @@ function! s:suite.__of__()
 
   function! of.validate_should_throw_if_it_received_non_list_value() abort
     let [A, T] = [s:A, s:T]
-    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Number/
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got number/
     \ A.of('test()').type(T.ANY).validate(42)
-    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got String/
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got string/
     \ A.of('test()').type(T.ANY).validate('')
-    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Funcref/
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got func/
     \ A.of('test()').type(T.ANY).validate(function('function'))
     call A.of('test()').type(T.ANY).validate([42])
-    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Dictionary/
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got dict/
     \ A.of('test()').type(T.ANY).validate({})
-    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Float/
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got float/
     \ A.of('test()').type(T.ANY).validate(3.14)
     if v:version >= 800
-      Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Bool/
+      Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got bool/
       \ A.of('test()').type(T.ANY).validate(v:false)
-      Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got None/
+      Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got none/
       \ A.of('test()').type(T.ANY).validate(v:null)
       " TODO: job, channel
     endif
@@ -163,9 +163,9 @@ function! s:suite.__of__()
   function! of.type_invalid_args() abort
     let [A, T] = [s:A, s:T]
 
-    Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got String/
-    \ A.of('test()').type('String')
-    Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got Number/
+    Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got string/
+    \ A.of('test()').type('string')
+    Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got number/
     \ A.of('test()').type(10)
 
     Throws /^vital: Validator.Args: Validator.type(): multiple OPTARG were given/
@@ -232,7 +232,7 @@ function! s:suite.__of__()
   function! of.mixed_validation_with_assert_and_type() abort
     let [A, T] = [s:A, s:T]
     " .type() checking failure
-    Throws /^test(): invalid type arguments were given (expected: String, got: Number)/
+    Throws /^test(): invalid type arguments were given (expected: string, got: number)/
     \ A.of('test()').type(T.STRING)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -40,6 +40,15 @@ function! s:suite.__of__()
     call A.of('test()').validate([1,'foo'])
   endfunction
 
+  function! of.validate_returns_given_args()
+    let A = s:A
+    Assert Equals(A.of('test()').validate([]), [])
+    Assert Equals(A.of('test()').validate(['foo']), ['foo'])
+    Assert Equals(
+    \         A.of('test()').validate(['str', ['list'], {'value': 'dict'}]),
+    \         ['str', ['list'], {'value': 'dict'}])
+  endfunction
+
   function! of.union_types()
     let [A, T] = [s:A, s:T]
     Throws /^test(): invalid type arguments were given (expected: String or Funcref, got: Number)/

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -13,21 +13,21 @@ function! s:suite.__of__()
 
   function! of.of_should_throw_if_it_received_non_string_value() abort
     let [A, T] = [s:A, s:T]
-    Throws /^Validator.Args: of(): expected String argument but got Number/
+    Throws /^vital: Validator.Args: of(): expected String argument but got Number/
     \ A.of(42)
     call A.of('')
-    Throws /^Validator.Args: of(): expected String argument but got Funcref/
+    Throws /^vital: Validator.Args: of(): expected String argument but got Funcref/
     \ A.of(function('function'))
-    Throws /^Validator.Args: of(): expected String argument but got List/
+    Throws /^vital: Validator.Args: of(): expected String argument but got List/
     \ A.of([42])
-    Throws /^Validator.Args: of(): expected String argument but got Dictionary/
+    Throws /^vital: Validator.Args: of(): expected String argument but got Dictionary/
     \ A.of({})
-    Throws /^Validator.Args: of(): expected String argument but got Float/
+    Throws /^vital: Validator.Args: of(): expected String argument but got Float/
     \ A.of(3.14)
     if v:version >= 800
-      Throws /^Validator.Args: of(): expected String argument but got Bool/
+      Throws /^vital: Validator.Args: of(): expected String argument but got Bool/
       \ A.of(v:false)
-      Throws /^Validator.Args: of(): expected String argument but got None/
+      Throws /^vital: Validator.Args: of(): expected String argument but got None/
       \ A.of(v:null)
       " TODO: job, channel
     endif
@@ -100,21 +100,21 @@ function! s:suite.__of__()
 
   function! of.validate_should_throw_if_it_received_non_list_value() abort
     let [A, T] = [s:A, s:T]
-    Throws /^Validator.Args: Validator.validate(): expected List argument but got Number/
+    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Number/
     \ A.of('test()').type(T.ANY).validate(42)
-    Throws /^Validator.Args: Validator.validate(): expected List argument but got String/
+    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got String/
     \ A.of('test()').type(T.ANY).validate('')
-    Throws /^Validator.Args: Validator.validate(): expected List argument but got Funcref/
+    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Funcref/
     \ A.of('test()').type(T.ANY).validate(function('function'))
     call A.of('test()').type(T.ANY).validate([42])
-    Throws /^Validator.Args: Validator.validate(): expected List argument but got Dictionary/
+    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Dictionary/
     \ A.of('test()').type(T.ANY).validate({})
-    Throws /^Validator.Args: Validator.validate(): expected List argument but got Float/
+    Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Float/
     \ A.of('test()').type(T.ANY).validate(3.14)
     if v:version >= 800
-      Throws /^Validator.Args: Validator.validate(): expected List argument but got Bool/
+      Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got Bool/
       \ A.of('test()').type(T.ANY).validate(v:false)
-      Throws /^Validator.Args: Validator.validate(): expected List argument but got None/
+      Throws /^vital: Validator.Args: Validator.validate(): expected List argument but got None/
       \ A.of('test()').type(T.ANY).validate(v:null)
       " TODO: job, channel
     endif
@@ -137,12 +137,12 @@ function! s:suite.__of__()
   function! of.type_invalid_args() abort
     let [A, T] = [s:A, s:T]
 
-    Throws /^Validator.Args: Validator.type(): expected type or union types but got String/
+    Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got String/
     \ A.of('test()').type('String')
-    Throws /^Validator.Args: Validator.type(): expected type or union types but got Number/
+    Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got Number/
     \ A.of('test()').type(10)
 
-    Throws /^Validator.Args: Validator.type(): multiple OPTARG were given/
+    Throws /^vital: Validator.Args: Validator.type(): multiple OPTARG were given/
     \ A.of('test()').type(T.OPTARG, T.OPTARG)
   endfunction
 
@@ -176,10 +176,10 @@ function! s:suite.__of__()
 
   function! of.assert_invalid_args() abort
     let [A, T] = [s:A, s:T]
-    Throws /^Validator.Args: Validator.assert(): the first argument number was not positive/
+    Throws /^vital: Validator.Args: Validator.assert(): the first argument number was not positive/
     \ A.of('test()').assert(-1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
-    Throws /^Validator.Args: Validator.assert(): the first argument number was not positive/
+    Throws /^vital: Validator.Args: Validator.assert(): the first argument number was not positive/
     \ A.of('test()').assert(0, 'v:val != ''''',
                    \            'the first argument should be non empty string')
     " TODO: is type check necessary?
@@ -256,19 +256,19 @@ function! s:suite.__of__()
 
   function! of.assert_no_out_of_range()
     let [A, T] = [s:A, s:T]
-    Throws /^Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1 arguments)/
+    Throws /^vital: Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1 arguments)/
     \ A.of('test()').type(T.STRING)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
                    \            'the second argument?')
-    Throws /^Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1 arguments)/
+    Throws /^vital: Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1 arguments)/
     \ A.of('test()').assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
                    \            'the second argument?')
                    \.type(T.STRING)
-    Throws /^Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1-2 arguments)/
+    Throws /^vital: Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1-2 arguments)/
     \ A.of('test()').type(T.STRING, T.OPTARG, T.STRING)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
@@ -276,7 +276,7 @@ function! s:suite.__of__()
                    \            'the second argument should be non empty string')
                    \.assert(3, 'v:val != ''''',
                    \            'the third argument?')
-    Throws /^Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1-2 arguments)/
+    Throws /^vital: Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1-2 arguments)/
     \ A.of('test()').assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
@@ -284,7 +284,7 @@ function! s:suite.__of__()
                    \.assert(3, 'v:val != ''''',
                    \            'the third argument?')
                    \.type(T.STRING, T.OPTARG, T.STRING)
-    Throws /^Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1-3 arguments)/
+    Throws /^vital: Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1-3 arguments)/
     \ A.of('test()').assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -28,7 +28,10 @@ function! s:suite.__of__()
     \ A.of(v:false)
     Throws /^vital: Validator.Args: of(): expected string argument but got none/
     \ A.of(v:null)
-    " TODO: job, channel
+    Throws /^vital: Validator.Args: of(): expected string argument but got job/
+    \ A.of(test_null_job())
+    Throws /^vital: Validator.Args: of(): expected string argument but got channel/
+    \ A.of(test_null_channel())
   endfunction
 
   function! of.of_should_not_validate_if_disabled() abort
@@ -80,7 +83,10 @@ function! s:suite.__of__()
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:false])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: none)/
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:null])
-    " TODO: job, channel
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: job)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([test_null_job()])
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: channel)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([test_null_channel()])
   endfunction
 
   function! of.any_type() abort
@@ -93,7 +99,8 @@ function! s:suite.__of__()
     call A.of('test()').type(T.ANY).validate([3.14])
     call A.of('test()').type(T.ANY).validate([v:false])
     call A.of('test()').type(T.ANY).validate([v:null])
-    " TODO: job, channel
+    call A.of('test()').type(T.ANY).validate([test_null_job()])
+    call A.of('test()').type(T.ANY).validate([test_null_channel()])
   endfunction
 
   function! of.wrong_types_and_correct_types()
@@ -113,7 +120,10 @@ function! s:suite.__of__()
     \ A.of('test()').type(T.STRING).validate([v:false])
     Throws /^test(): invalid type arguments were given (expected: string, got: none)/
     \ A.of('test()').type(T.STRING).validate([v:null])
-    " TODO: job, channel
+    Throws /^test(): invalid type arguments were given (expected: string, got: job)/
+    \ A.of('test()').type(T.STRING).validate([test_null_job()])
+    Throws /^test(): invalid type arguments were given (expected: string, got: channel)/
+    \ A.of('test()').type(T.STRING).validate([test_null_channel()])
   endfunction
 
   function! of.validate_should_throw_if_it_received_non_list_value() abort
@@ -133,7 +143,10 @@ function! s:suite.__of__()
     \ A.of('test()').type(T.ANY).validate(v:false)
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got none/
     \ A.of('test()').type(T.ANY).validate(v:null)
-    " TODO: job, channel
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got job/
+    \ A.of('test()').type(T.ANY).validate(test_null_job())
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got channel/
+    \ A.of('test()').type(T.ANY).validate(test_null_channel())
   endfunction
 
   function! of.arity_is_correct() abort


### PR DESCRIPTION
https://github.com/vim-jp/vital.vim/pull/504#issuecomment-301294962 でチラッと言ってたやつです。

> > * 不正な引数に対して型チェックをしないと無名関数やラムダが入り混じった深いスタックトレースが出て訳分からんので引数チェックする
> 
> この件は結構修正量デカくなりそうだったので別 PR へ持ち越します（汎用的な引数チェックモジュール Validator.Args を作成予定）。

関数の引数をチェックして、正しくない型や式にマッチしない値だったら例外を投げるモジュールです。