### PR TITLE
Fix ruby build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: generic
-rvm:
-  - 2.4.1
 sudo: false
 git:
   depth: 10
@@ -26,8 +24,10 @@ addons:
       - python3-dev
       - liblua5.1-0-dev
       - lua5.1
+      - ruby-dev
 
 install:
+  - rvm reset
   - bash scripts/install-vim.sh
   - export PATH=$HOME/vim/bin:$PATH
 


### PR DESCRIPTION
Recently, Travis-CI switched to Ubuntu trusty. At the same time, rvm was introduced and it caused a link error when building vim with if_ruby.
Disable rvm and use the system ruby to fix the problem.

Actually, if_ruby might not be needed...

Related: #540