### PR TITLE
Proposal: Interface Extension of MD5

### DIFF
--- a/autoload/vital/__vital__/Hash/MD5.vim
+++ b/autoload/vital/__vital__/Hash/MD5.vim
@@ -38,14 +38,27 @@ let s:table = [
       \ 0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
       \ ]
 
-
 function! s:sum(data) abort
+  let bytes = s:_str2bytes(a:data)
+  return s:sum_raw(bytes)
+endfunction
+
+function! s:sum_raw(bytes) abort
+  return s:_bytes2str(s:digest_raw(a:bytes))
+endfunction
+
+function! s:digest(data) abort
+  let bytes = s:_str2bytes(a:data)
+  return s:digest_raw(bytes)
+endfunction
+
+function! s:digest_raw(bytes) abort
   let l:a0 = 0x67452301
   let l:b0 = 0xefcdab89
   let l:c0 = 0x98badcfe
   let l:d0 = 0x10325476
 
-  let l:padded = s:_str2bytes(a:data)
+  let l:padded = a:bytes
   let l:orig_len = len(l:padded) * 8
   call add(l:padded, 0x80)
   while fmod(len(l:padded), 64) != 56
@@ -105,7 +118,7 @@ function! s:sum(data) abort
   call extend(l:bytes, s:_int2bytes(32, l:c0))
   call extend(l:bytes, s:_int2bytes(32, l:d0))
 
-  return s:_bytes2str(l:bytes)
+  return l:bytes
 endfunction
 
 function! s:_leftrotate(x, c) abort

--- a/autoload/vital/__vital__/Hash/MD5.vim
+++ b/autoload/vital/__vital__/Hash/MD5.vim
@@ -58,7 +58,7 @@ function! s:digest_raw(bytes) abort
   let l:c0 = 0x98badcfe
   let l:d0 = 0x10325476
 
-  let l:padded = a:bytes
+  let l:padded = copy(a:bytes)
   let l:orig_len = len(l:padded) * 8
   call add(l:padded, 0x80)
   while fmod(len(l:padded), 64) != 56

--- a/doc/vital/Hash/MD5.txt
+++ b/doc/vital/Hash/MD5.txt
@@ -13,7 +13,8 @@ INTERFACE		                |Vital.Hash.MD5-interface|
 INTRODUCTION				*Vital.Hash.MD5-introduction*
 
 *Vital.Hash.MD5* is a MD5 Utilities Library.
-It provides a single function to return the MD5 sum of a given string as hex
+It provides functions to return the MD5 sum/digest of a given string as
+hex/bytes list.
 
 ==============================================================================
 INTERFACE				*Vital.Hash.MD5-interface*
@@ -21,7 +22,12 @@ INTERFACE				*Vital.Hash.MD5-interface*
 FUNCTIONS				*Vital.Hash.MD5-functions*
 
 sum({str})				*Vital.Hash.MD5.sum()*
-	Return MD5 hashed string from {str}.
+sum_raw({bytes})			*Vital.Hash.MD5.sum_raw()*
+	Return MD5 hashed string from {str} or raw {bytes} list.
+
+digest({str})				*Vital.Hash.MD5.digest()*
+digest_raw({bytes})			*Vital.Hash.MD5.digest_raw()*
+	Return MD5 hashed bytes list from {str} or raw {bytes} list.
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/Hash/MD5.vim
+++ b/test/Hash/MD5.vim
@@ -17,4 +17,23 @@ function! s:suite.encode() abort
    call s:assert.equal(s:MD5.sum('abcdefghijklmnopqrstuvwxyz'), 'c3fcd3d76192e4007dfb496cca67e13b')
    call s:assert.equal(s:MD5.sum('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'), 'd174ab98d277d9f5a5611c2c9f419d9f')
    call s:assert.equal(s:MD5.sum('12345678901234567890123456789012345678901234567890123456789012345678901234567890'), '57edf4a22be3c955ac49da2e2107b67a')
+
+   " Exxtend Interface test
+   " test data
+   let exttest_string       = 'abc'
+   let exttest_bytelist     = [0x61, 0x62, 0x63]
+   let exttest_hashstring   = '900150983cd24fb0d6963f7d28e17f72'
+   let exttest_hashbytelist = [
+         \ 0x90, 0x01, 0x50, 0x98, 0x3c, 0xd2, 0x4f, 0xb0,
+         \ 0xd6, 0x96, 0x3f, 0x7d, 0x28, 0xe1, 0x7f, 0x72,
+         \]
+
+   " test sum        input string   output hashstring
+   call s:assert.equal(s:MD5.sum(exttest_string),         exttest_hashstring)
+   " test sum_raw    input bytelist output hashstring
+   call s:assert.equal(s:MD5.sum_raw(exttest_bytelist),   exttest_hashstring)
+   " test digest     input string   output hash byte list
+   call s:assert.equal(s:MD5.digest(exttest_string),      exttest_hashbytelist)
+   " test digest_raw input bytelist output hash byte list
+   call s:assert.equal(s:MD5.digest_raw(exttest_bytelist),exttest_hashbytelist)
 endfunction


### PR DESCRIPTION
Currently MD5 has only sum (like md5sum).

However, there is a shortage of APIs to use as components.

Proposal:

* sum : return hash string
* digest : return hash bytes list (new, easy to use for other process)

and matrix

* x(str) : accept string data
* x_raw(bytes) : accept bytes list

after PRed this API support.

Thanks.