### PR TITLE
Remove the workaround for covimerage

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,8 +31,6 @@ after_test:
   - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
   - pip install codecov
   - pip install covimerage
-  # Workaround: avoid covimerage error in Vim 8.1.0365 or later
-  - '%THEMIS_VIM% -u NONE -i NONE -N -e -s +g/Defined:/d +wq %THEMIS_PROFILE%'
   - covimerage write_coverage %THEMIS_PROFILE%
   - coverage xml
   - codecov -f coverage.xml

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -17,9 +17,6 @@ if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
     )$PATH
 fi
 
-# Workaround: avoid covimerage error in Vim 8.1.0365 or later
-vim -u NONE -i NONE -N -e -s '+g/Defined:/d' +wq "${THEMIS_PROFILE}"
-
 covimerage write_coverage "${THEMIS_PROFILE}"
 coverage xml
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
最新の covimerage (1.6~) では #651 が修正されているので workaround を削除しました。

Ref:
https://github.com/Vimjas/covimerage/issues/73
https://github.com/Vimjas/covimerage/issues/74