### PR TITLE
Data.Either: Fix the document of .return()

### DIFF
--- a/doc/vital/Data/Either.txt
+++ b/doc/vital/Data/Either.txt
@@ -80,7 +80,7 @@ right({value})				*Vital.Data.Either.right()*
 return({value})				*Vital.Data.Either.return()*
 	This is an alias of |Vital.Data.Either.right()| for monadic behavior.
 	The is like the Haskell's "return" function of Monad type class. It
-	represents identity element in Monad.
+	puts {value} into the monadic context.
 
 
 is_left({either})			*Vital.Data.Either.is_left()*


### PR DESCRIPTION
`return` may not be the identity of the monad in unclearly context :bow:  
特に「returnはモナドの単位元やで」って直接言ってしまった @rhysd さんに対して、誤った知識をすみません :bow:  
