### PR TITLE
Web.HTTP: Change how to get quote character

### DIFF
--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -646,7 +646,7 @@ function! s:clients.wget.request(settings) abort
 endfunction
 
 function! s:_quote() abort
-  return shellescape('')[0]
+  return &shell =~# 'sh$' ? "'" : '"'
 endfunction
 
 let &cpo = s:save_cpo

--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -646,7 +646,7 @@ function! s:clients.wget.request(settings) abort
 endfunction
 
 function! s:_quote() abort
-  return &shellxquote ==# '"' ?  "'" : '"'
+  return shellescape('')[0]
 endfunction
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
On Neovim v0.3.1 on Windows8.1, s:_quote() in Web/HTTP.vim returns ', but command line parameters must be quoted by ", not by ' on Windows.
shellescape('')[0] should return a correct quote character.