### PR TITLE
Data.List: add new()

### DIFF
--- a/autoload/vital/__vital__/Data/List.vim
+++ b/autoload/vital/__vital__/Data/List.vim
@@ -3,6 +3,10 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+function! s:new(size, f) abort
+  return map(range(0, a:size - 1), a:f)
+endfunction
+
 function! s:pop(list) abort
   return remove(a:list, -1)
 endfunction

--- a/autoload/vital/__vital__/Data/List.vim
+++ b/autoload/vital/__vital__/Data/List.vim
@@ -4,7 +4,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! s:new(size, f) abort
-  return map(range(0, a:size - 1), a:f)
+  return map(range(a:size), a:f)
 endfunction
 
 function! s:pop(list) abort

--- a/doc/vital/Data/List.txt
+++ b/doc/vital/Data/List.txt
@@ -48,6 +48,22 @@ INTERFACE				*Vital.Data.List-interface*
 ------------------------------------------------------------------------------
 FUNCTIONS				*Vital.Data.List-functions*
 
+new({size}, {f})			*Vital.Data.List.new()*
+	Create a new |List| with given arguments. The given |Funcref| {f} is
+	called for {size} times with index.
+>
+	s:L.new(3, { i -> i * 2 })
+	"=> [0, 2, 4]
+
+	s:L.new(4, { -> 'hello' })
+	"=> ['hello', 'hello', 'hello', 'hello']
+<
+	Basically this function is equivalent to the following one line.
+>
+	new(size, f) == map(range(0, size - 1), f)
+<
+
+
 pop({list})				*Vital.Data.List.pop()*
 	Removes the last element from |List| {list} and returns the element,
 	as if the {list} is a stack.

--- a/doc/vital/Data/List.txt
+++ b/doc/vital/Data/List.txt
@@ -49,7 +49,7 @@ INTERFACE				*Vital.Data.List-interface*
 FUNCTIONS				*Vital.Data.List-functions*
 
 new({size}, {f})			*Vital.Data.List.new()*
-	Create a new |List| with given arguments. The given |Funcref| {f} is
+	Creates a new |List| with given arguments. The given |Funcref| {f} is
 	called for {size} times with index.
 >
 	s:L.new(3, { i -> i * 2 })

--- a/doc/vital/Data/List.txt
+++ b/doc/vital/Data/List.txt
@@ -60,7 +60,7 @@ new({size}, {f})			*Vital.Data.List.new()*
 <
 	Basically this function is equivalent to the following one line.
 >
-	new(size, f) == map(range(0, size - 1), f)
+	new(size, f) == map(range(a:size), a:f)
 <
 
 

--- a/test/Data/List.vimspec
+++ b/test/Data/List.vimspec
@@ -47,6 +47,17 @@ Describe Data.List
     delfunction Even
   End
 
+  Describe .new()
+    It createa a new list with calling given {f} for {size} times.
+      Assert Equals(List.new(3, { i -> i * 2 }), [0, 2, 4])
+      Assert Equals(List.new(4, { -> 'hello' }), ['hello', 'hello', 'hello', 'hello'])
+    End
+
+    It causes an error when the list is empty
+      Throw /^Vim(\w*):E727:/ List.new(-1, { -> 3 })
+    End
+  End
+
   Describe .pop()
     It removes the last element from a list and returns that element
       let a = [1,2,3]

--- a/test/Data/List.vimspec
+++ b/test/Data/List.vimspec
@@ -50,7 +50,10 @@ Describe Data.List
   Describe .new()
     It createa a new list with calling given {f} for {size} times.
       Assert Equals(List.new(3, { i -> i * 2 }), [0, 2, 4])
+      Assert Equals(List.new(3, 'v:val * 2'), [0, 2, 4])
       Assert Equals(List.new(4, { -> 'hello' }), ['hello', 'hello', 'hello', 'hello'])
+      Assert Equals(List.new(4, '"hello"'), ['hello', 'hello', 'hello', 'hello'])
+      Assert Equals(List.new(5, 3), [3, 3, 3, 3, 3])
     End
 
     It causes an error when the list is empty

--- a/test/Data/List.vimspec
+++ b/test/Data/List.vimspec
@@ -48,7 +48,7 @@ Describe Data.List
   End
 
   Describe .new()
-    It createa a new list with calling given {f} for {size} times.
+    It creates a new list with calling given {f} for {size} times
       Assert Equals(List.new(3, { i -> i * 2 }), [0, 2, 4])
       Assert Equals(List.new(3, 'v:val * 2'), [0, 2, 4])
       Assert Equals(List.new(4, { -> 'hello' }), ['hello', 'hello', 'hello', 'hello'])
@@ -56,7 +56,7 @@ Describe Data.List
       Assert Equals(List.new(5, 3), [3, 3, 3, 3, 3])
     End
 
-    It causes an error when the list is empty
+    It causes an error when the {size} is negative
       Throw /^Vim(\w*):E727:/ List.new(-1, { -> 3 })
     End
   End


### PR DESCRIPTION
Ruby has the following feature:

```ruby
Array.new(10) { rand(10) }
#=> [1, 9, 5, 0, 7, 0, 3, 3, 8, 2]
```

With this patch, you can do similar thing with vital.vim.

```vim
s:List.new(10, { -> s:Random.range(0, 9) })
"=> [1, 9, 5, 0, 7, 0, 3, 3, 8, 2]
```