### PR TITLE
Let's say vital.vim supports Vim 7.4 or later in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ This is like a plugin which has both aspects of
 [Bundler](http://gembundler.com/) and [jQuery](http://jquery.com/) at the same
 time.
 
-## Targets
+Modules in vital.vim basically support Vim 7.4 or later. And some modules have stricter requirements and additional dependencies.
+Please read the docs of each module before using them.
+
+## Targets of this plugin
 
 If you are a Vim user who doesn't make Vim plugins, please ignore this page.
 

--- a/doc/vital.txt
+++ b/doc/vital.txt
@@ -25,6 +25,10 @@ jQuery at the same time.
 If you are a Vim user who doesn't make Vim plugins, please ignore this page.
 If you are a Vim plugin author, please check this out.
 
+Modules in vital.vim basically support Vim 7.4 or later. And some modules have
+stricter requirements and additioinal dependencies. Please read the docs of
+each module before using them.
+
 ==============================================================================
 USAGE					*Vital-usage*
 


### PR DESCRIPTION
While reviewing #560, I noticed that supported version by vital.vim is not documented. Let's say vital.vim supports Vim 7.4 or later explicitly in documentation.