### PR TITLE
Filepath.abspath are directory' path resolving fail fix

### DIFF
--- a/autoload/vital/__vital__/System/Filepath.vim
+++ b/autoload/vital/__vital__/System/Filepath.vim
@@ -202,8 +202,8 @@ function! s:abspath(path) abort
     return a:path
   endif
   " Note:
-  "   the behavior of ':p' for non existing file path is not defined
-  return filereadable(a:path)
+  "   the behavior of ':p' for non existing file path/directory is not defined
+  return (filereadable(a:path) || isdirectory(a:path))
         \ ? fnamemodify(a:path, ':p')
         \ : s:join(fnamemodify(getcwd(), ':p'), a:path)
 endfunction

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -61,7 +61,7 @@ Describe System.Filepath
       Assert Same(ret, abspath)
     End
 
-    It should return an absolute path of {path} which exists
+    It should return an absolute path of {path} which exists file
       let relpath = 'foo.txt'
       call writefile(['foo'], relpath)
       let ret = FP.abspath(relpath)
@@ -70,6 +70,17 @@ Describe System.Filepath
       Assert NotEquals(ret, relpath)
       Assert Equals(ret, exp)
       call delete(relpath)
+    End
+
+    It should return an absolute path of {path} which exists dir
+      let relpath = 'foo'
+      call mkdir(relpath, "")
+      let ret = FP.abspath(relpath)
+      let exp = FP.join(getcwd(), relpath)
+      Assert NotSame(ret, relpath)
+      Assert NotEquals(ret, relpath)
+      Assert Equals(ret, exp)
+      call delete(relpath, 'd')
     End
 
     It should return an absolute path of {path} which does not exist

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -76,7 +76,7 @@ Describe System.Filepath
       let relpath = 'foo'
       call mkdir(relpath, "")
       let ret = FP.abspath(relpath)
-      let exp = FP.join(getcwd(), relpath)
+      let exp = FP.join(getcwd(), relpath) . FP.separator()
       Assert NotSame(ret, relpath)
       Assert NotEquals(ret, relpath)
       Assert Equals(ret, exp)


### PR DESCRIPTION
環境 Windows
ターゲットpath D:\data
pwd D:\data\test

の状態で
FIlepath.abspathに、`\Data\`を入れると `D:\Data\test\Data\`のようになる
(カレントドライブレターはfinddir他で消えることがあるので...fnamemodifyで直ることを期待した)

これは、\Data\がisdirecotryではあってもfilereadableではないためのようです。
逆に上記の状態で`\Data\`はisdirectoryで1が返ります。そして手動でfnamemodifyするとフルパスが取れます。

filereadable or isdirectoryが条件でもいいのではないか、と思うのですが、どうでしょうか?
ドキュメントにも 

> abspath({path})			*Vital.System.Filepath.abspath()*
> 	Return an absolute path of {path}.
> 	If the {path} is already an absolute path, it return the {path}.
> 	cf. |Vital.System.Filepath.relpath()|

とあり、pathであってfile、という制限ではないように読めました。

関数
```vim
function! s:abspath(path) abort
  if s:is_absolute(a:path)
    return a:path
  endif
  " Note:
  "   the behavior of ':p' for non existing file path is not defined
  return filereadable(a:path)
        \ ? fnamemodify(a:path, ':p')
        \ : s:join(fnamemodify(getcwd(), ':p'), a:path)
endfunction
```

テスト用
```vim
:echo isdirectory('\Data\')
:echo filereadable('\Data\')
```