### PR TITLE
Fix calling luaeval()

### DIFF
--- a/autoload/vital/__vital__/Deprecated/Lua/Prelude.vim
+++ b/autoload/vital/__vital__/Deprecated/Lua/Prelude.vim
@@ -13,7 +13,7 @@ let s:sfile = tr(expand('<sfile>:p'), '\', '/')
 function! s:_vital_loaded(V) abort
   if exists('*luaeval')
     execute printf('lua vital_context = "%s"', s:sfile)
-    call luaeval('dofile(_A)', s:luafile_of(s:sfile))
+    call luaeval('0,dofile(_A)', s:luafile_of(s:sfile))
   endif
 endfunction
 

--- a/autoload/vital/__vital__/Deprecated/Text/Sexp.vim
+++ b/autoload/vital/__vital__/Deprecated/Text/Sexp.vim
@@ -13,7 +13,7 @@ function! s:_vital_loaded(V) abort
 
   if exists('*luaeval')
     execute printf('lua vital_context = "%s"', escape(s:sfile, '\'))
-    call luaeval('dofile(_A)', substitute(s:sfile, '.vim$', '.lua', ''))
+    call luaeval('0,dofile(_A)', substitute(s:sfile, '.vim$', '.lua', ''))
   endif
 endfunction
 

--- a/autoload/vital/__vital__/Interpreter/Brainf__k.vim
+++ b/autoload/vital/__vital__/Interpreter/Brainf__k.vim
@@ -14,7 +14,7 @@ function! s:_vital_loaded(V) abort
     let s:LuaP = s:P.lua_namespace()
 
     execute printf('lua vital_context = "%s"', escape(s:sfile, '\'))
-    call luaeval('dofile(_A)', substitute(s:sfile, '.vim$', '.lua', ''))
+    call luaeval('0,dofile(_A)', substitute(s:sfile, '.vim$', '.lua', ''))
   endif
 endfunction
 


### PR DESCRIPTION
`luaeval()` で評価した式がtableを返したり (`dofile()` など) 値を返さなかったり (`print()` など) すると cannot convert value エラーになるので、明示的に戻り値を指定しました。