### PR TITLE
Fix error catching

### DIFF
--- a/autoload/vital/__vital__/Data/Set.vim
+++ b/autoload/vital/__vital__/Data/Set.vim
@@ -228,7 +228,7 @@ endfunction
 function! s:set.remove(e) abort
   try
     unlet self._data[self._hash(a:e)]
-  catch /^Vim\%((\a\+)\)\?:E716/
+  catch /^Vim\%((\a\+)\)\?:E716:/
     call s:_throw('the element is not a member')
   endtry
 endfunction
@@ -247,7 +247,7 @@ endfunction
 function! s:set.pop() abort
   try
     let k = keys(self._data)[0]
-  catch /^Vim\%((\a\+)\)\?:E684/
+  catch /^Vim\%((\a\+)\)\?:E684:/
     call s:_throw('set is empty')
   endtry
   let v = self._data[k]

--- a/autoload/vital/__vital__/Vim/Python.vim
+++ b/autoload/vital/__vital__/Vim/Python.vim
@@ -41,9 +41,9 @@ function! s:is_python2_enabled() abort
       python 0
       let s:is_python2_enabled = 1
     endif
-  catch /^Vim(python)/
+  catch /^Vim(python):/
     let s:is_python2_enabled = 0
-  catch /^Vim\%((\a\+)\)\=:\%(E263\|E264\|E887\)/
+  catch /^Vim\%((\a\+)\)\=:\%(E263\|E264\|E887\):/
     let s:is_python2_enabled = 0
   endtry
   return s:is_python2_enabled
@@ -59,9 +59,9 @@ function! s:is_python3_enabled() abort
       python3 0
       let s:is_python3_enabled = 1
     endif
-  catch /^Vim(python3)/
+  catch /^Vim(python3):/
     let s:is_python3_enabled = 0
-  catch /^Vim\%((\a\+)\)\=:\%(E263\|E264\|E887\)/
+  catch /^Vim\%((\a\+)\)\=:\%(E263\|E264\|E887\):/
     let s:is_python3_enabled = 0
   endtry
   return s:is_python3_enabled

--- a/autoload/vital/__vital__/Vim/ScriptLocal.vim
+++ b/autoload/vital/__vital__/Vim/ScriptLocal.vim
@@ -35,7 +35,7 @@ endfunction
 function! s:_source(path) abort
   try
     execute ':source' fnameescape(a:path)
-  catch /^Vim\%((\a\+)\)\=:E121/
+  catch /^Vim\%((\a\+)\)\=:E121:/
     " NOTE: workaround for `E121: Undefined variable: s:save_cpo`
     execute ':source' fnameescape(a:path)
   endtry

--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -170,7 +170,7 @@ function! s:_get_module(name) abort dict
   let funcname = s:_import_func_name(self.plugin_name(), a:name)
   try
     return call(funcname, [])
-  catch /^Vim\%((\a\+)\)\?:E117/
+  catch /^Vim\%((\a\+)\)\?:E117:/
     return s:_get_builtin_module(a:name)
   endtry
 endfunction

--- a/test/Locale/Message.vimspec
+++ b/test/Locale/Message.vimspec
@@ -8,11 +8,11 @@ Describe Locale.Message
     try
       language message ja_JP.UTF-8
       let language_available = 'ja'
-    catch /^Vim\%((\a\+)\)\=:E197/
+    catch /^Vim\%((\a\+)\)\=:E197:/
       try
         language message en_US.UTF-8
         let language_available = 'en'
-      catch /^Vim\%((\a\+)\)\=:E197/
+      catch /^Vim\%((\a\+)\)\=:E197:/
         let language_available = ''
       endtry
     endtry


### PR DESCRIPTION
Some `:catch`s use incomplete patterns for errors.