### PR TITLE
Web.XML: Fix handling empty attribute values

### DIFF
--- a/autoload/vital/__vital__/Web/XML.vim
+++ b/autoload/vital/__vital__/Web/XML.vim
@@ -15,6 +15,9 @@ endfunction
 let s:__template = { 'name': '', 'attr': {}, 'child': [] }
 
 function! s:decodeEntityReference(str) abort
+  if a:str ==# ''
+    return a:str
+  endif
   let str = a:str
   let str = substitute(str, '&gt;', '>', 'g')
   let str = substitute(str, '&lt;', '<', 'g')
@@ -29,6 +32,9 @@ function! s:decodeEntityReference(str) abort
 endfunction
 
 function! s:encodeEntityReference(str) abort
+  if a:str ==# ''
+    return a:str
+  endif
   let str = a:str
   let str = substitute(str, '&', '\&amp;', 'g')
   let str = substitute(str, '>', '\&gt;', 'g')
@@ -209,9 +215,7 @@ function! s:__parse_tree(ctx, top) abort
     let tag_name = m[3]
     let attrs = m[4]
 
-    if m[1] !=# ''
-      let content .= s:decodeEntityReference(m[1])
-    endif
+    let content .= s:decodeEntityReference(m[1])
 
     if is_end_tag
       " closing tag: pop from stack and continue at upper level
@@ -244,7 +248,7 @@ function! s:__parse_tree(ctx, top) abort
       endif
       let name = attr_match[1]
       let value = attr_match[2] !=# '' ? attr_match[2] : attr_match[3] !=# '' ? attr_match[3] : attr_match[4] !=# '' ? attr_match[4] : ''
-      let node.attr[name] = value ==# '' ? '' : s:decodeEntityReference(value)
+      let node.attr[name] = s:decodeEntityReference(value)
       let attrs = attrs[stridx(attrs, attr_match[0]) + len(attr_match[0]):]
     endwhile
 

--- a/autoload/vital/__vital__/Web/XML.vim
+++ b/autoload/vital/__vital__/Web/XML.vim
@@ -244,10 +244,7 @@ function! s:__parse_tree(ctx, top) abort
       endif
       let name = attr_match[1]
       let value = attr_match[2] !=# '' ? attr_match[2] : attr_match[3] !=# '' ? attr_match[3] : attr_match[4] !=# '' ? attr_match[4] : ''
-      if value ==# ''
-        let value = name
-      endif
-      let node.attr[name] = s:decodeEntityReference(value)
+      let node.attr[name] = value ==# '' ? '' : s:decodeEntityReference(value)
       let attrs = attrs[stridx(attrs, attr_match[0]) + len(attr_match[0]):]
     endwhile
 

--- a/test/Web/XML.vimspec
+++ b/test/Web/XML.vimspec
@@ -1,0 +1,68 @@
+function! s:xml(...) abort
+  return join(['<?xml version="1.0" encoding="UTF-8"?>'] + a:000, "\n")
+endfunction
+
+Describe Web.XML
+  Before all
+    let X = vital#vital#import('Web.XML')
+  End
+
+  Describe .parse()
+    It parses an XML element
+      let s = s:xml('<test/>')
+      let doc = X.parse(s)
+      Assert Equal(doc.name, 'test')
+      Assert HasKey(doc, 'childNodes')
+      Assert Equal(len(doc.childNodes()), 0)
+      Assert Equal(len(doc.attr), 0)
+    End
+
+    It parses nested XML elements
+      let s = s:xml('<parent><child/></parent>')
+      let doc = X.parse(s)
+      Assert Equal(doc.name, 'parent')
+      let children = doc.childNodes()
+      Assert Equal(len(children), 1)
+      Assert Equal(children[0].name, 'child')
+      Assert Equal(len(children[0].childNodes()), 0)
+    End
+
+    It parses attributes of an XML element
+      let s = s:xml('<elem a="foo" b=''bar'' c="" d='''' e f = "piyo" g=baz />')
+      let doc = X.parse(s)
+      Assert Equal(doc.attr, {
+            \  'a': 'foo',
+            \  'b': 'bar',
+            \  'c': '',
+            \  'd': '',
+            \  'e': '',
+            \  'f': 'piyo',
+            \  'g': 'baz',
+            \ })
+    End
+
+    It parses comments
+      let s = s:xml(
+            \   '<--! comment -->',
+            \   '<--! ',
+            \   'comment',
+            \   ' -->',
+            \   '<test/>',
+            \   '<--! comment2 -->',
+            \ )
+      let doc = X.parse(s)
+      Assert Equals(doc.name, 'test')
+      Assert Equals(len(doc.childNodes()), 0)
+    End
+
+    It raises an error on empty document
+      let s = s:xml()
+      Throws /^vital: Web.XML: Parse Error$/ X.parse(s)
+    End
+
+    It raises an error when tag not closing
+      let s = s:xml('<foo')
+      Throws /^vital: Web.XML: Parse Error$/ X.parse(s)
+    End
+  End
+End


### PR DESCRIPTION
When parsing `<tag attr=""/>`, currently the value of `attr` is parsed as `'attr'`. But it should be `''` in XML. I fixed the point.

ref: https://twitter.com/mattn_jp/status/952766828199030784