### PR TITLE
Make CI faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ matrix:
       env:
         - VIM_VERSION=master
         - THEMIS_PROFILE=vim-profile-master.txt
-        - RUN_LINT=true
     - os: osx
       osx_image: xcode8.3
       env:
         - THEMIS_PROFILE=vim-profile-osx.txt
+    - os: linux
+      env:
+        - RUN_LINT=true
 
 addons:
   apt:
@@ -53,16 +55,14 @@ script:
   - uname -a
   - which -a vim
   - vim --cmd version --cmd quit
-  - vim --cmd "try | helptags doc/ | catch | cquit | endtry" --cmd quit
-  # - /tmp/vim-themis/bin/themis --runtimepath /tmp/vimproc --reporter dot
-  - /tmp/vim-themis/bin/themis --runtimepath /tmp/vimproc --exclude ConcurrentProcess --reporter dot
-  - ruby scripts/check-changelog.rb
+  - |
+    if [[ "${RUN_LINT}" != "true" ]]; then
+        /tmp/vim-themis/bin/themis --runtimepath /tmp/vimproc --exclude ConcurrentProcess --reporter dot
+    fi
   - if [[ "${RUN_LINT}" == "true" ]] ; then bash scripts/run-lint-on-ci.sh ; fi
 
 after_success:
-  - covimerage write_coverage $THEMIS_PROFILE
-  - coverage xml
-  - bash <(curl -s https://codecov.io/bash)
+  - bash scripts/coverage.sh
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,6 @@ addons:
       - python-dev
       - python3-dev
       - python3-pip
-      - liblua5.1-0-dev
-      - lua5.1
       - ruby-dev
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,9 @@ addons:
     packages:
       - language-pack-ja
       - vim
-      - libperl-dev
       - python-dev
       - python3-dev
       - python3-pip
-      - ruby-dev
 
 install:
   - rvm reset

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ev
+
+if [[ "${THEMIS_PROFILE}" == "" ]]; then
+    exit
+fi
+
+covimerage write_coverage $THEMIS_PROFILE
+coverage xml
+bash <(curl -s https://codecov.io/bash)

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -8,14 +8,14 @@ case "${TRAVIS_OS_NAME}" in
 		cd /tmp/vim
 		./configure --prefix="${HOME}/vim" --with-features=huge \
 			--enable-perlinterp --enable-pythoninterp --enable-python3interp \
-			--enable-rubyinterp --enable-luainterp --enable-fail-if-missing
+			--enable-rubyinterp --enable-fail-if-missing
 		make -j2
 		make install
 		;;
 	osx)
 		export HOMEBREW_NO_AUTO_UPDATE=1
 		brew update
-		brew install macvim --with-override-system-vim --with-lua
+		brew install macvim --with-override-system-vim
 		;;
 	*)
 		echo "Unknown value of \${TRAVIS_OS_NAME}: ${TRAVIS_OS_NAME}"

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -15,7 +15,10 @@ case "${TRAVIS_OS_NAME}" in
 	osx)
 		export HOMEBREW_NO_AUTO_UPDATE=1
 		brew update
-		brew install macvim --with-override-system-vim
+		brew install macvim
+		# Instead of --with-override-system-vim, manually link the executable because
+		# it prevents MacVim installation with a bottle.
+		ln -s "$(brew --prefix macvim)/bin/mvim" "/usr/local/bin/vim"
 		;;
 	*)
 		echo "Unknown value of \${TRAVIS_OS_NAME}: ${TRAVIS_OS_NAME}"

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -16,8 +16,6 @@ case "${TRAVIS_OS_NAME}" in
 		make install
 		;;
 	osx)
-		export HOMEBREW_NO_AUTO_UPDATE=1
-		brew update
 		brew install macvim
 		# Instead of --with-override-system-vim, manually link the executable because
 		# it prevents MacVim installation with a bottle.

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -4,6 +4,9 @@ set -ev
 
 case "${TRAVIS_OS_NAME}" in
 	linux)
+		if [[ "${VIM_VERSION}" == "" ]]; then
+			exit
+		fi
 		git clone --depth 1 --branch "${VIM_VERSION}" https://github.com/vim/vim /tmp/vim
 		cd /tmp/vim
 		./configure --prefix="${HOME}/vim" --with-features=huge \

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -9,9 +9,8 @@ case "${TRAVIS_OS_NAME}" in
 		fi
 		git clone --depth 1 --branch "${VIM_VERSION}" https://github.com/vim/vim /tmp/vim
 		cd /tmp/vim
-		./configure --prefix="${HOME}/vim" --with-features=huge \
-			--enable-perlinterp --enable-pythoninterp --enable-python3interp \
-			--enable-rubyinterp --enable-fail-if-missing
+		./configure --prefix="${HOME}/vim" --with-features=huge --enable-pythoninterp \
+			--enable-python3interp --enable-fail-if-missing
 		make -j2
 		make install
 		;;

--- a/scripts/run-lint-on-ci.sh
+++ b/scripts/run-lint-on-ci.sh
@@ -34,3 +34,9 @@ go get -d -v ./scripts
 
 # Run reviewdog.
 reviewdog -reporter=github-pr-check
+
+# Check tag name conflicts
+vim --cmd "try | helptags doc/ | catch | cquit | endtry" --cmd quit
+
+# Validate changelog
+ruby scripts/check-changelog.rb


### PR DESCRIPTION
I made running CI faster.

Before: https://travis-ci.org/vim-jp/vital.vim/builds/390362502
After: https://travis-ci.org/rhysd/vital.vim/builds/390389523

Total: 5min 47sec -> 4min 2sec (1min 45sec faster)

Optimizations:

- Enabled a binary package (bottle) on macOS worker by removing installation options which prevented it. (4m54s -> 2m58s)
  - macOS worker is slow to start. It was a bottleneck.
  - Removed Lua dependency since Lua was not actually used in CI. (`--with-lua` could be omitted by this change)
  - Link `vim` executable directly (`--with-override-system-vim` could be omitted by this change)
- Separate running linters into another job.
  - Since it took 200s.
  - After optimizing macOS worker, the job which run linters was a bottleneck.

I assigned people as reviewers who would be familiar with
- CI scripts
- macOS

Fix #534 