### PR TITLE
Text.TOML: Fix an error with multiline basic string

### DIFF
--- a/autoload/vital/__vital__/Text/TOML.vim
+++ b/autoload/vital/__vital__/Text/TOML.vim
@@ -156,7 +156,7 @@ function! s:_basic_string(input) abort
 endfunction
 
 function! s:_multiline_basic_string(input) abort
-  let s = s:_consume(a:input, '"\{3}\_.\{-}"\{3}')
+  let s = s:_consume(a:input, '"\{3}\%(\\.\|\_.\)\{-}"\{3}')
   let s = s[3 : -4]
   let s = substitute(s, "^\n", '', '')
   let s = substitute(s, '\\' . "\n" . '\_s*', '', 'g')

--- a/test/Text/TOML.vim
+++ b/test/Text/TOML.vim
@@ -108,6 +108,16 @@ function! s:suite.__parse__()
 
       call s:assert.same(data.hoge, 'The quick brown fox jumps over the lazy dog.')
     endfunction
+
+    function! multiline_basic_strings.includes_escaped_character()
+      let data = s:TOML.parse(join([
+      \ 'hoge = """\',
+      \ 'delimiter = ''\"""''\',
+      \ '"""',
+      \], "\n"))
+
+      call s:assert.same(data.hoge, 'delimiter = ''"""''')
+    endfunction
   endfunction
 
   function! parse.literal_string()


### PR DESCRIPTION
Consider the following TOML file:

```
foo = """
delimiter = '\"""'
"""
```

`"""` in the second line is escaped by `\`, but an old implementation
stops parsing at here and had occurred an error.