### PR TITLE
Process: Fix shellescape() on Windows

### DIFF
--- a/autoload/vital/__vital__/Process.vim
+++ b/autoload/vital/__vital__/Process.vim
@@ -22,34 +22,23 @@ let s:TYPE_LIST = type([])
 let s:TYPE_STRING = type('')
 
 function! s:spawn(expr, ...) abort
-  let shellslash = 0
-  if s:is_windows
-    let shellslash = &l:shellslash
-    setlocal noshellslash
+  if type(a:expr) is s:TYPE_LIST
+    let special = 1
+    let cmdline = join(map(a:expr, 's:shellescape(v:val, special)'), ' ')
+  elseif type(a:expr) is s:TYPE_STRING
+    let cmdline = a:expr
+    if a:0 && a:1
+      " for :! command
+      let cmdline = substitute(cmdline, '\([!%#]\|<[^<>]\+>\)', '\\\1', 'g')
+    endif
+  else
+    throw 'vital: Process: invalid argument (value type:' . type(a:expr) . ')'
   endif
-  try
-    if type(a:expr) is s:TYPE_LIST
-      let special = 1
-      let cmdline = join(map(a:expr, 'shellescape(v:val, special)'), ' ')
-    elseif type(a:expr) is s:TYPE_STRING
-      let cmdline = a:expr
-      if a:0 && a:1
-        " for :! command
-        let cmdline = substitute(cmdline, '\([!%#]\|<[^<>]\+>\)', '\\\1', 'g')
-      endif
-    else
-      throw 'vital: Process: invalid argument (value type:' . type(a:expr) . ')'
-    endif
-    if s:is_windows
-      silent execute '!start' cmdline
-    else
-      silent execute '!' cmdline '&'
-    endif
-  finally
-    if s:is_windows
-      let &l:shellslash = shellslash
-    endif
-  endtry
+  if s:is_windows
+    silent execute '!start' cmdline
+  else
+    silent execute '!' cmdline '&'
+  endif
   return ''
 endfunction
 

--- a/autoload/vital/__vital__/Process.vim
+++ b/autoload/vital/__vital__/Process.vim
@@ -153,8 +153,14 @@ function! s:get_last_status() abort
 endfunction
 
 if s:is_windows
-  function! s:shellescape(command) abort
-    return substitute(a:command, '[&()[\]{}^=;!''+,`~]', '^\0', 'g')
+  function! s:shellescape(...) abort
+    try
+      let shellslash = &shellslash
+      set noshellslash
+      return call('shellescape', a:000)
+    finally
+      let &shellslash = shellslash
+    endtry
   endfunction
 else
   function! s:shellescape(...) abort

--- a/test/Process.vimspec
+++ b/test/Process.vimspec
@@ -1,15 +1,32 @@
-
-scriptencoding utf-8
-
 Describe Process
   Before all
-    let Process = vital#vital#new().import('Process')
+    let Vital = vital#vital#new()
+    let Process = Vital.import('Process')
+    let IS_WINDOWS = has('win16') || has('win32') || has('win64') || has('win95')
   End
 
   Describe .system()
     It runs an external command and returns the stdout
       " assuming you have echo command
       Assert Equals(Process.system('echo 1234'), "1234\n")
+      Assert Equals(Process.get_last_status(), 0)
+    End
+  End
+
+  Describe .shellescape()
+    Before
+      let ss = &shellslash
+      set noshellslash
+    End
+
+    After
+      let &shellslash = ss
+    End
+
+    It escapes shell input
+      let have = Process.shellescape("foo 'bar'")
+      let want = IS_WINDOWS ? '"foo ''bar''"' : "'foo '\\''bar'\\'''"
+      Assert Equals(have, want)
     End
   End
 End


### PR DESCRIPTION
Windows における `shellescape()` が結果をダブルクォートで囲んでいなかったので，囲むようにしました．

ただ，ここが自力でエスケープしようとしているのは，多分標準の `shellescape()` が Windows の cmd.exe はダブルクォートで囲まないといけないのに `shellslash` が on のときはシングルクォートで囲んでしまうからですよね？それであれば，自力でエスケープしなくても上の `s:spawn` でやっているように一時的に `shellslash` をオフにしてしまえば良いのかなと思うのですが，それだとまずいでしょうか？