### PR TITLE
System.Filepath: doc: add example to path_separator()

### DIFF
--- a/doc/vital/System/Filepath.txt
+++ b/doc/vital/System/Filepath.txt
@@ -26,7 +26,9 @@ separator()			*Vital.System.Filepath.separator()*
 
 path_separator()		*Vital.System.Filepath.path_separator()*
 	Return OS related path separator as string.
-
+>
+	split('/path/to/file', s:F.path_separator()) == ['path', 'to', 'file']
+<
 path_extensions()		*Vital.System.Filepath.path_extensions()*
 	Return OS related path extensions as array of string.
 


### PR DESCRIPTION
Close #545 

Original PR (#545) which introduce `path_separate()` function was rejected
because `split(path, path_separator())` was enough.

However, `path_separator()` lacks its example in the document.