### PR TITLE
Contribute Hash.SHA1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Module						 | Description
 [DateTime](doc/vital/DateTime.txt)		 | date and time library
 [Experimental.Functor](doc/vital/Experimental/Functor.txt) | Utilities for functor
 [Hash.MD5](doc/vital/Hash/MD5.txt) | MD5 encoding
+[Hash.SHA1](doc/vital/Hash/SHA1.txt) | SHA1 encoding
 [Interpreter.Brainf__k](doc/vital/Interpreter/Brainf__k.txt) | Brainf\*\*k interpreter
 [Locale.Message](doc/vital/Locale/Message.txt)	 | very simple message localization library
 [Mapping](doc/vital/Mapping.txt)		 | Utilities for mapping

--- a/autoload/vital/__vital__/Hash/SHA1.vim
+++ b/autoload/vital/__vital__/Hash/SHA1.vim
@@ -106,7 +106,7 @@ let s:sha1context = {
       \ 'Corrupted'          : 0,
       \}
 
-function! s:sha1circular_shift(bits, word) abort
+function! s:_sha1circular_shift(bits, word) abort
   return s:bitwise.or(s:bitwise.lshift32(a:word, a:bits), s:bitwise.rshift32(a:word, 32 - a:bits))
 endfunction
 
@@ -208,7 +208,7 @@ function! s:sha1context.process() dict abort
   endfor
 
   for t in range(16, 79)
-    let W[t] = s:sha1circular_shift(1, s:bitwise.xor(s:bitwise.xor(s:bitwise.xor(W[t-3], W[t-8]), W[t-14]), W[t-16]))
+    let W[t] = s:_sha1circular_shift(1, s:bitwise.xor(s:bitwise.xor(s:bitwise.xor(W[t-3], W[t-8]), W[t-14]), W[t-16]))
   endfor
 
   let A = self.intermediatehash[0]
@@ -218,42 +218,42 @@ function! s:sha1context.process() dict abort
   let E = self.intermediatehash[4]
 
   for t in range(20)
-    let temp = s:sha1circular_shift(5,A) +
+    let temp = s:_sha1circular_shift(5,A) +
           \ s:bitwise.or(s:bitwise.and(B, C), s:bitwise.and(s:bitwise.invert(B), D)) +
           \ E + W[t] + K[0]
     let E = D
     let D = C
-    let C = s:sha1circular_shift(30,B)
+    let C = s:_sha1circular_shift(30,B)
     let B = A
     let A = temp
   endfor
 
   for t in range(20, 39)
-    let temp = s:sha1circular_shift(5,A) + s:bitwise.xor(s:bitwise.xor(B, C), D) + E + W[t] + K[1]
+    let temp = s:_sha1circular_shift(5,A) + s:bitwise.xor(s:bitwise.xor(B, C), D) + E + W[t] + K[1]
     let E = D
     let D = C
-    let C = s:sha1circular_shift(30,B)
+    let C = s:_sha1circular_shift(30,B)
     let B = A
     let A = temp
   endfor
 
   for t in range(40, 59)
-    let temp = s:sha1circular_shift(5,A) +
+    let temp = s:_sha1circular_shift(5,A) +
           \ s:bitwise.or(s:bitwise.or(s:bitwise.and(B, C), s:bitwise.and(B, D)), s:bitwise.and(C, D)) +
           \ E + W[t] + K[2]
     let E = D
     let D = C
-    let C = s:sha1circular_shift(30,B)
+    let C = s:_sha1circular_shift(30,B)
     let B = A
     let A = temp
   endfor
 
   for t in range(60, 79)
-    let temp = s:sha1circular_shift(5,A) +
+    let temp = s:_sha1circular_shift(5,A) +
           \ s:bitwise.xor(s:bitwise.xor(B, C), D) + E + W[t] + K[3]
     let E = D
     let D = C
-    let C = s:sha1circular_shift(30,B)
+    let C = s:_sha1circular_shift(30,B)
     let B = A
     let A = temp
   endfor

--- a/autoload/vital/__vital__/Hash/SHA1.vim
+++ b/autoload/vital/__vital__/Hash/SHA1.vim
@@ -23,7 +23,7 @@ function! s:sum(data) abort
 endfunction
 
 function! s:sum_raw(bytes) abort
