### PR TITLE
Web.URI: fix: URI.new_from_seq_string('foo bar: baz') was wrongly accepted

### DIFF
--- a/autoload/vital/__vital__/Web/URI.vim
+++ b/autoload/vital/__vital__/Web/URI.vim
@@ -202,7 +202,7 @@ function! s:_eat_hier_part(rest, pattern_set) abort
     let port = authority.port
     " path
     let [path, rest] = s:_eat_path_abempty(rest, a:pattern_set)
-  elseif rest =~# ':'
+  elseif rest =~# '^:'
     let rest = rest[1:]
     let userinfo = ''
     let host = ''

--- a/test/Web/URI.vimspec
+++ b/test/Web/URI.vimspec
@@ -238,6 +238,12 @@ Describe Web.URI
         Assert Equals([uri, origuri, rest], expected)
       endfor
     End
+
+    It doesn't accept invalid URIs
+      let NONE = []
+      let ret = URI.new_from_seq_string('foo bar: baz', NONE)
+      Assert ret is NONE
+    End
   End
 
   Describe .new_default_pattern_set()


### PR DESCRIPTION
via https://github.com/tyru/open-browser.vim/issues/96