### PR TITLE
Output v:throwpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         - VIM_VERSION=master
         - THEMIS_PROFILE=vim-profile-master.txt
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.4
       env:
         - THEMIS_PROFILE=vim-profile-osx.txt
     - os: linux
@@ -39,7 +39,6 @@ install:
   - bash scripts/install-vim.sh
   - export PATH=$HOME/vim/bin:$PATH
     # Install https://github.com/Vimjas/covimerage
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then brew install python3 ; fi
   - pip3 install --user --upgrade pip
   - pip3 install --user --upgrade setuptools
   - pip3 install --user covimerage

--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -158,7 +158,7 @@ function! s:_import(name) abort dict
       call module._vital_loaded(vital#{s:plugin_name}#new())
     catch
       unlet s:loaded[a:name]
-      throw 'vital: fail to call ._vital_loaded(): ' . v:exception
+      throw 'vital: fail to call ._vital_loaded(): ' . v:exception . "\nat " . v:throwpoint
     endtry
   endif
   return copy(s:loaded[a:name])

--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -158,12 +158,45 @@ function! s:_import(name) abort dict
       call module._vital_loaded(vital#{s:plugin_name}#new())
     catch
       unlet s:loaded[a:name]
-      throw 'vital: fail to call ._vital_loaded(): ' . v:exception . "\nat " . v:throwpoint
+      throw 'vital: fail to call ._vital_loaded(): ' . v:exception . " from:\n" . s:format_throwpoint(v:throwpoint)
     endtry
   endif
   return copy(s:loaded[a:name])
 endfunction
 let s:Vital._import = function('s:_import')
+
+function! s:format_throwpoint(throwpoint) abort
+  let funcs = []
+  for line in split(a:throwpoint, '\.\.')
+    let m = matchlist(line, '^\%(<SNR>\(\d\+\)_\)\?\(.\+\)\[\(\d\+\)\]$')
+    if empty(m)
+      call add(funcs, line)
+      continue
+    endif
+    let [sid, name, lnum] = m[1:3]
+    let attr = ''
+    if !empty(sid)
+      let name = printf('<SNR>%d_%s', sid, name)
+    endif
+    let file = s:get_file_by_func_name(name)
+    call add(funcs, printf('function %s(...)%s Line:%d (%s)', name, attr, lnum, file))
+  endfor
+  return join(funcs, "\n")
+endfunction
+
+function! s:get_file_by_func_name(name) abort
+  redir => body
+  silent execute 'verbose function' a:name
+  redir END
+  let lines = split(body, "\n")
+  let signature = matchstr(lines[0], '^\s*\zs.*')
+  let file = matchstr(lines[1], '^\t\%(Last set from\|.\{-}:\)\s*\zs.*$')
+  let file = substitute(file, '[/\\]\+', '/', 'g')
+  " let arguments = split(matchstr(signature, '(\zs.*\ze)'), '\s*,\s*')
+  " let has_extra_arguments = get(arguments, -1, '') ==# '...'
+  " let arity = len(arguments) - (has_extra_arguments ? 1 : 0)
+  return file
+endfunction
 
 " s:_get_module() returns module object wihch has all script local functions.
 function! s:_get_module(name) abort dict

--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -167,7 +167,8 @@ let s:Vital._import = function('s:_import')
 
 function! s:format_throwpoint(throwpoint) abort
   let funcs = []
-  for line in split(a:throwpoint, '\.\.')
+  let stack = matchstr(a:throwpoint, '^function \zs.*\ze, line \d\+$')
+  for line in split(stack, '\.\.')
     let m = matchlist(line, '^\%(<SNR>\(\d\+\)_\)\?\(.\+\)\[\(\d\+\)\]$')
     if empty(m)
       call add(funcs, line)
@@ -185,9 +186,12 @@ function! s:format_throwpoint(throwpoint) abort
 endfunction
 
 function! s:get_file_by_func_name(name) abort
-  redir => body
-  silent execute 'verbose function' a:name
-  redir END
+  try
+    redir => body
+    silent execute 'verbose function' a:name
+  finally
+    redir END
+  endtry
   let lines = split(body, "\n")
   let signature = matchstr(lines[0], '^\s*\zs.*')
   let file = matchstr(lines[1], '^\t\%(Last set from\|.\{-}:\)\s*\zs.*$')

--- a/scripts/install-vim.sh
+++ b/scripts/install-vim.sh
@@ -18,7 +18,7 @@ case "${TRAVIS_OS_NAME}" in
 		brew install macvim
 		# Instead of --with-override-system-vim, manually link the executable because
 		# it prevents MacVim installation with a bottle.
-		ln -s "$(brew --prefix macvim)/bin/mvim" "/usr/local/bin/vim"
+		ln -fs "$(brew --prefix macvim)/bin/mvim" "/usr/local/bin/vim"
 		;;
 	*)
 		echo "Unknown value of \${TRAVIS_OS_NAME}: ${TRAVIS_OS_NAME}"


### PR DESCRIPTION
Ref. https://github.com/vim-jp/vital.vim/pull/624#issuecomment-450456144

vitalizer の import 時にエラーが起きると、スタックトレースが含まれてなくてどこで起きたか分からなかったので足しました。
@ichizok さんの #624 のブランチをベースにしてます。