### PR TITLE
Sideeffects: s:_bytes2str(bytes) modify arg bytes

### DIFF
--- a/autoload/vital/__vital__/Hash/MD5.vim
+++ b/autoload/vital/__vital__/Hash/MD5.vim
@@ -44,7 +44,7 @@ function! s:sum(data) abort
 endfunction
 
 function! s:sum_raw(bytes) abort
-  return s:_bytes2str(s:digest_raw(a:bytes))
+  return s:_bytes2binstr(s:digest_raw(a:bytes))
 endfunction
 
 function! s:digest(data) abort
@@ -126,8 +126,8 @@ function! s:_leftrotate(x, c) abort
   return s:bitwise.and(s:bitwise.or(s:bitwise.lshift(l:x, a:c), s:bitwise.rshift(l:x, (32-a:c))), 0xFFFFFFFF)
 endfunction
 
-function! s:_bytes2str(bytes) abort
-  return join(map(a:bytes, 'printf(''%02x'', v:val)'), '')
+function! s:_bytes2binstr(bytes) abort
+  return join(map(copy(a:bytes), 'printf(''%02x'', v:val)'), '')
 endfunction
 
 function! s:_str2bytes(str) abort


### PR DESCRIPTION
以下にある、上記の関数では副作用として引数を変更します。
いまのところ実害はない使い方をしていますが、実装を副作用のないものに変えたほうがいいかもしれません。

- Data.Base64 (用途違い、対策不要)
- Data.Base32 (用途違い、対策不要)
- Hash.MD5

修正案

```vim
function! s:_bytes2str(bytes) abort
  return join(map(copy(a:bytes), 'printf(''%02x'', v:val)'), '')
endfunction
```