### PR TITLE
Avoid Vim's bug of :return in try-catch

### DIFF
--- a/autoload/vital/__vital__/Data/Closure.vim
+++ b/autoload/vital/__vital__/Data/Closure.vim
@@ -370,7 +370,9 @@ endfunction
 
 function! s:_function_exists(name) abort
   try
-    return s:_is_funcname(a:name) && exists('*' . a:name)
+    " Avoid Vim's bug: https://github.com/vim/vim/pull/2483
+    let ret = s:_is_funcname(a:name) && exists('*' . a:name)
+    return ret
   catch
   endtry
   return 0

--- a/autoload/vital/__vital__/System/File.vim
+++ b/autoload/vital/__vital__/System/File.vim
@@ -281,7 +281,9 @@ endfunction
 " Returns false if failure.
 function! s:mkdir_nothrow(...) abort
   try
-    return call('mkdir', a:000)
+    " Avoid Vim's bug: https://github.com/vim/vim/pull/2483
+    let ret = call('mkdir', a:000)
+    return ret
   catch
     return 0
   endtry

--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -184,7 +184,9 @@ let s:Vital._import = s:_function('s:_import')
 function! s:_get_module(name) abort dict
   let funcname = s:_import_func_name(self.plugin_name(), a:name)
   try
-    return call(funcname, [])
+    " Avoid Vim's bug: https://github.com/vim/vim/pull/2483
+    let ret = call(funcname, [])
+    return ret
   catch /^Vim\%((\a\+)\)\?:E117/
     return s:_get_builtin_module(a:name)
   endtry

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -55,7 +55,9 @@ endfunction
 
 function! s:git_checkout(hash) abort
   try
-    return s:git('checkout ' . a:hash)
+    " Avoid Vim's bug: https://github.com/vim/vim/pull/2483
+    let ret = s:git('checkout ' . a:hash)
+    return ret
   catch
     throw "vitalizer: 'git checkout' failed: " . v:exception
   endtry


### PR DESCRIPTION
Vim script の `:return {expr}` の `{expr}` で例外が飛んでも `:catch` で補足されないようです．回避する修正を入れました．

- 報告： https://github.com/vim-jp/issues/issues/1135
- 修正： https://github.com/vim/vim/pull/2483