### PR TITLE
Process: Fix test on Windows

### DIFF
--- a/test/Process.vimspec
+++ b/test/Process.vimspec
@@ -8,7 +8,7 @@ Describe Process
   Describe .system()
     It runs an external command and returns the stdout
       " assuming you have echo command
-      if IS_WINDOWS && &shell =~# '\<cmd\(\.exe\)\?$'
+      if IS_WINDOWS && &shell =~# '\<cmd\(\.exe\)\?$' && !Process.has_vimproc()
         Assert Equals(Process.system('echo 1234'), "1234 \n")
       else
         Assert Equals(Process.system('echo 1234'), "1234\n")

--- a/test/Process.vimspec
+++ b/test/Process.vimspec
@@ -8,7 +8,7 @@ Describe Process
   Describe .system()
     It runs an external command and returns the stdout
       " assuming you have echo command
-      if IS_WINDOWS
+      if IS_WINDOWS && &shell =~# '\<cmd\(\.exe\)\?$'
         Assert Equals(Process.system('echo 1234'), "1234 \n")
       else
         Assert Equals(Process.system('echo 1234'), "1234\n")

--- a/test/Process.vimspec
+++ b/test/Process.vimspec
@@ -8,7 +8,11 @@ Describe Process
   Describe .system()
     It runs an external command and returns the stdout
       " assuming you have echo command
-      Assert Equals(Process.system('echo 1234'), "1234\n")
+      if IS_WINDOWS
+        Assert Equals(Process.system('echo 1234'), "1234 \n")
+      else
+        Assert Equals(Process.system('echo 1234'), "1234\n")
+      endif
       Assert Equals(Process.get_last_status(), 0)
     End
   End


### PR DESCRIPTION
Ref. #535

`echo 1234` in cmd.exe outputs `1234<space><CR><NL>`.
Vim's system() truncates `<CR>`.
so expected output is `1234<space><NL>`