### PR TITLE
Fix: Base64 base32's reviewed s:_binstr2bytes(str) check fixing

### DIFF
--- a/autoload/vital/__vital__/Data/Base64.vim
+++ b/autoload/vital/__vital__/Data/Base64.vim
@@ -71,7 +71,7 @@ function! s:_b64decode(b64, table, pad) abort
 endfunction
 
 function! s:_binstr2bytes(str) abort
-  return map(range(len(a:str)/2), 'eval("0x".a:str[v:val*2 : v:val*2+1])')
+  return map(range(len(a:str)/2), 'str2nr(a:str[v:val*2 : v:val*2+1], 16)')
 endfunction
 
 function! s:_str2bytes(str) abort


### PR DESCRIPTION
see #639

review check point spread other module
checkk all "eval decode 16/2 base num"

---

base32レビュー時にでた指摘を水平展開します。
この修正が必要なのが他にはなさそうなので、これだけです。

1行関数みたいなのは各モジュールが自前で持ってますし、正直くくりだしが難しいですが、アップデートとDRYを考えると悩ましいですね。