### PR TITLE
System.Filepath: doc: fix path_separator()/separator() examples

### DIFF
--- a/doc/vital/System/Filepath.txt
+++ b/doc/vital/System/Filepath.txt
@@ -26,22 +26,6 @@ separator()			*Vital.System.Filepath.separator()*
 	This returns "/" on non-Windows, or Windows and |'shellslash'| is on.
 	This returns "\" on Windows and |'shellslash'| is off.
 
-	Note that splitting raw path given by user results in unexpected
-	result: >
-	" on Windows and shellslash is on
-	set shellslash
-	" path was given by user
-	let path = 'c:\Windows\system32'
-	" output: ['c:\Windows\system32']
-	echo split(path, s:F.separator())
-<
-	To handle this, path string must be normalized by
-	|Vital.System.Filepath.realpath()|.
-	It normalizes directory separators of an arbitrary path depending on
-	current OS and |'shellslash'| value: >
-	" output: ['c:', 'Windows', 'system32']
-	echo split(s:F.realpath(path), s:F.separator())
-<
 path_separator()		*Vital.System.Filepath.path_separator()*
 	Return OS related path separator as string.
 	This returns ";" on Windows.
@@ -113,8 +97,6 @@ realpath({path})		*Vital.System.Filepath.realpath()*
 	In windows, it call |Vital.System.Filepath.unixpath()| when the
 	Vim is compiled with '+shellslash' and |shellslash| is specified.
 	Otherwise it call |Vim.System.Filepath.winpath()| internally.
-
-	See also: |Vital.System.Filepath.separator()|
 
 is_root_directory({path})	*Vital.System.Filepath.is_root_directory()*
 	Return 1 if the given {path} points to the root directory, otherwise

--- a/doc/vital/System/Filepath.txt
+++ b/doc/vital/System/Filepath.txt
@@ -23,11 +23,13 @@ FUNCTIONS				*Vital.System.Filepath-functions*
 
 separator()			*Vital.System.Filepath.separator()*
 	Return OS related directory separator as string.
-
+>
+	split('/path/to/file', s:F.separator()) == ['path', 'to', 'file']
+<
 path_separator()		*Vital.System.Filepath.path_separator()*
 	Return OS related path separator as string.
 >
-	split('/path/to/file', s:F.path_separator()) == ['path', 'to', 'file']
+	split('/usr/bin:/bin', s:F.path_separator()) == ['/usr/bin', '/bin']
 <
 path_extensions()		*Vital.System.Filepath.path_extensions()*
 	Return OS related path extensions as array of string.

--- a/doc/vital/System/Filepath.txt
+++ b/doc/vital/System/Filepath.txt
@@ -23,13 +23,31 @@ FUNCTIONS				*Vital.System.Filepath-functions*
 
 separator()			*Vital.System.Filepath.separator()*
 	Return OS related directory separator as string.
->
-	split('/path/to/file', s:F.separator()) == ['path', 'to', 'file']
+	This returns "/" on non-Windows, or Windows and |'shellslash'| is on.
+	This returns "\" on Windows and |'shellslash'| is off.
+
+	Note that splitting raw path given by user results in unexpected
+	result: >
+	" on Windows and shellslash is on
+	set shellslash
+	" path was given by user
+	let path = 'c:\Windows\system32'
+	" output: ['c:\Windows\system32']
+	echo split(path, s:F.separator())
+<
+	To handle this, path string must be normalized by
+	|Vital.System.Filepath.realpath()|.
+	It normalizes directory separators of an arbitrary path depending on
+	current OS and |'shellslash'| value: >
+	" output: ['c:', 'Windows', 'system32']
+	echo split(s:F.realpath(path), s:F.separator())
 <
 path_separator()		*Vital.System.Filepath.path_separator()*
 	Return OS related path separator as string.
+	This returns ";" on Windows.
+	Otherwise this returns ":".
 >
-	split('/usr/bin:/bin', s:F.path_separator()) == ['/usr/bin', '/bin']
+	split($PATH, s:F.path_separator())
 <
 path_extensions()		*Vital.System.Filepath.path_extensions()*
 	Return OS related path extensions as array of string.
@@ -95,6 +113,8 @@ realpath({path})		*Vital.System.Filepath.realpath()*
 	In windows, it call |Vital.System.Filepath.unixpath()| when the
 	Vim is compiled with '+shellslash' and |shellslash| is specified.
 	Otherwise it call |Vim.System.Filepath.winpath()| internally.
+
+	See also: |Vital.System.Filepath.separator()|
 
 is_root_directory({path})	*Vital.System.Filepath.is_root_directory()*
 	Return 1 if the given {path} points to the root directory, otherwise

--- a/doc/vital/System/Filepath.txt
+++ b/doc/vital/System/Filepath.txt
@@ -30,6 +30,8 @@ path_separator()		*Vital.System.Filepath.path_separator()*
 	Return OS related path separator as string.
 	This returns ";" on Windows.
 	Otherwise this returns ":".
+
+	You can get list of each filepath of $PATH by:
 >
 	split($PATH, s:F.path_separator())
 <


### PR DESCRIPTION
via #548 

As @k-takata was pointing out, `path_separator()` example is not correct (the right place of the example is `separator()`).

* Move `path_separator()` example to `separator()`
* Add `path_separator()` example (which @k-takata gave [here](https://github.com/vim-jp/vital.vim/pull/548#issuecomment-342700768))