### PR TITLE
DateTime: use strftime('%H %M', 0) on Windows

### DIFF
--- a/autoload/vital/__vital__/DateTime.vim
+++ b/autoload/vital/__vital__/DateTime.vim
@@ -799,9 +799,8 @@ if has('win16') || has('win32') || has('win64')
   function! s:_default_tz() abort
     let hm = map(split(strftime('%H %M', 0), ' '), 'str2nr(v:val)')
     if str2nr(strftime('%Y', 0)) != 1970
-      let tz_sec = hm[0] * s:NUM_SECONDS * s:NUM_MINUTES + hm[1] * s:NUM_SECONDS
-      let tz_sec = s:NUM_SECONDS * s:NUM_MINUTES * s:NUM_HOURS - tz_sec
-      return printf('-%02d%02d', tz_sec / s:NUM_SECONDS / s:NUM_MINUTES, (tz_sec / s:NUM_SECONDS) % s:NUM_MINUTES)
+      let tz_sec = s:SECONDS_OF_DAY - hm[0] * s:SECONDS_OF_HOUR + hm[1] * s:NUM_SECONDS
+      return printf('-%02d%02d', tz_sec / s:SECONDS_OF_HOUR, (tz_sec / s:NUM_SECONDS) % s:NUM_MINUTES)
     endif
     return printf('+%02d%02d', hm[0], hm[1])
   endfunction

--- a/autoload/vital/__vital__/DateTime.vim
+++ b/autoload/vital/__vital__/DateTime.vim
@@ -797,13 +797,13 @@ endfunction
 " TODO Use Prelude.is_windows() to avoid duplicate
 if has('win16') || has('win32') || has('win64')
   function! s:_default_tz() abort
-    let l:hms = map(split(strftime('%H %M', 0), ' '), 'str2nr(v:val)')
-    let l:tz_sec = l:hms[0] * s:NUM_SECONDS * s:NUM_MINUTES + l:hms[1] * s:NUM_SECONDS
+    let hm = map(split(strftime('%H %M', 0), ' '), 'str2nr(v:val)')
     if str2nr(strftime('%Y', 0)) != 1970
-      let l:tz_sec = s:NUM_SECONDS * s:NUM_MINUTES * s:NUM_HOURS - l:tz_sec
-      return printf('-%02d%02d', l:tz_sec / s:NUM_SECONDS / s:NUM_MINUTES, (l:tz_sec / s:NUM_SECONDS) % s:NUM_MINUTES)
+      let tz_sec = hm[0] * s:NUM_SECONDS * s:NUM_MINUTES + hm[1] * s:NUM_SECONDS
+      let tz_sec = s:NUM_SECONDS * s:NUM_MINUTES * s:NUM_HOURS - tz_sec
+      return printf('-%02d%02d', tz_sec / s:NUM_SECONDS / s:NUM_MINUTES, (tz_sec / s:NUM_SECONDS) % s:NUM_MINUTES)
     endif
-    return printf('+%02d%02d', l:hms[0], l:hms[1])
+    return printf('+%02d%02d', hm[0], hm[1])
   endfunction
 else
   function! s:_default_tz() abort

--- a/autoload/vital/__vital__/DateTime.vim
+++ b/autoload/vital/__vital__/DateTime.vim
@@ -799,7 +799,7 @@ if has('win16') || has('win32') || has('win64')
   function! s:_default_tz() abort
     let hm = map(split(strftime('%H %M', 0), ' '), 'str2nr(v:val)')
     if str2nr(strftime('%Y', 0)) != 1970
-      let tz_sec = s:SECONDS_OF_DAY - hm[0] * s:SECONDS_OF_HOUR + hm[1] * s:NUM_SECONDS
+      let tz_sec = s:SECONDS_OF_DAY - hm[0] * s:SECONDS_OF_HOUR - hm[1] * s:NUM_SECONDS
       return printf('-%02d%02d', tz_sec / s:SECONDS_OF_HOUR, (tz_sec / s:NUM_SECONDS) % s:NUM_MINUTES)
     endif
     return printf('+%02d%02d', hm[0], hm[1])

--- a/autoload/vital/__vital__/DateTime.vim
+++ b/autoload/vital/__vital__/DateTime.vim
@@ -797,14 +797,14 @@ endfunction
 " TODO Use Prelude.is_windows() to avoid duplicate
 if has('win16') || has('win32') || has('win64')
   function! s:_default_tz() abort
