### PR TITLE
Data.OrderedSet: Remove version()

### DIFF
--- a/autoload/vital/__vital__/Data/OrderedSet.vim
+++ b/autoload/vital/__vital__/Data/OrderedSet.vim
@@ -2,10 +2,6 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 
-function! s:version() abort
-  return '0.0.15'
-endfunction
-
 function! s:new(...) abort
   let obj = deepcopy(s:ordered_set)
   if a:0


### PR DESCRIPTION
Data.OrderedSet.version() を消しました。
Changes に書くべきか悩みましたが、 #522 と同じく undocumented なメソッドの仕様変更ということで書きませんでした。
ref. #440 