### PR TITLE
SupportUpdate: Vim.Type currently not map blob type

### DIFF
--- a/autoload/vital/__vital__/Vim/Type.vim
+++ b/autoload/vital/__vital__/Vim/Type.vim
@@ -1,14 +1,15 @@
 let s:types = {
-\   'number': 0,
-\   'string': 1,
-\   'func': 2,
-\   'list': 3,
-\   'dict': 4,
-\   'float': 5,
-\   'bool': 6,
-\   'none': 7,
-\   'job': 8,
-\   'channel': 9,
+\   'number'  : 0,
+\   'string'  : 1,
+\   'func'    : 2,
+\   'list'    : 3,
+\   'dict'    : 4,
+\   'float'   : 5,
+\   'bool'    : 6,
+\   'none'    : 7,
+\   'job'     : 8,
+\   'channel' : 9,
+\   'blob'    : 10,
 \ }
 lockvar 1 s:types
 
@@ -23,6 +24,7 @@ let s:type_names = {
 \   '7': 'none',
 \   '8': 'job',
 \   '9': 'channel',
+\  '10': 'blob',
 \ }
 lockvar 1 s:type_names
 
@@ -63,6 +65,9 @@ function! s:_make_is_comparable_cache() abort
   \   exists('*test_null_job') ? test_null_job() : 0,
   \   exists('*test_null_channel') ? test_null_channel() : 0,
   \ ]
+  if has('patch-8.1.0735')
+    let vals += [0z00]
+  endif
 
   let result = []
   for l:V1 in vals

--- a/doc/vital/Vim/Type.txt
+++ b/doc/vital/Vim/Type.txt
@@ -41,6 +41,7 @@ types					*Vital.Vim.Type-types*
 	none: 7
 	job: 8
 	channel: 9
+	blob: 10
 >
 	let s:t = s:T.types
 
@@ -54,16 +55,17 @@ types					*Vital.Vim.Type-types*
 type_names				*Vital.Vim.Type-type_names*
 	A dictionary that maps from type value to type name.
 
-	0: number
-	1: string
-	2: func
-	3: list
-	4: dict
-	5: float
-	6: bool
-	7: none
-	8: job
-	9: channel
+	 0: number
+	 1: string
+	 2: func
+	 3: list
+	 4: dict
+	 5: float
+	 6: bool
+	 7: none
+	 8: job
+	 9: channel
+	10: blob
 >
 	:echo s:T.type_names[type('')]
 	string

--- a/test/Vim/Type.vimspec
+++ b/test/Vim/Type.vimspec
@@ -36,6 +36,11 @@ Describe Vim.Type
         Assert Equals(T.types.channel, type(test_null_channel()))
       End
     endif
+    if has('patch-8.1.0735')
+      It has .blob
+        Assert Equals(T.types.blob, type(0z00))
+      End
+    endif
     It is locked
       Assert True(islocked('T.types'))
     End
@@ -72,6 +77,11 @@ Describe Vim.Type
       End
       It can get name of "channel"
         Assert Equals(T.type_names[type(test_null_channel())], 'channel')
+      End
+    endif
+    if has('patch-8.1.0735')
+      It can get name of "blob"
+        Assert Equals(T.type_names[type(0z00)], 'blob')
       End
     endif
     It is locked
@@ -151,6 +161,9 @@ Describe Vim.Type
       let vals = [0, '', function('type'), [], {}, 0.0]
       if 800 <= v:version
         let vals += [v:false, v:null, test_null_job(), test_null_channel()]
+      endif
+      if has('patch-8.1.0735')
+        let vals += [0z00]
       endif
 
       let true_group = []


### PR DESCRIPTION
vital.vimとしてはblob未サポート環境もまだ範囲内ですが、利用側としてはblobを使う可能性があるので、サポートを拡充したほうがよいと思います。
