### PR TITLE
Data.Base64 decode miss operation?

### DIFF
--- a/autoload/vital/__vital__/Data/Base64.vim
+++ b/autoload/vital/__vital__/Data/Base64.vim
@@ -1,4 +1,5 @@
 " Utilities for Base64.
+" RFC 4648 http://tools.ietf.org/html/rfc4648.html
 
 let s:save_cpo = &cpo
 set cpo&vim
@@ -61,10 +62,10 @@ function! s:_b64decode(b64, table, pad) abort
     call add(bytes, n % 0x100)
   endfor
   if a:b64[-1] == a:pad
-    unlet a:b64[-1]
+    unlet bytes[-1]
   endif
   if a:b64[-2] == a:pad
-    unlet a:b64[-1]
+    unlet bytes[-1]
   endif
   return bytes
 endfunction


### PR DESCRIPTION
https://github.com/vim-jp/vital.vim/blob/ccc69e2a0fd3ed1fb1576b217dbc6236e1a9b018/autoload/vital/__vital__/Data/Base64.vim#L63-L68

デコードでの上記処理ですが、a:b64処理後に削っても意味がなく、意図するところとしてbytesを削るのではないでしょうか?

下記のようにして動作を確認し、正常ではあることは簡単には確認できました。
意図する所に当っているか、確認したいと思いIssueを挙げます。

```vim
  if a:b64[-1] == a:pad
    unlet bytes[-1]
  endif
  if a:b64[-2] == a:pad
    unlet bytes[-1]
  endif
```

RFCのBase64の

```
 (1) The final quantum of encoding input is an integral multiple of 24
       bits; here, the final unit of encoded output will be an integral
       multiple of 4 characters with no "=" padding.

   (2) The final quantum of encoding input is exactly 8 bits; here, the
       final unit of encoded output will be two characters followed by
       two "=" padding characters.

   (3) The final quantum of encoding input is exactly 16 bits; here, the
       final unit of encoded output will be three characters followed by
       one "=" padding character.
```

を読むに、
* 末尾24bit丁度のデータなら、4キャラになって=パディングなし
* 同8bitで2キャラ、=は2つ
* 同16bitで3キャラ、=は1つ

なので、過剰データの削除のためですよね。Base32もその想定動作があったので、そちらは対処しています。