### PR TITLE
Proposal: Interface Extension of Base64/Base32

### DIFF
--- a/autoload/vital/__vital__/Data/Base32.vim
+++ b/autoload/vital/__vital__/Data/Base32.vim
@@ -5,19 +5,25 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! s:encode(data) abort
-  let b32 = s:_b32encode(s:_str2bytes(a:data), s:standard_table, '=')
-  return join(b32, '')
+  return s:encodebytes(s:_str2bytes(a:data))
 endfunction
 
 function! s:encodebin(data) abort
-  let b32 = s:_b32encode(s:_binstr2bytes(a:data), s:standard_table, '=')
+  return s:encodebytes(s:_binstr2bytes(a:data))
+endfunction
+
+function! s:encodebytes(data) abort
+  let b32 = s:_b32encode(a:data, s:standard_table, '=')
   return join(b32, '')
 endfunction
 
 function! s:decode(data) abort
+  return s:_bytes2str(s:decoderaw(a:data))
+endfunction
+
+function! s:decoderaw(data) abort
   let data = toupper(a:data) " case insensitive
-  let bytes = s:_b32decode(split(data, '\zs'), s:standard_table, '=')
-  return s:_bytes2str(bytes)
+  return s:_b32decode(split(data, '\zs'), s:standard_table, '=')
 endfunction
 
 let s:standard_table = [

--- a/autoload/vital/__vital__/Data/Base64.vim
+++ b/autoload/vital/__vital__/Data/Base64.vim
@@ -5,18 +5,24 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function! s:encode(data) abort
-  let b64 = s:_b64encode(s:_str2bytes(a:data), s:standard_table, '=')
-  return join(b64, '')
+  return s:encodebytes(s:_str2bytes(a:data))
 endfunction
 
 function! s:encodebin(data) abort
-  let b64 = s:_b64encode(s:_binstr2bytes(a:data), s:standard_table, '=')
+  return s:encodebytes(s:_binstr2bytes(a:data))
+endfunction
+
+function! s:encodebytes(data) abort
+  let b64 = s:_b64encode(a:data, s:standard_table, '=')
   return join(b64, '')
 endfunction
 
 function! s:decode(data) abort
-  let bytes = s:_b64decode(split(a:data, '\zs'), s:standard_table, '=')
-  return s:_bytes2str(bytes)
+  return s:_bytes2str(s:decoderaw(a:data))
+endfunction
+
+function! s:decoderaw(data) abort
+  return s:_b64decode(split(a:data, '\zs'), s:standard_table, '=')
 endfunction
 
 let s:standard_table = [

--- a/doc/vital/Data/Base32.txt
+++ b/doc/vital/Data/Base32.txt
@@ -29,9 +29,15 @@ encodebin({str})			*Vital.Data.Base32.encodebin()*
 	Return base32 encoded string from {str}. {str} is hex encoded string
 	figured as bytes.
 
+encodebytes({bytes})			*Vital.Data.Base32.encodebytes()*
+	Return base32 encoded string from {bytes}.
+
 decode({str})				*Vital.Data.Base32.decode()*
 	Return decoded string from {str} that's base32 encoded.
 	{str} are case insensitive.
+
+decoderaw({str})			*Vital.Data.Base32.decoderaw()*
+	Return decoded bytes-list from {str} that's base32 encoded.
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/doc/vital/Data/Base64.txt
+++ b/doc/vital/Data/Base64.txt
@@ -27,8 +27,14 @@ encodebin({str})			*Vital.Data.Base64.encodebin()*
 	Return base64 encoded string from {str}. {str} is hex encoded string
 	figured as bytes.
 
+encodebytes({bytes})			*Vital.Data.Base64.encodebytes()*
+	Return base64 encoded string from {bytes}.
+
 decode({str})				*Vital.Data.Base64.decode()*
 	Return decoded string from {str} that's base64 encoded.
+
+decoderaw({str})			*Vital.Data.Base64.decoderaw()*
+	Return decoded bytes-list from {str} that's base64 encoded.
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl

--- a/test/Data/Base32.vimspec
+++ b/test/Data/Base32.vimspec
@@ -33,6 +33,12 @@ Describe Data.Base32
     End
   End
 
+  Describe .encodebytes()
+    It encode bytes-list encoded as hex to base32 encoded string.
+      Assert Equals(B.encodebytes([0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]), 'NBSWY3DPFQQHO33SNRSCC===')
+    End
+  End
+
   Describe .decode()
     It decode base32 encoded string to string.
       Assert Equals(B.decode("NBSWY3DPFQQHO33SNRSCC==="), 'hello, world!')
@@ -54,6 +60,12 @@ Describe Data.Base32
     End
     It decode string RFC Test Vector 6.
       Assert Equals(B.decode("MZXW6YTBOI======"), 'foobar')
+    End
+  End
+
+  Describe .decoderaw()
+    It decode base32 encoded string to bytes-list.
+      Assert Equals(B.decoderaw("NBSWY3DPFQQHO33SNRSCC==="), [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21])
     End
   End
 End

--- a/test/Data/Base64.vimspec
+++ b/test/Data/Base64.vimspec
@@ -36,6 +36,12 @@ Describe Data.Base64
     End
   End
 
+  Describe .encodebytes()
+    It encode bytes-list encoded as hex to base64 encoded string.
+      Assert Equals(B.encodebytes([0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21]), 'aGVsbG8sIHdvcmxkIQ==')
+    End
+  End
+
   Describe .decode()
     It decode base64 encoded string to string.
       Assert Equals(B.decode("aGVsbG8sIHdvcmxkIQ=="), 'hello, world!')
@@ -61,6 +67,12 @@ Describe Data.Base64
     End
     It decode string RFC Test Vector 7.
       Assert Equals(B.decode("Zm9vYmFy"), 'foobar')
+    End
+  End
+
+  Describe .decoderaw()
+    It decode base64 encoded string to bytes-list.
+      Assert Equals(B.decoderaw("aGVsbG8sIHdvcmxkIQ=="), [0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x21])
     End
   End
 End


### PR DESCRIPTION
Currently Base64/32 do not have byte-list from/to API.

Therefore, there is a shortage of APIs to use as components.

Proposal:

```
Bytes-list encode to BaseX
encodebytes({bytes})			
	Return baseX encoded string from {bytes}.

Return decoded Bytes-list
decoderaw({str})			
	Return decoded bytes-list from {str} that's baseX encoded.
```

Thanks.