### PR TITLE
Make CI 1.7x faster

### DIFF
--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -14,9 +14,7 @@ case "${TRAVIS_OS_NAME}" in
 		;;
 	osx)
 		brew update
-		brew upgrade
-		brew install lua python ruby
-		brew install vim --with-lua
+		brew install macvim --with-lua
 		;;
 	*)
 		echo "Unknown value of \${TRAVIS_OS_NAME}: ${TRAVIS_OS_NAME}"

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -13,8 +13,7 @@ case "${TRAVIS_OS_NAME}" in
 		make install
 		;;
 	osx)
-		brew update
-		brew install macvim --with-lua
+		brew install macvim --with-override-system-vim --with-lua
 		;;
 	*)
 		echo "Unknown value of \${TRAVIS_OS_NAME}: ${TRAVIS_OS_NAME}"


### PR DESCRIPTION
I improved the time to spend for running CI.

Before: 10 minutes https://travis-ci.org/vim-jp/vital.vim/builds/285078709
After: 6 minutes https://travis-ci.org/rhysd/vital.vim/builds/285091846

Bottleneck was preparing environment for tests on macOS on Travis CI.

Changes are following:

- Use MacVim instead of Vim because many users use MacVim, not a pure Vim on macOS
- MacVim can be built with system Python. So installing/upgrading `python` package is no longer needed
- `brew update` is automatically done in `brew install` so we don't need to do it manually.
- `brew upgrade` updates all outdated packages but they are not needed in our tests