-  return s:_bytes2str(s:digest_raw(a:bytes))
+  return s:_bytes2binstr(s:digest_raw(a:bytes))
 endfunction
 
 function! s:digest(data) abort
@@ -333,8 +333,8 @@ function! s:_str2bytes(str) abort
   return map(range(len(a:str)), 'char2nr(a:str[v:val])')
 endfunction
 
-function! s:_bytes2str(bytes) abort
-  return join(map(a:bytes, 'printf(''%02x'', v:val)'), '')
+function! s:_bytes2binstr(bytes) abort
+  return join(map(copy(a:bytes), 'printf(''%02x'', v:val)'), '')
 endfunction
 
 let &cpo = s:save_cpo

--- a/autoload/vital/__vital__/Hash/SHA1.vim
+++ b/autoload/vital/__vital__/Hash/SHA1.vim
@@ -1,39 +1,9 @@
 " Utilities for SHA1.
-" RFC 3174 https://tools.ietf.org/html/rfc3174
-"
-" original github vim-scripts/sha1.vim
-"
-" sha1 digest calculator
-" This is a port of rfc3174 sha1 function.
-" http://www.ietf.org/rfc/rfc3174.txt
-" Last Change:  2010-02-13
-" Maintainer:   Yukihiro Nakadaira <yukihiro.nakadaira@gmail.com>
-" Original Copyright:
-" Copyright (C) The Internet Society (2001).  All Rights Reserved.
-"
-" This document and translations of it may be copied and furnished to
-" others, and derivative works that comment on or otherwise explain it
-" or assist in its implementation may be prepared, copied, published
-" and distributed, in whole or in part, without restriction of any
-" kind, provided that the above copyright notice and this paragraph are
-" included on all such copies and derivative works.  However, this
-" document itself may not be modified in any way, such as by removing
-" the copyright notice or references to the Internet Society or other
-" Internet organizations, except as needed for the purpose of
-" developing Internet standards in which case the procedures for
-" copyrights defined in the Internet Standards process must be
-" followed, or as required to translate it into languages other than
-" English.
-"
-" The limited permissions granted above are perpetual and will not be
-" revoked by the Internet Society or its successors or assigns.
-"
-" This document and the information contained herein is provided on an
-" "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
-" TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
-" BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
-" HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
-" MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+" Tsuyoshi CHO <Tsuyoshi.CHO@Gmail.com>
+" License CC0
+" Code:
+"   based on RFC 3174 Refeerence implementation. https://tools.ietf.org/html/rfc3174
+"   based on Vim implementation vim-scripts/sha1.vim (Licensed)
 
 let s:save_cpo = &cpo
 set cpo&vim

--- a/autoload/vital/__vital__/Hash/SHA1.vim
+++ b/autoload/vital/__vital__/Hash/SHA1.vim
@@ -62,12 +62,13 @@ function! s:digest(data) abort
 endfunction
 
 function! s:digest_raw(bytes) abort
+  let bytes = copy(a:bytes)
   let sha = deepcopy(s:sha1context, 1)
   let digest = repeat([0], s:sha1hashsize)
 
   call sha.init()
 
-  let err = sha.input(a:bytes)
+  let err = sha.input(bytes)
   if err
     throw printf('vital: Hash.SHA1: input Error %d', err)
   endif

--- a/doc/vital.txt
+++ b/doc/vital.txt
@@ -186,6 +186,7 @@ LINKS					*Vital-links*
   |vital/DateTime.txt|		date and time library.
   |vital/Experimental/Functor.txt|	Utilities for functor.
   |vital/Hash/MD5.txt|	        MD5 encoding.
+  |vital/Hash/SHA1.txt|	        SHA1 encoding.
   |vital/Interpreter/Brainf__k.txt|	Brainf**k interpreter
   |vital/Locale/Message.txt|	very simple message localization library.
   |vital/Mapping.txt|		Utilities for mapping.

--- a/doc/vital/Hash/SHA1.txt
+++ b/doc/vital/Hash/SHA1.txt
@@ -16,6 +16,11 @@ INTRODUCTION				*Vital.Hash.SHA1-introduction*
 It provides functions to return the SHA1 sum/digest of a given string as
 hex/bytes list.
 
