### PR TITLE
Fix to failure `:Vitalize` when included environment in args.

### DIFF
--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -552,7 +552,7 @@ function! vitalizer#command(args) abort
   if empty(args)
     call insert(options, '--help')
   else
-    let to = fnamemodify(args[0], ':p')
+    let to = fnamemodify(expand(args[0]), ':p')
     let modules = args[1 :]
   endif
   let hash = ''


### PR DESCRIPTION
## 概要

READMEの通り，（https://github.com/vim-jp/vital.vim/blame/master/README.md#L90)

```vim
:Vitalize --name=your_plugin_name $HOME/.vim/bundle/your_plugin_dir/
```
を実行しようとしてみたところ， `vitalizer: {target-dir} must exist.` という例外が投げられます．

READMEから察するに，環境変数は使えるべきだと判断し，この修正を行いました．

もし，意図して `expand` していないのであれば，READMEを修正するべきかなと思いました．

## 再現手順

一応，再現手順を書いておきます．
（ホームディレクトリに foo というディレクトリがない前提）

```vim
:!mkdir ~/foo
:Vitalize --name=test $HOME/foo
" => vitalizer: {target-dir} must exist.
```

## 備考

`:Vitalize` 及び， `vitalize#command()` の テストが存在しなかったので，もし必要であれば書きます．
(別のPRのほうが良いかもしれない？）