### PR TITLE
Avoid covimerage error

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,8 @@ after_test:
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov
   - pip install covimerage
+  # Workaround: avoid covimerage error in Vim 8.1.0365 or later
+  - '%THEMIS_VIM% -u NONE -i NONE -N -e -s +g/Defined:/d +wq %THEMIS_PROFILE%'
   - covimerage write_coverage %THEMIS_PROFILE%
   - coverage xml
   - codecov -f coverage.xml

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -6,6 +6,9 @@ if [[ "${THEMIS_PROFILE}" == "" ]]; then
     exit
 fi
 
-covimerage write_coverage $THEMIS_PROFILE
+# Workaround: avoid covimerage error in Vim 8.1.0365 or later
+vim -u NONE -i NONE -N -e -s '+g/Defined:/d' +wq "${THEMIS_PROFILE}"
+
+covimerage write_coverage "${THEMIS_PROFILE}"
 coverage xml
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
## Cause

Vim 8.1.0365 よりプロファイルログに関数定義箇所が記載されるようになった。
(`Defined: /path/to/src.vim line XXX`)
covimerage はその情報を使って関数内容とソース行を対応させているが、`execute` を使って文字列評価により定義した関数では、関数内容とソース行が文字列として一致しない。
e.g. https://github.com/vim-jp/vital.vim/blob/master/autoload/vital/__vital__/Web/URI.vim#L640-L644

そのような場合に covimerage は assert で終了する。

## Solution (workaround)

`Defined:` の行を削除し、ログを 8.1.0365 以前のフォーマットにする。

covimerage にその辺りをうまく処理するようなオプションが欲しいところです。