### PR TITLE
Web.HTTP: Support HEAD method for curl client

### DIFF
--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -498,7 +498,12 @@ function! s:clients.curl.request(settings) abort
   if has_key(a:settings, 'gzipDecompress') && a:settings.gzipDecompress
     let command .= ' --compressed '
   endif
-  let command .= ' -L -s -k -X ' . a:settings.method
+  let command .= ' -L -s -k '
+  if a:settings.method ==? 'HEAD'
+    let command .= '--head'
+  else
+    let command .= '-X ' . a:settings.method
+  endif
   let command .= ' --max-redirs ' . a:settings.maxRedirect
   let command .= s:_make_header_args(a:settings.headers, '-H ', quote)
   let timeout = get(a:settings, 'timeout', '')
@@ -543,7 +548,7 @@ function! s:clients.curl.request(settings) abort
   else
     let responses = [[[], '']]
   endif
-  if has_output_file
+  if has_output_file || a:settings.method ==? 'HEAD'
     let content = ''
   else
     let content = s:_readfile(output_file)


### PR DESCRIPTION
# Problem

Currently `Web.HTTP.request()` function does not work with `HEAD` HTTP method when client is curl.

## reproduce

```vim
let V = vital#of('vital')
let HTTP = V.import('Web.HTTP')

echo HTTP.request('http://example.com', {"method": 'HEAD', "client": 'curl'}) " Stop this program here!
```



# Cause


curl(1) does not support `-X HEAD`.

```bash
$ curl -X HEAD http://example.com
Warning: Setting custom HTTP method to HEAD with -X/--request may not work the 
Warning: way you want. Consider using -I/--head instead.
```


# Solution


Use `--head` option instead of `-X HEAD`.