### PR TITLE
write-coverage -> write_coverage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -33,7 +33,7 @@ after_test:
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov
   - pip install covimerage
-  - covimerage write-coverage %THEMIS_PROFILE%
+  - covimerage write_coverage %THEMIS_PROFILE%
   - coverage xml
   - codecov -f coverage.xml
 


### PR DESCRIPTION
ref. Vimjas/covimerage#57, #608 

Now the new version of covimerage is uploaded to PyPI.
So let's fix the command name again.

@ujihisa @thinca Sorry! please approve this again.