### PR TITLE
System.File: quote file names in command arguments

### DIFF
--- a/autoload/vital/__vital__/System/File.vim
+++ b/autoload/vital/__vital__/System/File.vim
@@ -117,13 +117,15 @@ elseif s:is_windows
     let dest = substitute(dest, '[/\\]\+', '\', 'g')
     " src must not have trailing '\'.
     let src  = substitute(src, '\\$', '', 'g')
+
     " All characters must be encoded to system encoding.
     if s:need_trans
       let src  = iconv(src, &encoding, 'char')
       let dest = iconv(dest, &encoding, 'char')
     endif
+
     let cmd_exe = (&shell =~? 'cmd\.exe$' ? '' : 'cmd /c ')
-    call system(cmd_exe . 'move /y ' . src  . ' ' . dest)
+    call system(cmd_exe . 'move /y "' . src  . '" "' . dest . '"')
     return !v:shell_error
   endfunction
 else
@@ -162,9 +164,17 @@ elseif s:is_windows
     if !s:_has_copy_dir_exe()
       return 0
     endif
-    let src  = s:_shellescape_robocopy(a:src)
-    let dest = s:_shellescape_robocopy(a:dest)
-    call system('robocopy /e ' . src . ' ' . dest)
+    let [src, dest] = [a:src, a:dest]
+    let src  = s:_shellescape_robocopy(src)
+    let dest = s:_shellescape_robocopy(dest)
+
+    " All characters must be encoded to system encoding.
+    if s:need_trans
+      let src  = iconv(src, &encoding, 'char')
+      let dest = iconv(dest, &encoding, 'char')
+    endif
+
+    call system('robocopy /e "' . src . '" "' . dest . '"')
     return v:shell_error <# 8
   endfunction
   function! s:_shellescape_robocopy(path) abort
@@ -256,8 +266,15 @@ elseif s:is_windows
     let [src, dest] = [a:src, a:dest]
     let src  = substitute(src, '/', '\', 'g')
     let dest = substitute(dest, '/', '\', 'g')
+
+    " All characters must be encoded to system encoding.
+    if s:need_trans
+      let src  = iconv(src, &encoding, 'char')
+      let dest = iconv(dest, &encoding, 'char')
+    endif
+
     let cmd_exe = (&shell =~? 'cmd\.exe$' ? '' : 'cmd /c ')
-    call system(cmd_exe . 'copy /y ' . src . ' ' . dest)
+    call system(cmd_exe . 'copy /y "' . src . '" "' . dest . '"')
     return !v:shell_error
   endfunction
 else
@@ -312,22 +329,19 @@ elseif s:is_unix
 
 elseif s:is_windows
   function! s:rmdir(path, ...) abort
+    let path = a:path
     let flags = a:0 ? a:1 : ''
-    if &shell =~? 'sh$'
-      let cmd = flags =~# 'r' ? 'rm -rf' : 'rmdir'
-      let ret = system(cmd . ' ' . shellescape(a:path))
-    else
-      " 'f' flag does not make sense.
-      let cmd = 'rmdir /Q'
-      let cmd .= flags =~# 'r' ? ' /S' : ''
-      let ret = system(cmd . ' "' . a:path . '"')
+    " All characters must be encoded to system encoding.
+    if s:need_trans
+      let path  = iconv(path, &encoding, 'char')
     endif
-    if v:shell_error
-      let ret = iconv(ret, 'char', &encoding)
-      throw 'vital: System.File: rmdir(): ' . substitute(ret, '\n', '', 'g')
-    endif
-  endfunction
 
+    " 'f' flag does not make sense.
+    let cmd = 'rmdir /Q'
+    let cmd .= flags =~# 'r' ? ' /S' : ''
+    call system(cmd . ' "' . path . '"')
+    return !v:shell_error
+  endfunction
 else
   function! s:rmdir(...) abort
     throw 'vital: System.File: rmdir(): your platform is not supported'


### PR DESCRIPTION
Also fixing encoding of arguments

Fixes #616 

For fixing this, I removed part throwing exceptionin rmdir and fallback to rm-rf command since there are no sense of unity for code. I may add this again.

```vim
    if v:shell_error	
      let ret = iconv(ret, 'char', &encoding)	
      throw 'vital: System.File: rmdir(): ' . substitute(ret, '\n', '', 'g')	
    endif
```

```vim
 if &shell =~? 'sh$'	    " All characters must be encoded to system encoding.
      let cmd = flags =~# 'r' ? 'rm -rf' : 'rmdir'	    if s:need_trans
      let ret = system(cmd . ' ' . shellescape(a:path))	      let path  = iconv(path, &encoding, 'char')
    else
```

I think we should decide what should do here.

* Arguments must be converted to &encoding to char? (yes, fixed)
* Need to quote with double-quote in the command? (yes, fixed)
* Need to throw exception when the command fail?
* Need to do fallback with another command?

Any thought?