+The algorithm was ported to Vim script by Yukihiro Nakadaira and this module is
+imported from the implementation.
+
+https://github.com/vim-scripts/sha1.vim
+
 ==============================================================================
 INTERFACE				*Vital.Hash.SHA1-interface*
 ------------------------------------------------------------------------------

--- a/doc/vital/Hash/SHA1.txt
+++ b/doc/vital/Hash/SHA1.txt
@@ -1,0 +1,33 @@
+*vital/Hash/SHA1.txt*		sha1 utilities library.
+
+Maintainer: Tsuyoshi CHO <Tsuyoshi.CHO@Gmail.com>
+
+==============================================================================
+CONTENTS				*Vital.Hash.SHA1-contents*
+
+INTRODUCTION		                |Vital.Hash.SHA1-introduction|
+INTERFACE		                |Vital.Hash.SHA1-interface|
+  Functions                             |Vital.Hash.SHA1-functions|
+
+==============================================================================
+INTRODUCTION				*Vital.Hash.SHA1-introduction*
+
+*Vital.Hash.SHA1* is a SHA1 Utilities Library.
+It provides functions to return the SHA1 sum/digest of a given string as
+hex/bytes list.
+
+==============================================================================
+INTERFACE				*Vital.Hash.SHA1-interface*
+------------------------------------------------------------------------------
+FUNCTIONS				*Vital.Hash.SHA1-functions*
+
+sum({str})				*Vital.Hash.SHA1.sum()*
+sum_raw({bytes})			*Vital.Hash.SHA1.sum_raw()*
+	Return SHA1 hashed string from {str} or raw {bytes} list.
+
+digest({str})				*Vital.Hash.SHA1.digest()*
+digest_raw({bytes})			*Vital.Hash.SHA1.digest_raw()*
+	Return SHA1 hashed bytes list from {str} or raw {bytes} list.
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/Hash/SHA1.vim
+++ b/test/Hash/SHA1.vim
@@ -1,0 +1,47 @@
+let s:suite = themis#suite('Hash.SHA1')
+let s:assert = themis#helper('assert')
+
+function! s:suite.before()
+  let s:SHA1 = vital#vital#new().import('Hash.SHA1')
+endfunction
+
+function! s:suite.after()
+  unlet! s:SHA1
+endfunction
+
+function! s:suite.encode() abort
+   call s:assert.equal(s:SHA1.sum(''), 'da39a3ee5e6b4b0d3255bfef95601890afd80709')
+   call s:assert.equal(s:SHA1.sum('a'), '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8')
+   call s:assert.equal(s:SHA1.sum('abc'), 'a9993e364706816aba3e25717850c26c9cd0d89d')
+   call s:assert.equal(s:SHA1.sum('message digest'), 'c12252ceda8be8994d5fa0290a47231c1d16aae3')
+   call s:assert.equal(s:SHA1.sum('abcdefghijklmnopqrstuvwxyz'), '32d10c7b8cf96570ca04ce37f2a19d84240d3a89')
+   call s:assert.equal(s:SHA1.sum('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'), '761c457bf73b14d27e9e9265c46f4b4dda11f940')
+   call s:assert.equal(s:SHA1.sum('12345678901234567890123456789012345678901234567890123456789012345678901234567890'), '50abf5706a150990a08b2c5ea40fa0e585554732')
+
+   " RFC Test Driver's testdata
+   let s:TEST1   = "abc"
+   let s:TEST2a  = "abcdbcdecdefdefgefghfghighijhi"
+   let s:TEST2b  = "jkijkljklmklmnlmnomnopnopq"
+   let s:TEST2   = s:TEST2a . s:TEST2b
+   let s:TEST3   = "a"
+   let s:TEST4a  = "01234567012345670123456701234567"
+   let s:TEST4b  = "01234567012345670123456701234567"
+   " an exact multiple of 512 bits
+   let s:TEST4   = s:TEST4a . s:TEST4b
+   let s:testarray = [
+         \ s:TEST1,
+         \ s:TEST2,
+         \ s:TEST3,
+         \ s:TEST4
+         \ ]
+   let s:resultarray = [
+         \ "a9993e364706816aba3e25717850c26c9cd0d89d",
+         \ "84983e441c3bd26ebaae4aa1f95129e5e54670f1",
+         \ "34aa973cd4c4daa4f61eeb2bdbad27316534016f",
+         \ "dea356a2cddd90c7a7ecedc5ebb563934f460452"
+         \ ]
+   call s:assert.equal(s:SHA1.sum(s:testarray[0]),s:resultarray[0])
+   call s:assert.equal(s:SHA1.sum(s:testarray[1]),s:resultarray[1])
+   call s:assert.equal(s:SHA1.sum(s:testarray[2]),s:resultarray[2])
+   call s:assert.equal(s:SHA1.sum(s:testarray[3]),s:resultarray[3])
+endfunction

