### PR TITLE
Data.Base64: Remove unused variable

### DIFF
--- a/autoload/vital/__vital__/Data/Base64.vim
+++ b/autoload/vital/__vital__/Data/Base64.vim
@@ -24,12 +24,6 @@ let s:standard_table = [
       \ 'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v',
       \ 'w','x','y','z','0','1','2','3','4','5','6','7','8','9','+','/']
 
-let s:urlsafe_table = [
-      \ 'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P',
-      \ 'Q','R','S','T','U','V','W','X','Y','Z','a','b','c','d','e','f',
-      \ 'g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v',
-      \ 'w','x','y','z','0','1','2','3','4','5','6','7','8','9','-','_']
-
 function! s:_b64encode(bytes, table, pad) abort
   let b64 = []
   for i in range(0, len(a:bytes) - 1, 3)


### PR DESCRIPTION
`s:urlsafe_table` seems unused. what is this purpose? >@mattn (this module's author)