### PR TITLE
Async.Promise: Add .finally() method to Promise object

### DIFF
--- a/doc/vital/Async/Promise.txt
+++ b/doc/vital/Async/Promise.txt
@@ -413,6 +413,36 @@ asynchronous operation. It represents one of following states:
 	  call Promise.reject('ERROR').then(v:null, {msg -> execute('echo msg', '')})
 	  call Promise.reject('ERROR').catch({msg -> execute('echo msg', '')})
 <
+{promise}.finally([{onFinally}])	*Vital.Async.Promise-Promise.finally()*
+
+	It returns a Promise and the passed callback is called once the
+	promise is settled, whether fulfilled or rejected.
+	This provides a way for code that must be executed once the promise
+	has been dealt with to be run whether it was fulfilled successfully or
+	rejected. {onFinally} is a |Funcref| which has no parameter.
+>
+	  " Both followings echo 'on finally'
+	  call Promise.resolve(42).finally({-> execute('echo "on finally"', '')})
+	  call Promise.reject('ERROR!').finally({-> execute('echo "on finally"', '')})
+<
+	|:throw| in the {onFinally} callback will reject the new promise with
+	the thrown error.
+
+	Unlike passing the callback to both 1st and 2nd parameters of
+	.then(), it propagates its receiver's result.
+>
+	  " Following echoes 42
+	  call Promise.resolve(42)
+	    \.finally({-> v:null})
+	    \.then({x -> execute('echo x', '')})
+<
+	Note:
+	As an above code, .finally() is different from .then() in terms of
+	the resolved/rejected value. `Promise.resolve(42).finally()` resolves
+	with 42, but `Promise.resolve(42).then({-> v:null}, {-> v:null})`
+	resolves with v:null.
+
+
 
 ------------------------------------------------------------------------------
 Exception Object			*Vital.Async.Promise-objects-Exception*

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -7,7 +7,7 @@ function! s:wait_has_key(obj, name) abort
     endif
     let i += 1
   endwhile
-  throw 's:wait_has_key(): After 5000ms, ' . string(a:obj) . ' did not have key ' . a:name
+  throw printf("s:wait_has_key(): After 5000ms, the given object does not have key '%s': %s", a:name, a:obj)
 endfunction
 
 function! s:resolver(resolve, reject) abort
@@ -401,6 +401,79 @@ Describe Async.Promise
         call s:wait_has_key(l, 'reason')
         Assert Equals(p._state, REJECTED)
         Assert Equals(reason, 42)
+      End
+    End
+
+    Describe .finally()
+      It should call its callback and propagate its parent's value when resolved
+        let l = l:
+        for l:Val in [42, 'foo', {'foo': 42}, {}, [1, 2, 3], [], function('empty')]
+          let p = P.resolve(l:Val).finally({-> extend(l, {'On_resolved': Val})})
+          call p.then({x -> extend(l, {'Result': x})})
+          call s:wait_has_key(l, 'Result')
+          Assert HasKey(l, 'On_resolved')
+          Assert Equals(p._state, FULFILLED)
+          Assert Equals(Result, Val)
+          Assert Equals(l.On_resolved, Val)
+          unlet l:Val
+          unlet l:On_resolved
+          unlet l:Result
+        endfor
+      End
+
+      It should call its callback and propagate its parent's value when rejected
+        let l = l:
+        for l:Val in [42, 'foo', {'foo': 42}, {}, [1, 2, 3], [], function('empty')]
+          let p = P.reject(l:Val).finally({-> extend(l, {'On_rejected': Val})})
+          call p.catch({x -> extend(l, {'Err': x})})
+          call s:wait_has_key(l, 'Err')
+          Assert HasKey(l, 'On_rejected')
+          Assert Equals(p._state, REJECTED)
+          Assert Equals(Err, Val)
+          Assert Equals(l.On_rejected, Val)
+          unlet l:Val
+          unlet l:On_rejected
+          unlet l:Err
+        endfor
+      End
+
+      It should just propagates a resolved value when no argument given
+        let l = l:
+        let p = P.resolve(42).finally()
+        call p.then({x -> extend(l, {'result': x})})
+        call s:wait_has_key(l, 'result')
+        Assert Equals(p._state, FULFILLED)
+        Assert Equals(l.result, 42)
+      End
+
+      It should just propagates a rejected value when no argument given
+        let l = l:
+        let p = P.reject('ERROR!').finally()
+        call p.catch({x -> extend(l, {'err': x})})
+        call s:wait_has_key(l, 'err')
+        Assert Equals(p._state, REJECTED)
+        Assert Equals(l.err, 'ERROR!')
+      End
+
+      It should not pass parent's result to its callback
+        let l = l:
+        let p = P.resolve(42).finally({x -> extend(l, {'on_finally': x})})
+        call p.catch({e -> extend(l, {'err': e})})
+        call s:wait_has_key(l, 'err')
+        Assert Equals(p._state, REJECTED)
+        Assert KeyNotExists(l, 'on_finally')
+        Assert HasKey(err, 'throwpoint')
+        Assert Equals(stridx(err.exception, 'Vim(call):E119:'), 0, err.exception)
+      End
+
+      It should return rejected promise when an exception is thrown in its callback
+        let l = l:
+        let p = P.resolve(42).finally({-> execute('throw "Exception in onFinally"')})
+        call p.catch({e -> extend(l, {'err': e})})
+        call s:wait_has_key(l, 'err')
+        Assert Equals(p._state, REJECTED)
+        Assert HasKey(err, 'throwpoint')
+        Assert Equals(err.exception, 'Exception in onFinally')
       End
     End
   End


### PR DESCRIPTION
I implemented .finally() method to Promise object.

.finally() is a method which executes its callback when the receiver is settled (whether resolved or rejected). It is similar to :finally.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally

Now `Promise.prototype.finally` is on stage4 (last phase for being the part of ECMAScript spec). So it'll be standard soon.

https://github.com/tc39/proposal-promise-finally#readme