### PR TITLE
System.File: Remove dependence to Prelude module

### DIFF
--- a/autoload/vital/__vital__/System/File.vim
+++ b/autoload/vital/__vital__/System/File.vim
@@ -4,12 +4,11 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! s:_vital_loaded(V) abort
-  let s:Prelude = a:V.import('Prelude')
   let s:Filepath = a:V.import('System.Filepath')
 endfunction
 
 function! s:_vital_depends() abort
-  return ['Prelude', 'System.Filepath']
+  return ['System.Filepath']
 endfunction
 
 let s:is_unix = has('unix')
@@ -183,7 +182,7 @@ endif
 " Implemented by pure Vim script.
 function! s:copy_dir_vim(src, dest) abort
   if isdirectory(a:src)
-    for src in s:Prelude.glob(s:Filepath.join(a:src, '*'))
+    for src in glob(s:Filepath.join(a:src, '*'), 1, 1)
       let basename = s:Filepath.basename(src)
       let dest = s:Filepath.join(a:dest, basename)
       if !s:copy_dir_vim(src, dest)


### PR DESCRIPTION
Use `glob()` directly.

Here is Prelude's code:

```vim
if v:version > 703 ||
\  (v:version == 703 && has('patch465'))
  function! s:glob(expr) abort
    return glob(a:expr, 1, 1)
  endfunction
else
  function! s:glob(expr) abort
    return split(glob(a:expr, 1), '\n')
  endfunction
endif
```

Vital.vim now supports Vim 7.4 or later so we can use third argument of `glob()`.