### PR TITLE
Fix mac build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
       - ruby-dev
 
 install:
-  - rvm reset
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then rvm reset; fi
   - bash scripts/install-vim.sh
   - export PATH=$HOME/vim/bin:$PATH
 

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -13,6 +13,7 @@ case "${TRAVIS_OS_NAME}" in
 		make install
 		;;
 	osx)
+		brew update
 		brew install macvim --with-override-system-vim --with-lua
 		;;
 	*)


### PR DESCRIPTION
CI fails after #542 was merged.
https://travis-ci.org/vim-jp/vital.vim/jobs/285464273#L1726
(Not sure why no error occurred in the PR #542 itself.)

Execute "rvm reset" only on Linux.
Execute "brew update" before "brew install".