--- a/test/Hash/SHA1.vim
+++ b/test/Hash/SHA1.vim
@@ -34,12 +34,22 @@ function! s:suite.encode() abort
          \ s:TEST3,
          \ s:TEST4
          \ ]
+   " original result
+   " let s:resultarray = [
+   "      \ "a9993e364706816aba3e25717850c26c9cd0d89d",
+   "      \ "84983e441c3bd26ebaae4aa1f95129e5e54670f1",
+   "      \ "34aa973cd4c4daa4f61eeb2bdbad27316534016f",
+   "      \ "dea356a2cddd90c7a7ecedc5ebb563934f460452"
+   "      \ ]
+
+   " other SHA1 test site generate result
    let s:resultarray = [
          \ "a9993e364706816aba3e25717850c26c9cd0d89d",
          \ "84983e441c3bd26ebaae4aa1f95129e5e54670f1",
-         \ "34aa973cd4c4daa4f61eeb2bdbad27316534016f",
-         \ "dea356a2cddd90c7a7ecedc5ebb563934f460452"
-         \ ]
+         \ "86f7e437faa5a7fce15d1ddcb9eaeaea377667b8",
+         \ "e0c094e867ef46c350ef54a7f59dd60bed92ae83"
+         \]
+
    call s:assert.equal(s:SHA1.sum(s:testarray[0]),s:resultarray[0])
    call s:assert.equal(s:SHA1.sum(s:testarray[1]),s:resultarray[1])
    call s:assert.equal(s:SHA1.sum(s:testarray[2]),s:resultarray[2])

--- a/test/Hash/SHA1.vim
+++ b/test/Hash/SHA1.vim
@@ -54,4 +54,24 @@ function! s:suite.encode() abort
    call s:assert.equal(s:SHA1.sum(s:testarray[1]),s:resultarray[1])
    call s:assert.equal(s:SHA1.sum(s:testarray[2]),s:resultarray[2])
    call s:assert.equal(s:SHA1.sum(s:testarray[3]),s:resultarray[3])
+
+
+   " Exxtend Interface test
+   " test data
+   let exttest_string       = 'abc'
+   let exttest_bytelist     = [0x61, 0x62, 0x63]
+   let exttest_hashstring   = 'a9993e364706816aba3e25717850c26c9cd0d89d'
+   let exttest_hashbytelist = [
+         \ 0xa9, 0x99, 0x3e, 0x36, 0x47, 0x06, 0x81, 0x6a, 0xba, 0x3e,
+         \ 0x25, 0x71, 0x78, 0x50, 0xc2, 0x6c, 0x9c, 0xd0, 0xd8, 0x9d
+         \]
+
+   " test sum        input string   output hashstring
+   call s:assert.equal(s:SHA1.sum(exttest_string),         exttest_hashstring)
+   " test sum_raw    input bytelist output hashstring
+   call s:assert.equal(s:SHA1.sum_raw(exttest_bytelist),   exttest_hashstring)
+   " test digest     input string   output hash byte list
+   call s:assert.equal(s:SHA1.digest(exttest_string),      exttest_hashbytelist)
+   " test digest_raw input bytelist output hash byte list
+   call s:assert.equal(s:SHA1.digest_raw(exttest_bytelist),exttest_hashbytelist)
 endfunction


### PR DESCRIPTION
based on [vim\-scripts/sha1\.vim: sha1\(\) function](https://github.com/vim-scripts/sha1.vim)

- support same I/F MD5
- add test
- add document

---

元にしたものがvim-scriptsオフィシャルにあること、ライセンス的にIETFのRFCのままの文面が付加されていますが...素ライセンス的にやや謎なことなど、微妙な面がありますね...
BSD/MITレベルだとは思うので、あまり問題はない、と信じたいのですが...