-    let item = split(strftime('%c', 0), ' ')
-    let hms = map(split(item[1], '[^0-9]'), 'str2nr(v:val)')
-    let tz_sec = hms[0] * 60 * 60 + hms[1] * 60
-    if item[0] !~ '^1970'
-      let tz_sec = 60 * 60 * 24 - tz_sec
-      return printf('-%02d%02d', tz_sec / 60 / 60, (tz_sec / 60) % 60)
+    let l:item = split(strftime('%c', 0), ' ')
+    let l:hms = map(split(l:item[1], '[^0-9]'), 'str2nr(v:val)')
+    let l:tz_sec = l:hms[0] * 60 * 60 + l:hms[1] * 60
+    if l:item[0] !~# '^1970'
+      let l:tz_sec = 60 * 60 * 24 - l:tz_sec
+      return printf('-%02d%02d', l:tz_sec / 60 / 60, (l:tz_sec / 60) % 60)
     endif
-    return printf('+%02d%02d', hms[0], hms[1])
+    return printf('+%02d%02d', l:hms[0], l:hms[1])
   endfunction
 else
   function! s:_default_tz() abort

--- a/autoload/vital/__vital__/DateTime.vim
+++ b/autoload/vital/__vital__/DateTime.vim
@@ -797,12 +797,11 @@ endfunction
 " TODO Use Prelude.is_windows() to avoid duplicate
 if has('win16') || has('win32') || has('win64')
   function! s:_default_tz() abort
-    let l:item = split(strftime('%c', 0), ' ')
-    let l:hms = map(split(l:item[1], '[^0-9]'), 'str2nr(v:val)')
-    let l:tz_sec = l:hms[0] * 60 * 60 + l:hms[1] * 60
-    if l:item[0] !~# '^1970'
-      let l:tz_sec = 60 * 60 * 24 - l:tz_sec
-      return printf('-%02d%02d', l:tz_sec / 60 / 60, (l:tz_sec / 60) % 60)
+    let l:hms = map(split(strftime('%H %M', 0), ' '), 'str2nr(v:val)')
+    let l:tz_sec = l:hms[0] * s:NUM_SECONDS * s:NUM_MINUTES + l:hms[1] * s:NUM_SECONDS
+    if str2nr(strftime('%Y', 0)) != 1970
+      let l:tz_sec = s:NUM_SECONDS * s:NUM_MINUTES * s:NUM_HOURS - l:tz_sec
+      return printf('-%02d%02d', l:tz_sec / s:NUM_SECONDS / s:NUM_MINUTES, (l:tz_sec / s:NUM_SECONDS) % s:NUM_MINUTES)
     endif
     return printf('+%02d%02d', l:hms[0], l:hms[1])
   endfunction

--- a/autoload/vital/__vital__/DateTime.vim
+++ b/autoload/vital/__vital__/DateTime.vim
@@ -26,13 +26,6 @@ function! s:_vital_loaded(V) abort
   let s:AM_PM_TIMES = map([0, 12],
   \   's:from_date(1970, 1, 1, v:val, 0, 0, 0).unix_time()')
 
-  if s:Prelude.is_windows()
-    let key = 'HKLM\System\CurrentControlSet\Control\TimeZoneInformation'
-    let regs = s:Process.system(printf('reg query "%s" /v Bias', key))
-    let time = matchstr(regs, 'REG_DWORD\s*\zs0x\x\+')
-    let s:win_tz = empty(time) ? 0 : s:Bitwise.sign_extension(time) / -s:NUM_MINUTES
-  endif
-
   " default values
   call extend(s:DateTime, {
   \   '_year': 0,
@@ -804,7 +797,14 @@ endfunction
 " TODO Use Prelude.is_windows() to avoid duplicate
 if has('win16') || has('win32') || has('win64')
   function! s:_default_tz() abort
-    return s:win_tz
+    let item = split(strftime('%c', 0), ' ')
+    let hms = map(split(item[1], '[^0-9]'), 'str2nr(v:val)')
+    let tz_sec = hms[0] * 60 * 60 + hms[1] * 60
+    if item[0] !~ '^1970'
+      let tz_sec = 60 * 60 * 24 - tz_sec
+      return printf('-%02d%02d', tz_sec / 60 / 60, (tz_sec / 60) % 60)
+    endif
+    return printf('+%02d%02d', hms[0], hms[1])
   endfunction
 else
   function! s:_default_tz() abort


### PR DESCRIPTION
Current implementation on Windows use Windows registory since %z on Windows return '東京 (標準時)'. But it is bit slow. strftime('%c', 0) must be epoch based on 1970/1/1 0:0:0, so hours and minutes
must be time offset.