### PR TITLE
DateTime: support 64bit unix epoch in DateTime.unix_time()

### DIFF
--- a/autoload/vital/__vital__/DateTime.vim
+++ b/autoload/vital/__vital__/DateTime.vim
@@ -363,7 +363,8 @@ function! s:DateTime.quarter() abort
 endfunction
 function! s:DateTime.unix_time() abort
   if !has_key(self, '__unix_time')
-    if self._year < 1969 || 2038 < self._year
+    if self._year < 1969 ||
+          \ (!has('num64') && (2038 < self._year))
       let self.__unix_time = -1
     else
       let utc = self.to(0)

--- a/doc/vital/DateTime.txt
+++ b/doc/vital/DateTime.txt
@@ -159,6 +159,8 @@ DateTime.quarter()		*Vital.DateTime-DateTime.quarter()*
 DateTime.unix_time()		*Vital.DateTime-DateTime.unix_time()*
 	Returns the unix time.
 	If this DateTime is out of range of unix time, returns -1.
+	NOTE: When `num64` has supported. do not has "Year 2038 problem", work
+	correctly.
 
 DateTime.is_leap_year()		*Vital.DateTime-DateTime.is_leap_year()*
 	Returns true when the year is a leap year.

--- a/doc/vital/DateTime.txt
+++ b/doc/vital/DateTime.txt
@@ -159,8 +159,7 @@ DateTime.quarter()		*Vital.DateTime-DateTime.quarter()*
 DateTime.unix_time()		*Vital.DateTime-DateTime.unix_time()*
 	Returns the unix time.
 	If this DateTime is out of range of unix time, returns -1.
-	NOTE: When `num64` has supported. do not has "Year 2038 problem", work
-	correctly.
+	The upper limit is 2038, but if your Vim has `+num64` it's limitless.
 
 DateTime.is_leap_year()		*Vital.DateTime-DateTime.is_leap_year()*
 	Returns true when the year is a leap year.

--- a/test/DateTime.vimspec
+++ b/test/DateTime.vimspec
@@ -356,7 +356,7 @@ Describe DateTime
         Assert Equals(new_dt.to_string(), dt.to_string())
       End
 
-      Context when DateTime is in the range of 64bit unix time
+      Context when DateTime is beyond 2038 but within the range of 64 bit unix time
         if has('num64')
           It returns the unix time
             "  20000000000 | 2603-10-11 11:33:20

--- a/test/DateTime.vimspec
+++ b/test/DateTime.vimspec
@@ -355,6 +355,22 @@ Describe DateTime
         let new_dt = DT.from_unix_time(unix_time, dt.timezone())
         Assert Equals(new_dt.to_string(), dt.to_string())
       End
+
+      Context when DateTime is in the range of 64bit unix time
+        if has('num64')
+          It returns the unix time
+            "  20000000000 | 2603-10-11 11:33:20
+            let dt = DT.from_date(2603, 10, 11, 11, 33, 20, 0)
+            Assert Equals(dt.unix_time(), 20000000000)
+          End
+        else
+          It returns the unix time; overflow is -1
+            "  20000000000 | 2603-10-11 11:33:20
+            let dt = DT.from_date(2603, 10, 11, 11, 33, 20, 0)
+            Assert Equals(dt.unix_time(), -1)
+          End
+        endif
+      End
     End
 
     Describe .is_leap_year()


### PR DESCRIPTION
This PR is fix #658 

- check num64
- add test num64 and not num64
- document update