### PR TITLE
Data.Dict: Add .from_list()

### DIFF
--- a/autoload/vital/__vital__/Data/Dict.vim
+++ b/autoload/vital/__vital__/Data/Dict.vim
@@ -11,6 +11,39 @@ function! s:_vital_depends() abort
   return ['Vim.Type']
 endfunction
 
+
+function! s:_ensure_key(key) abort
+  let t = type(a:key)
+  if t != s:t.string && t != s:t.number
+    throw 'vital: Data.Dict: Invalid key: ' . string(a:key)
+  endif
+endfunction
+
+function! s:from_list(list) abort
+  let dict = {}
+  let i = 0
+  let len = len(a:list)
+  while i < len
+    if type(a:list[i]) == s:t.list
+      let key_value = a:list[i]
+      if len(key_value) != 2
+        throw 'vital: Data.Dict: Invalid key-value pair index at ' . i
+      endif
+      call s:_ensure_key(key_value[0])
+      let dict[key_value[0]] = key_value[1]
+      let i += 1
+    else
+      if len <= i + 1
+        throw 'vital: Data.Dict: Invalid key-value pair index at ' . i
+      endif
+      call s:_ensure_key(a:list[i])
+      let dict[a:list[i]] = a:list[i + 1]
+      let i += 2
+    endif
+  endwhile
+  return dict
+endfunction
+
 " Makes a dict from keys and values
 function! s:make(keys, values, ...) abort
   let dict = {}

--- a/autoload/vital/__vital__/Data/Dict.vim
+++ b/autoload/vital/__vital__/Data/Dict.vim
@@ -3,12 +3,20 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! s:_vital_loaded(V) abort
+  let s:t = a:V.import('Vim.Type').types
+endfunction
+
+function! s:_vital_depends() abort
+  return ['Vim.Type']
+endfunction
+
 " Makes a dict from keys and values
 function! s:make(keys, values, ...) abort
   let dict = {}
   let fill = a:0 ? a:1 : 0
   for i in range(len(a:keys))
-    let key = type(a:keys[i]) == type('') ? a:keys[i] : string(a:keys[i])
+    let key = type(a:keys[i]) == s:t.string ? a:keys[i] : string(a:keys[i])
     if key ==# ''
       throw "vital: Data.Dict: Can't use an empty string for key."
     endif

--- a/doc/vital/Data/Dict.txt
+++ b/doc/vital/Data/Dict.txt
@@ -21,6 +21,13 @@ INTERFACE				*Vital.Data.Dict-interface*
 ------------------------------------------------------------------------------
 FUNCTIONS				*Vital.Data.Dict-functions*
 
+from_list({key-value-list})		*Vital.Data.Dict.from_list()*
+	Makes a dictionary from {key-value-list}.
+	{key-value-list} is one of following forms: >
+	[key, value, key, value]
+<	or >
+	[[key, value], [key, value]]
+
 make({keys}, {values} [, {fill}])	*Vital.Data.Dict.make()*
 	Makes a dictionary from {keys} and {values}.
 	If the length of {keys} is less than {values}, tails of {values} are

--- a/test/Data/Dict.vimspec
+++ b/test/Data/Dict.vimspec
@@ -3,6 +3,50 @@ Describe Data.Dict
     let D = vital#vital#new().import('Data.Dict')
   End
 
+  Describe .from_list()
+    Context with a list like [key, value, key, value]
+      It makes a new dictionary
+        let list = ['one', 1, 'two', 2]
+        Assert Equals(D.from_list(list), {'one': 1, 'two': 2})
+      End
+    End
+
+    Context with a list like [[key, value], [key, value]]
+      It makes a new dictionary
+        let list = [['one', 1], ['two', 2]]
+        Assert Equals(D.from_list(list), {'one': 1, 'two': 2})
+      End
+    End
+
+    Context with a list like [key, value, [key, value]]
+      It makes a new dictionary
+        let list = ['one', 1, ['two', 2], 'three', [3]]
+        Assert Equals(D.from_list(list), {'one': 1, 'two': 2, 'three': [3]})
+      End
+    End
+
+    Context when length of a list which have key-value pair is wrong
+      It throws an error
+        let list = [['key']]
+        Throws /^vital: Data.Dict:/ D.from_list(list)
+      End
+    End
+
+    Context when there is no value corresponding to the key
+      It throws an error
+        let list = ['key1', 'value1', 'key2']
+        Throws /^vital: Data.Dict:/ D.from_list(list)
+      End
+    End
+
+    Context when key is not string or number
+      It throws an error
+        let list = [0.0, 'value1']
+        Throws /^vital: Data.Dict:/ D.from_list(list)
+      End
+    End
+  End
+
   Describe .make()
     It makes a new dictionary from keys and values
       Assert Equals(D.make(['one', 'two', 'three'], [1, 2, 3]), {'one': 1, 'two': 2, 'three': 3})


### PR DESCRIPTION
`Data.Dict.from_array()` can make a dictionary from an array like `[key, value, key, value, ...]` or `[[key, value], [key, value], ...]`.