### PR TITLE
Set `HOMEBREW_NO_AUTO_UPDATE`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
       - ruby-dev
 
 install:
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then rvm reset; fi
+  - rvm reset
   - bash scripts/install-vim.sh
   - export PATH=$HOME/vim/bin:$PATH
 

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -13,6 +13,7 @@ case "${TRAVIS_OS_NAME}" in
 		make install
 		;;
 	osx)
+		export HOMEBREW_NO_AUTO_UPDATE=1
 		brew update
 		brew install macvim --with-override-system-vim --with-lua
 		;;


### PR DESCRIPTION
Related: #543 

* [brew 1.3.5](https://github.com/Homebrew/brew/releases/tag/1.3.5) から ruby 2.3 以上が必要になった

`brew-update` で ruby (2.3) をダウンロードしてそれを使うようになっているのですが、`brew-install` 内で `brew-update` を実行されると `brew-install` 側では更新前の ruby (2.0) を指しているためにバージョンチェックでエラーになってしまうという構図でした。

#542 が、PR の CI は通ったのにマージしたら fail したのは、この間に brew のバージョンが上がったためです。

ということで、以下のように変更しました。

* 明示的に `brew-update` を実行
* `HOMEBREW_NO_AUTO_UPDATE=1` を設定し、 `brew-install` 内では `brew-update` しない