### PR TITLE
Data.Optional: Expect functions as the alternative of .get_or

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+3d60a4ce079fd0d4e123cbcea787a1769cab7572
+	Modules: Data.Optional
+	Data.Optional.get_or will expect a function as {alternative}.
+	It was expecting a value as {alternative}.
 1a595b4d77d518b1cb60b36d1eac7cfde61d94f9
 	Modules: Deprecated.ProcessManager
 	Remove completely

--- a/autoload/vital/__vital__/Data/Optional.vim
+++ b/autoload/vital/__vital__/Data/Optional.vim
@@ -63,7 +63,7 @@ function! s:get_unsafe(o) abort
 endfunction
 
 function! s:get_or(o, alt) abort
-  return get(a:o, 0, a:alt)
+  return get(a:o, 0, a:alt())
 endfunction
 
 function! s:has(o, type) abort

--- a/doc/vital/Data/Optional.txt
+++ b/doc/vital/Data/Optional.txt
@@ -108,7 +108,11 @@ get({optional})				*Vital.Data.Optional.get()*
 
 get_or({optional}, {alternative})	*Vital.Data.Optional.get_or()*
 	Returns a contained value in {optional}.  If {optional} is an invalid
-	value, it returns {alternative} instead.
+	value, it returns the {alternative}'s value instead.
+>
+	echo O.get_or(O.new(10), { -> -1 }) " 10
+	echo O.get_or(O.none(),  { -> -1 }) " -1
+<
 
 get_unsafe({optional})			*Vital.Data.Optional.get_unsafe()*
 	Returns a contained value in {optional}.  If {optional} is an invalid

--- a/test/Data/Optional.vimspec
+++ b/test/Data/Optional.vimspec
@@ -96,14 +96,24 @@ Describe Data.Optional
   End
 
   Describe .get_or()
-    It returns the content of optional value
-      let o = O.some(42)
-      Assert Equals(O.get_or(o, -1), 42)
+    Before all
+      function! Negative1() abort
+        return -1
+      endfunction
     End
 
-    It returns the second argument as alternative if the first argument is invalid
+    After all
+      delfunction Negative1
+    End
+
+    It returns the content of optional value
+      let o = O.some(42)
+      Assert Equals(O.get_or(o, function('Negative1')), 42)
+    End
+
+    It returns the second argument result as alternative if the first argument is invalid
       let o = O.none()
-      Assert Equals(O.get_or(o, -1), -1)
+      Assert Equals(O.get_or(o, function('Negative1')), -1)
     End
   End
 


### PR DESCRIPTION
## 問題
現在の `.get_or` は代替として値を受け取っており、こういうときに不便 :sob:

```vim
let s:Msg = vital#foo#import('Vim.Message')

let x = s:なんかOptionalを返すやつ()
call s:Optional.get_or(x, s:Msg.error('無効な値がきたよ'))
" ↑ 本当はxがnoneだった場合にerrorを表示したいけど、
"    これだとどちらにせよerrorが表示されちゃう
```

## 改善案（このPRが与える変更）

```vim
let s:Msg = vital#foo#import('Vim.Message')

let x = s:なんかOptionalを返すやつ()
call s:Optional.get_or(x, { -> s:Msg.error('無効な値がきたよ') })
" ↑ xがnoneのときだけerrorが呼ばれる
```

## 議論が必要な点

- `.get_or`に破壊的変更が入る
    - `.get_or_else`という名前で新しく生やすのもいいと思うんだけど、  
      ユーザー的にわかりにくかったりするかどうかというのを考えている。  
      （どうでしょうか…… :thinking:）
