### PR TITLE
Validator.Args: Support blob type, and remove Mod.TYPE constant

### DIFF
--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -9,25 +9,34 @@ lockvar! s:NONE
 function! s:_vital_loaded(V) abort
   let s:T = a:V.import('Vim.Type')
 
-  if exists('v:t_blob')
-    let s:t_end = v:t_blob
-  else
-    for t in [
-    \ exists('v:null') ? type(v:null) : -1,
-    \ exists('v:true') ? type(v:true) : -1,
-    \ type(0.0),
-    \ type({}),
-    \ type([]),
-    \ type(function('function')),
-    \ type(''),
-    \ type(0),
-    \]
-      if t >= 0
-        let s:t_end = t
-        break
-      endif
-    endfor
-  endif
+  let s:t_end = -1
+  for t in has('nvim') ? [
+  \ exists('v:null') ? type(v:null) : -1,
+  \ exists('v:true') ? type(v:true) : -1,
+  \ type(0.0),
+  \ type({}),
+  \ type([]),
+  \ type(function('function')),
+  \ type(''),
+  \ type(0),
+  \] : [
+  \ get(v:, 't_blob', -1),
+  \ get(v:, 't_channel', -1),
+  \ get(v:, 't_job', -1),
+  \ get(v:, 't_none', -1),
+  \ get(v:, 't_bool', -1),
+  \ get(v:, 't_float', -1),
+  \ get(v:, 't_dict', -1),
+  \ get(v:, 't_list', -1),
+  \ get(v:, 't_func', -1),
+  \ get(v:, 't_string', -1),
+  \ get(v:, 't_number', -1),
+  \]
+    if t >= 0
+      let s:t_end = t
+      break
+    endif
+  endfor
 endfunction
 
 function! s:_vital_depends() abort

--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -17,7 +17,8 @@ let s:TYPE.BOOL = 6
 let s:TYPE.NONE = 7
 let s:TYPE.JOB = 8
 let s:TYPE.CHANNEL = 9
-let s:TYPE.ANY = range(s:TYPE.NUMBER, s:TYPE.CHANNEL)
+let s:TYPE.BLOB = 10
+let s:TYPE.ANY = range(s:TYPE.NUMBER, s:TYPE.BLOB)
 let s:TYPE.OPTARG = []
 lockvar! s:TYPE
 
@@ -92,12 +93,12 @@ function! s:_check_type_args(args) abort
       endif
     endif
     if !(type(a:args[i]) is s:TYPE.NUMBER &&
-    \     a:args[i] >= s:TYPE.NUMBER &&
-    \     a:args[i] <= s:TYPE.CHANNEL) &&
+    \     a:args[i] >= s:TYPE.ANY[0] &&
+    \     a:args[i] <= s:TYPE.ANY[-1]) &&
     \  !(type(a:args[i]) is s:TYPE.LIST &&
     \     empty(filter(copy(a:args[i]),
     \                  'type(v:val) isnot s:TYPE.NUMBER || ' .
-    \                  'v:val < s:TYPE.NUMBER || v:val > s:TYPE.CHANNEL')))
+    \                  'v:val < s:TYPE.NUMBER || v:val > s:TYPE.BLOB')))
       throw 'vital: Validator.Args: Validator.type(): expected type or union types ' .
       \     'but got ' . s:T.type_names[type(a:args[i])]
     endif

--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -6,39 +6,18 @@ set cpo&vim
 let s:NONE = []
 lockvar! s:NONE
 
-let s:TYPE = {}
-let s:TYPE.NUMBER = 0
-let s:TYPE.STRING = 1
-let s:TYPE.FUNC = 2
-let s:TYPE.LIST = 3
-let s:TYPE.DICT = 4
-let s:TYPE.FLOAT = 5
-let s:TYPE.BOOL = 6
-let s:TYPE.NONE = 7
-let s:TYPE.JOB = 8
-let s:TYPE.CHANNEL = 9
-let s:TYPE.BLOB = 10
-let s:TYPE.ANY = range(s:TYPE.NUMBER, s:TYPE.BLOB)
-let s:TYPE.OPTARG = []
-lockvar! s:TYPE
-
 function! s:_vital_loaded(V) abort
   let s:T = a:V.import('Vim.Type')
-endfunction
-
-function! s:_vital_created(module) abort
-  let a:module.TYPE = s:TYPE
 endfunction
 
 function! s:_vital_depends() abort
   return ['Vim.Type']
 endfunction
 
-
 function! s:of(prefix, ...) abort
-  if type(a:prefix) isnot s:TYPE.STRING
-    throw 'vital: Validator.Args: of(): expected ' . s:T.type_names[s:TYPE.STRING] .
-    \     ' argument but got ' . s:T.type_names[type(a:prefix)]
+  if type(a:prefix) isnot# v:t_string
+    throw 'vital: Validator.Args: of(): expected ' . s:_type_name(v:t_string) .
+    \     ' argument but got ' . s:_type_name(type(a:prefix))
   endif
   let validator = {
   \ '_prefix': a:prefix,
@@ -59,7 +38,7 @@ function! s:of(prefix, ...) abort
       call s:_check_out_of_range(a:no, self._types)
     endif
     let self._asserts[a:no - 1] = {
-    \ 'funclist': type(a:funclist) is s:TYPE.LIST ? a:funclist : [a:funclist],
+    \ 'funclist': type(a:funclist) is# v:t_list ? a:funclist : [a:funclist],
     \ 'msg': get(a:000, 0, 'the ' . a:no . 'th argument''s assertion was failed')
     \}
     return self
@@ -68,9 +47,9 @@ function! s:of(prefix, ...) abort
     if !self._enable
       return a:args
     endif
-    if type(a:args) isnot s:TYPE.LIST
-      throw 'vital: Validator.Args: Validator.validate(): expected ' . s:T.type_names[s:TYPE.LIST] .
-      \     ' argument but got ' . s:T.type_names[type(a:args)]
+    if type(a:args) isnot# v:t_list
+      throw 'vital: Validator.Args: Validator.validate(): expected ' . s:_type_name(v:t_list) .
+      \     ' argument but got ' . s:_type_name(type(a:args))
     endif
     if has_key(self, '_types')
       call s:_validate_arg_types(a:args, self._types, self._prefix)
@@ -86,23 +65,45 @@ endfunction
 function! s:_check_type_args(args) abort
   let optarg = 0
   for i in range(len(a:args))
-    if a:args[i] is s:TYPE.OPTARG
+    if a:args[i] is# 'option'
       let optarg += 1
       if optarg > 1
-        throw 'vital: Validator.Args: Validator.type(): multiple OPTARG were given'
+        throw 'vital: Validator.Args: Validator.type(): multiple optional arguments were given'
       endif
     endif
-    if !(type(a:args[i]) is s:TYPE.NUMBER &&
-    \     a:args[i] >= s:TYPE.ANY[0] &&
-    \     a:args[i] <= s:TYPE.ANY[-1]) &&
-    \  !(type(a:args[i]) is s:TYPE.LIST &&
-    \     empty(filter(copy(a:args[i]),
-    \                  'type(v:val) isnot s:TYPE.NUMBER || ' .
-    \                  'v:val < s:TYPE.NUMBER || v:val > s:TYPE.BLOB')))
+    if !s:_is_valid_type_arg(a:args[i])
       throw 'vital: Validator.Args: Validator.type(): expected type or union types ' .
-      \     'but got ' . s:T.type_names[type(a:args[i])]
+      \     'but got ' . s:_type_name(type(a:args[i]))
     endif
   endfor
+endfunction
+
+function! s:_is_valid_type_arg(arg) abort
+  let n = type(a:arg)
+  if n is# v:t_number && (v:t_number <=# a:arg && a:arg <=# v:t_blob)
+    return 1
+  endif
+  if n is# v:t_string && (a:arg is# 'any' || a:arg is# 'option')
+    return 1
+  endif
+  if n is# v:t_list && empty(filter(copy(a:arg), '!s:_is_valid_type_arg(v:val)'))
+    return 1
+  endif
+  return 0
+endfunction
+
+function! s:_type_name(type) abort
+  if !s:_is_valid_type_arg(a:type)
+    throw 'vital: Validator.Args: invalid type value: ' . string(a:type)
+  endif
+  let n = type(a:type)
+  if n is# v:t_number
+    return s:T.type_names[a:type]
+  elseif n is# v:t_string
+    return a:type
+  else
+    return join(map(copy(a:type), 's:_type_name(v:val)'), ' or ')
+  endif
 endfunction
 
 function! s:_check_assert_args(args) abort
@@ -114,7 +115,7 @@ function! s:_check_assert_args(args) abort
 endfunction
 
 function! s:_check_out_of_range(no, types) abort
-  let idx = index(a:types, s:TYPE.OPTARG)
+  let idx = index(a:types, 'option')
   if a:no > len(a:types) - (idx >= 0 && idx !=# len(a:types) - 1 ? 1 : 0)
     if idx >= 0
       let arity = idx . '-' . (len(a:types) - idx)
@@ -134,13 +135,13 @@ function! s:_validate_arg_types(args, types, prefix) abort
   let i = 0
   while i < argslen
     if i + optarg >= typelen
-      if optarg && a:types[-1] is s:TYPE.OPTARG
+      if optarg && a:types[-1] is# 'option'
         break
       else
         throw a:prefix . ': too many arguments'
       endif
     endif
-    if a:types[i + optarg] is s:TYPE.OPTARG
+    if a:types[i + optarg] is# 'option'
       let optarg += 1
       continue
     endif
@@ -149,33 +150,36 @@ function! s:_validate_arg_types(args, types, prefix) abort
     \)
     let i += 1
   endwhile
-  if !optarg && i < typelen && a:types[i] isnot s:TYPE.OPTARG
+  if !optarg && i < typelen && a:types[i] isnot# 'option'
     throw a:prefix . ': too few arguments'
   endif
 endfunction
 
 function! s:_validate_type(value, expected_type, prefix, ...) abort
-  if type(a:expected_type) is s:TYPE.LIST
+  if a:expected_type is# 'any'
+    return a:value
+  endif
+  if type(a:expected_type) is# v:t_list
     let matched = filter(copy(a:expected_type),
-    \     's:_validate_type(a:value, v:val, a:prefix, s:NONE) isnot s:NONE')
+    \     's:_validate_type(a:value, v:val, a:prefix, s:NONE) isnot# s:NONE')
     if empty(matched)
       if a:0
         return a:1
       endif
-      let expected = join(map(copy(a:expected_type), 's:T.type_names[v:val]'), ' or ')
+      let expected = s:_type_name(a:expected_type)
       throw a:prefix . ': invalid type arguments were given ' .
       \     '(expected: ' . expected .
-      \     ', got: ' . s:T.type_names[type(a:value)] . ')'
+      \     ', got: ' . s:_type_name(type(a:value)) . ')'
     endif
     return
   endif
-  if type(a:value) isnot a:expected_type
+  if type(a:value) isnot# a:expected_type
     if a:0
       return a:1
     endif
     throw a:prefix . ': invalid type arguments were given ' .
-    \     '(expected: ' . s:T.type_names[a:expected_type] .
-    \     ', got: ' . s:T.type_names[type(a:value)] . ')'
+    \     '(expected: ' . s:_type_name(a:expected_type) .
+    \     ', got: ' . s:_type_name(type(a:value)) . ')'
   endif
   return a:value
 endfunction
@@ -197,7 +201,7 @@ function! s:_validate_assert(value, funclist, msg, prefix) abort
 endfunction
 
 function! s:_call1(f, arg) abort
-  if type(a:f) is s:TYPE.FUNC
+  if type(a:f) is# v:t_func
     return call(a:f, [a:arg])
   else
     return map([a:arg], a:f)[0]

--- a/autoload/vital/__vital__/Validator/Args.vim
+++ b/autoload/vital/__vital__/Validator/Args.vim
@@ -8,6 +8,26 @@ lockvar! s:NONE
 
 function! s:_vital_loaded(V) abort
   let s:T = a:V.import('Vim.Type')
+
+  if exists('v:t_blob')
+    let s:t_end = v:t_blob
+  else
+    for t in [
+    \ exists('v:null') ? type(v:null) : -1,
+    \ exists('v:true') ? type(v:true) : -1,
+    \ type(0.0),
+    \ type({}),
+    \ type([]),
+    \ type(function('function')),
+    \ type(''),
+    \ type(0),
+    \]
+      if t >= 0
+        let s:t_end = t
+        break
+      endif
+    endfor
+  endif
 endfunction
 
 function! s:_vital_depends() abort
@@ -80,7 +100,7 @@ endfunction
 
 function! s:_is_valid_type_arg(arg) abort
   let n = type(a:arg)
-  if n is# v:t_number && (v:t_number <=# a:arg && a:arg <=# v:t_blob)
+  if n is# v:t_number && (v:t_number <=# a:arg && a:arg <=# s:t_end)
     return 1
   endif
   if n is# v:t_string && (a:arg is# 'any' || a:arg is# 'option')

--- a/doc/vital/Validator/Args.txt
+++ b/doc/vital/Validator/Args.txt
@@ -9,7 +9,6 @@ INTRODUCTION			|Vital.Validator.Args-introduction|
 EXAMPLES			|Vital.Validator.Args-examples|
 INTERFACE			|Vital.Validator.Args-interface|
   FUNCTIONS			  |Vital.Validator.Args-functions|
-  TYPES				  |Vital.Validator.Args-types|
 VALIDATOR OBJECT		|Vital.Validator.Args-Validator-object|
 
 ==============================================================================
@@ -31,7 +30,7 @@ type()				*Vital.Validator.Args-example-type*
 	" s:func1() receives one number argument
 	let s:func1_args =
 	\ s:Validator.of('func1()')
-	            \.type(s:TYPE.NUMBER)
+	            \.type(v:t_number)
 	function! s:func1(...) abort
 	  " validate() throws an exception when:
 	  " * arity is not 1
@@ -43,7 +42,7 @@ type()				*Vital.Validator.Args-example-type*
 	" s:func2() receives two number and string arguments
 	let s:func2_args =
 	\ s:Validator.of('func2()')
-	            \.type(s:TYPE.NUMBER, s:TYPE.STRING)
+	            \.type(v:t_number, v:t_string)
 <
 type(): Union types		*Vital.Validator.Args-example-union-types*
 -------------------
@@ -51,23 +50,23 @@ type(): Union types		*Vital.Validator.Args-example-union-types*
 	" s:func3() receives one number or float argument
 	let s:func3_args =
 	\ s:Validator.of('func3()')
-	            \.type([s:TYPE.NUMBER, s:TYPE.FLOAT])
+	            \.type([v:t_number, v:t_float])
 <
 			*Vital.Validator.Args-example-optional-arguments*
 type(): Optional arguments
 --------------------------
 >
 	" s:func4() receives one string argument and zero or more optional arguments
-	" (NOTE: if the last type is OPTARG, skip the rest arguments validations)
+	" (NOTE: if the last type is optional argument, skip the rest arguments validations)
 	let s:func4_args =
 	\ s:Validator.of('func4()')
-	            \.type(s:TYPE.STRING, s:TYPE.OPTARG)
+	            \.type(v:t_string, 'option')
 
 	" if you want to check also the optional arguments, specify the types
-	" after OPTARG (s:func5() receives exact 1-2 argument(s): Number [, Number])
+	" after optional argument (s:func5() receives exact 1-2 argument(s): Number [, Number])
 	let s:func5_args =
 	\ s:Validator.of('func5()')
-	            \.type(s:TYPE.NUMBER, s:TYPE.OPTARG, s:TYPE.NUMBER)
+	            \.type(v:t_number, 'option', v:t_number)
 <
 type(): Any type		*Vital.Validator.Args-example-any-type*
 ----------------
@@ -75,7 +74,7 @@ type(): Any type		*Vital.Validator.Args-example-any-type*
 	" s:func6() receives one arbitrary type argument
 	let s:func6_args =
 	\ s:Validator.of('func6()')
-	            \.type(s:TYPE.ANY)
+	            \.type('any')
 <
 assert()			*Vital.Validator.Args-example-assert*
 --------
@@ -85,7 +84,7 @@ assert()			*Vital.Validator.Args-example-assert*
 	"  regardless of invoked order)
 	let s:func7_args =
 	\ s:Validator.of('func7()')
-	            \.type(s:TYPE.NUMBER)
+	            \.type(v:t_number)
 	            \.assert(1, 'v:val > 0',
 	            \  'the first argument should be a positive number')
 	function! s:func7(...) abort
@@ -99,7 +98,7 @@ assert()			*Vital.Validator.Args-example-assert*
 	
 	" Here is an example of Vim script's built-in function range()
 	let s:range_args = validator.of('vital: Stream: range()')
-	                           \.type(T.NUMBER, T.OPTARG, T.NUMBER, T.NUMBER)
+	                           \.type(v:t_number, 'option', v:t_number, v:t_number)
 	                           \.assert(3, 'v:val !=# 0', 'stride is zero')
 <
 ==============================================================================
@@ -118,61 +117,30 @@ of({prefix} [, {enable}])				*Vital.Validator.Args.of()*
 	" Validates arguments if 'g:myplugin#enable_debug' is non-zero.
 	" Otherwise this does not validate arguments.
 	let func_args = s:Validator.of('func()', g:myplugin#enable_debug)
-	                          \.type(s:TYPE.NUMBER)
+	                          \.type(v:t_number)
 	function! s:func(...) abort
 	  let [n] = s:func_args.validate(a:000)
 
 	  " ...
 	endfunction
 <
-------------------------------------------------------------------------------
-TYPES				*Vital.Validator.Args-types*
-
-TYPE.NUMBER		*Vital.Validator.Args-type-NUMBER*
-	A |Number| argument.
-
-TYPE.STRING		*Vital.Validator.Args-type-STRING*
-	A |String| argument.
-
-TYPE.FUNC		*Vital.Validator.Args-type-FUNC*
-	A |Funcref| argument.
-
-TYPE.LIST		*Vital.Validator.Args-type-LIST*
-	A |List| argument.
-
-TYPE.DICT		*Vital.Validator.Args-type-DICT*
-	A |Dictionary| argument.
-
-TYPE.FLOAT		*Vital.Validator.Args-type-FLOAT*
-	A |Float| argument.
-
-TYPE.BOOL		*Vital.Validator.Args-type-BOOL*
-	A Boolean argument (|v:true| or |v:false|).
-
-TYPE.NONE		*Vital.Validator.Args-type-NONE*
-	A None argument (|v:null| or |v:none|).
-
-TYPE.JOB		*Vital.Validator.Args-type-JOB*
-	A |Job| argument.
-
-TYPE.CHANNEL		*Vital.Validator.Args-type-CHANNEL*
-	A |Channel| argument.
-
-TYPE.ANY		*Vital.Validator.Args-type-ANY*
-	An arbitrary type argument.
-
-TYPE.OPTARG		*Vital.Validator.Args-type-OPTARG*
-	An optional argument (Vim script's "..." in :function arguments).
-	If the last type is OPTARG, skip validation of rest arguments.
-	But if any type(s) were given after OPTARG, check the type(s) and arity.
-
 ==============================================================================
 VALIDATOR OBJECT			*Vital.Validator.Args-Validator-object*
 
 Validator.type([{type} ...])		*Vital.Validator.Args-Validator.type()*
 	Specify types of arguments.
+	{type} is |Number| (like `type(42)`, `v:t_string`) or
+	some special |String| values below.
 
-	See |Vital.Validator.Args-types| for all available types.
+	"any"
+		An arbitrary type argument.
+	"option"
+		An optional argument (Vim script's "..." in :function arguments).
+		If the last type is optional argument, skip validation of rest arguments.
+		But if any type(s) were given after optional argument, check the type(s)
+		and arity.
+		See examples for |Vital.Validator.Args-example-optional-arguments|.
+
 	See |Vital.Validator.Args-example-type| for examples.
 
 					*Vital.Validator.Args-Validator.assert()*

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -32,6 +32,8 @@ function! s:suite.__of__()
     \ A.of(test_null_job())
     Throws /^vital: Validator.Args: of(): expected string argument but got channel/
     \ A.of(test_null_channel())
+    Throws /^vital: Validator.Args: of(): expected string argument but got blob/
+    \ A.of(test_null_blob())
   endfunction
 
   function! of.of_should_not_validate_if_disabled() abort
@@ -87,6 +89,8 @@ function! s:suite.__of__()
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([test_null_job()])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: channel)/
     \ A.of('test()').type([T.STRING, T.FUNC]).validate([test_null_channel()])
+    Throws /^test(): invalid type arguments were given (expected: string or func, got: blob)/
+    \ A.of('test()').type([T.STRING, T.FUNC]).validate([test_null_blob()])
   endfunction
 
   function! of.any_type() abort
@@ -101,6 +105,7 @@ function! s:suite.__of__()
     call A.of('test()').type(T.ANY).validate([v:null])
     call A.of('test()').type(T.ANY).validate([test_null_job()])
     call A.of('test()').type(T.ANY).validate([test_null_channel()])
+    call A.of('test()').type(T.ANY).validate([test_null_blob()])
   endfunction
 
   function! of.wrong_types_and_correct_types()
@@ -124,6 +129,8 @@ function! s:suite.__of__()
     \ A.of('test()').type(T.STRING).validate([test_null_job()])
     Throws /^test(): invalid type arguments were given (expected: string, got: channel)/
     \ A.of('test()').type(T.STRING).validate([test_null_channel()])
+    Throws /^test(): invalid type arguments were given (expected: string, got: blob)/
+    \ A.of('test()').type(T.STRING).validate([test_null_blob()])
   endfunction
 
   function! of.validate_should_throw_if_it_received_non_list_value() abort
@@ -147,6 +154,8 @@ function! s:suite.__of__()
     \ A.of('test()').type(T.ANY).validate(test_null_job())
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got channel/
     \ A.of('test()').type(T.ANY).validate(test_null_channel())
+    Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got blob/
+    \ A.of('test()').type(T.ANY).validate(test_null_blob())
   endfunction
 
   function! of.arity_is_correct() abort
@@ -169,7 +178,7 @@ function! s:suite.__of__()
     Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got string/
     \ A.of('test()').type('string')
     Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got number/
-    \ A.of('test()').type(10)
+    \ A.of('test()').type(999)
 
     Throws /^vital: Validator.Args: Validator.type(): multiple OPTARG were given/
     \ A.of('test()').type(T.OPTARG, T.OPTARG)

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -5,14 +5,13 @@ let s:assert = themis#helper('assert')
 
 function! s:suite.before()
   let s:A = vital#vital#import('Validator.Args')
-  let s:T = s:A.TYPE
 endfunction
 
 function! s:suite.__of__()
   let of = themis#suite('of')
 
   function! of.of_should_throw_if_it_received_non_string_value() abort
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^vital: Validator.Args: of(): expected string argument but got number/
     \ A.of(42)
     call A.of('')
@@ -37,10 +36,8 @@ function! s:suite.__of__()
   endfunction
 
   function! of.of_should_not_validate_if_disabled() abort
-    let [A, T] = [s:A, s:T]
-
     " disabled
-    let v = A.of('func()', 0).type(T.STRING)
+    let v = s:A.of('func()', 0).type(v:t_string)
     try
       Assert Equals(v.validate([42]), [42])
     catch
@@ -48,16 +45,15 @@ function! s:suite.__of__()
     endtry
 
     " enabled
-    let v = A.of('func()', 1).type(T.STRING)
+    let v = s:A.of('func()', 1).type(v:t_string)
     Throws /^func(): invalid type arguments were given (expected: string, got: number)/
     \ v.validate([42])
   endfunction
 
   function! of.no_check()
-    let A = s:A
-    call A.of('test()').validate([])
-    call A.of('test()').validate([1])
-    call A.of('test()').validate([1,'foo'])
+    call s:A.of('test()').validate([])
+    call s:A.of('test()').validate([1])
+    call s:A.of('test()').validate([1,'foo'])
   endfunction
 
   function! of.validate_returns_given_args()
@@ -70,135 +66,132 @@ function! s:suite.__of__()
   endfunction
 
   function! of.union_types()
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^test(): invalid type arguments were given (expected: string or func, got: number)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([42])
-    call A.of('test()').type([T.STRING, T.FUNC]).validate([''])
-    call A.of('test()').type([T.STRING, T.FUNC]).validate([function('function')])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([42])
+    call A.of('test()').type([v:t_string, v:t_func]).validate([''])
+    call A.of('test()').type([v:t_string, v:t_func]).validate([function('function')])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: list)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([[]])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([[]])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: dict)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([{}])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([{}])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: float)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([3.14])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([3.14])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: bool)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:false])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([v:false])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: none)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([v:null])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([v:null])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: job)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([test_null_job()])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([test_null_job()])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: channel)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([test_null_channel()])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([test_null_channel()])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: blob)/
-    \ A.of('test()').type([T.STRING, T.FUNC]).validate([test_null_blob()])
+    \ A.of('test()').type([v:t_string, v:t_func]).validate([test_null_blob()])
   endfunction
 
   function! of.any_type() abort
-    let [A, T] = [s:A, s:T]
-    call A.of('test()').type(T.ANY).validate([42])
-    call A.of('test()').type(T.ANY).validate([''])
-    call A.of('test()').type(T.ANY).validate([function('function')])
-    call A.of('test()').type(T.ANY).validate([[]])
-    call A.of('test()').type(T.ANY).validate([{}])
-    call A.of('test()').type(T.ANY).validate([3.14])
-    call A.of('test()').type(T.ANY).validate([v:false])
-    call A.of('test()').type(T.ANY).validate([v:null])
-    call A.of('test()').type(T.ANY).validate([test_null_job()])
-    call A.of('test()').type(T.ANY).validate([test_null_channel()])
-    call A.of('test()').type(T.ANY).validate([test_null_blob()])
+    call s:A.of('test()').type('any').validate([42])
+    call s:A.of('test()').type('any').validate([''])
+    call s:A.of('test()').type('any').validate([function('function')])
+    call s:A.of('test()').type('any').validate([[]])
+    call s:A.of('test()').type('any').validate([{}])
+    call s:A.of('test()').type('any').validate([3.14])
+    call s:A.of('test()').type('any').validate([v:false])
+    call s:A.of('test()').type('any').validate([v:null])
+    call s:A.of('test()').type('any').validate([test_null_job()])
+    call s:A.of('test()').type('any').validate([test_null_channel()])
+    call s:A.of('test()').type('any').validate([test_null_blob()])
   endfunction
 
   function! of.wrong_types_and_correct_types()
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^test(): invalid type arguments were given (expected: string, got: number)/
-    \ A.of('test()').type(T.STRING).validate([42])
-    call A.of('test()').type(T.STRING).validate([''])
+    \ A.of('test()').type(v:t_string).validate([42])
+    call A.of('test()').type(v:t_string).validate([''])
     Throws /^test(): invalid type arguments were given (expected: string, got: func)/
-    \ A.of('test()').type(T.STRING).validate([function('function')])
+    \ A.of('test()').type(v:t_string).validate([function('function')])
     Throws /^test(): invalid type arguments were given (expected: string, got: list)/
-    \ A.of('test()').type(T.STRING).validate([[]])
+    \ A.of('test()').type(v:t_string).validate([[]])
     Throws /^test(): invalid type arguments were given (expected: string, got: dict)/
-    \ A.of('test()').type(T.STRING).validate([{}])
+    \ A.of('test()').type(v:t_string).validate([{}])
     Throws /^test(): invalid type arguments were given (expected: string, got: float)/
-    \ A.of('test()').type(T.STRING).validate([3.14])
+    \ A.of('test()').type(v:t_string).validate([3.14])
     Throws /^test(): invalid type arguments were given (expected: string, got: bool)/
-    \ A.of('test()').type(T.STRING).validate([v:false])
+    \ A.of('test()').type(v:t_string).validate([v:false])
     Throws /^test(): invalid type arguments were given (expected: string, got: none)/
-    \ A.of('test()').type(T.STRING).validate([v:null])
+    \ A.of('test()').type(v:t_string).validate([v:null])
     Throws /^test(): invalid type arguments were given (expected: string, got: job)/
-    \ A.of('test()').type(T.STRING).validate([test_null_job()])
+    \ A.of('test()').type(v:t_string).validate([test_null_job()])
     Throws /^test(): invalid type arguments were given (expected: string, got: channel)/
-    \ A.of('test()').type(T.STRING).validate([test_null_channel()])
+    \ A.of('test()').type(v:t_string).validate([test_null_channel()])
     Throws /^test(): invalid type arguments were given (expected: string, got: blob)/
-    \ A.of('test()').type(T.STRING).validate([test_null_blob()])
+    \ A.of('test()').type(v:t_string).validate([test_null_blob()])
   endfunction
 
   function! of.validate_should_throw_if_it_received_non_list_value() abort
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got number/
-    \ A.of('test()').type(T.ANY).validate(42)
+    \ A.of('test()').type('any').validate(42)
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got string/
-    \ A.of('test()').type(T.ANY).validate('')
+    \ A.of('test()').type('any').validate('')
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got func/
-    \ A.of('test()').type(T.ANY).validate(function('function'))
-    call A.of('test()').type(T.ANY).validate([42])
+    \ A.of('test()').type('any').validate(function('function'))
+    call A.of('test()').type('any').validate([42])
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got dict/
-    \ A.of('test()').type(T.ANY).validate({})
+    \ A.of('test()').type('any').validate({})
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got float/
-    \ A.of('test()').type(T.ANY).validate(3.14)
+    \ A.of('test()').type('any').validate(3.14)
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got bool/
-    \ A.of('test()').type(T.ANY).validate(v:false)
+    \ A.of('test()').type('any').validate(v:false)
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got none/
-    \ A.of('test()').type(T.ANY).validate(v:null)
+    \ A.of('test()').type('any').validate(v:null)
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got job/
-    \ A.of('test()').type(T.ANY).validate(test_null_job())
+    \ A.of('test()').type('any').validate(test_null_job())
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got channel/
-    \ A.of('test()').type(T.ANY).validate(test_null_channel())
+    \ A.of('test()').type('any').validate(test_null_channel())
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got blob/
-    \ A.of('test()').type(T.ANY).validate(test_null_blob())
+    \ A.of('test()').type('any').validate(test_null_blob())
   endfunction
 
   function! of.arity_is_correct() abort
-    let [A, T] = [s:A, s:T]
-    call A.of('test()').type(T.STRING).validate(['foo'])
-    call A.of('test()').type(T.STRING, T.OPTARG, T.STRING)
+    call s:A.of('test()').type(v:t_string).validate(['foo'])
+    call s:A.of('test()').type(v:t_string, 'option', v:t_string)
                         \.validate(['foo', 'bar'])
-    call A.of('test()').type(T.STRING, T.OPTARG, T.STRING, T.STRING)
+    call s:A.of('test()').type(v:t_string, 'option', v:t_string, v:t_string)
                         \.validate(['foo', 'bar'])
-    " if the last type is OPTARG, skip validation of rest arguments
-    " (but if any types were given after OPTARG, check the types and arity)
-    call A.of('test()').type(T.STRING, T.OPTARG).validate(['foo'])
-    call A.of('test()').type(T.STRING, T.OPTARG).validate(['foo', 'bar'])
-    call A.of('test()').type(T.STRING, T.OPTARG).validate(['foo', 'bar', 'baz'])
+    " if the last type is optional argument, skip validation of rest arguments
+    " (but if any types were given after optional argument, check the types and arity)
+    call s:A.of('test()').type(v:t_string, 'option').validate(['foo'])
+    call s:A.of('test()').type(v:t_string, 'option').validate(['foo', 'bar'])
+    call s:A.of('test()').type(v:t_string, 'option').validate(['foo', 'bar', 'baz'])
   endfunction
 
   function! of.type_invalid_args() abort
-    let [A, T] = [s:A, s:T]
-
+    let A = s:A
     Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got string/
     \ A.of('test()').type('string')
     Throws /^vital: Validator.Args: Validator.type(): expected type or union types but got number/
     \ A.of('test()').type(999)
 
-    Throws /^vital: Validator.Args: Validator.type(): multiple OPTARG were given/
-    \ A.of('test()').type(T.OPTARG, T.OPTARG)
+    Throws /^vital: Validator.Args: Validator.type(): multiple optional arguments were given/
+    \ A.of('test()').type('option', 'option')
   endfunction
 
   function! of.arity_is_wrong() abort
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^test(): too few arguments/
-    \ A.of('test()').type(T.STRING, T.OPTARG).validate([])
+    \ A.of('test()').type(v:t_string, 'option').validate([])
     Throws /^test(): too few arguments/
-    \ A.of('test()').type(T.STRING).validate([])
+    \ A.of('test()').type(v:t_string).validate([])
     Throws /^test(): too many arguments/
-    \ A.of('test()').type(T.STRING).validate(['foo', 'bar'])
+    \ A.of('test()').type(v:t_string).validate(['foo', 'bar'])
     Throws /^test(): too many arguments/
-    \ A.of('test()').type(T.STRING, T.OPTARG, T.STRING)
+    \ A.of('test()').type(v:t_string, 'option', v:t_string)
                     \.validate(['foo', 'bar', 'baz'])
   endfunction
 
   function! of.assert_only() abort
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^test(): the first argument should be non empty string/
     \ A.of('test()').assert(1, 'type(v:val) is type('''') && v:val != ''''',
                    \           'the first argument should be non empty string')
@@ -213,7 +206,7 @@ function! s:suite.__of__()
   endfunction
 
   function! of.assert_invalid_args() abort
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^vital: Validator.Args: Validator.assert(): the first argument number was not positive/
     \ A.of('test()').assert(-1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
@@ -224,67 +217,67 @@ function! s:suite.__of__()
   endfunction
 
   function! of.assert_with_type() abort
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^test(): the first argument should be non empty string/
-    \ A.of('test()').type(T.STRING)
+    \ A.of('test()').type(v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.validate([''])
     Throws /^test(): the 1th argument's assertion was failed/
-    \ A.of('test()').type(T.STRING)
+    \ A.of('test()').type(v:t_string)
                    \.assert(1, 'v:val != ''''')
                    \.validate([''])
     call
-    \ A.of('test()').type(T.STRING)
+    \ A.of('test()').type(v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.validate(['foo'])
   endfunction
 
   function! of.mixed_validation_with_assert_and_type() abort
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     " .type() checking failure
     Throws /^test(): invalid type arguments were given (expected: string, got: number)/
-    \ A.of('test()').type(T.STRING)
+    \ A.of('test()').type(v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.validate([42])
     " too few arguments
     Throws /^test(): too few arguments/
-    \ A.of('test()').type(T.STRING)
+    \ A.of('test()').type(v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.validate([])
     " too many arguments
     Throws /^test(): too many arguments/
-    \ A.of('test()').type(T.STRING)
+    \ A.of('test()').type(v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.validate(['foo', 'bar'])
-    " type() with OPTARG, and assert()
+    " type() with optional argument, and assert()
     call
-    \ A.of('test()').type(T.STRING, T.OPTARG)
+    \ A.of('test()').type(v:t_string, 'option')
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
                    \            'the second argument should be non empty string')
                    \.validate(['foo', 'bar'])
     Throws /^test(): the second argument should be non empty string/
-    \ A.of('test()').type(T.STRING, T.OPTARG)
+    \ A.of('test()').type(v:t_string, 'option')
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
                    \            'the second argument should be non empty string')
                    \.validate(['foo', ''])
     call
-    \ A.of('test()').type(T.STRING, T.OPTARG, T.STRING)
+    \ A.of('test()').type(v:t_string, 'option', v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
                    \            'the second argument should be non empty string')
                    \.validate(['foo', 'bar'])
     Throws /^test(): the second argument should be non empty string/
-    \ A.of('test()').type(T.STRING, T.OPTARG, T.STRING)
+    \ A.of('test()').type(v:t_string, 'option', v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
@@ -293,9 +286,9 @@ function! s:suite.__of__()
   endfunction
 
   function! of.assert_no_out_of_range()
-    let [A, T] = [s:A, s:T]
+    let A = s:A
     Throws /^vital: Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1 arguments)/
-    \ A.of('test()').type(T.STRING)
+    \ A.of('test()').type(v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
@@ -305,9 +298,9 @@ function! s:suite.__of__()
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
                    \            'the second argument?')
-                   \.type(T.STRING)
+                   \.type(v:t_string)
     Throws /^vital: Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1-2 arguments)/
-    \ A.of('test()').type(T.STRING, T.OPTARG, T.STRING)
+    \ A.of('test()').type(v:t_string, 'option', v:t_string)
                    \.assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
                    \.assert(2, 'v:val != ''''',
@@ -321,7 +314,7 @@ function! s:suite.__of__()
                    \            'the second argument should be non empty string')
                    \.assert(3, 'v:val != ''''',
                    \            'the third argument?')
-                   \.type(T.STRING, T.OPTARG, T.STRING)
+                   \.type(v:t_string, 'option', v:t_string)
     Throws /^vital: Validator.Args: Validator.assert(): the first argument number was out of range (type() defines 1-3 arguments)/
     \ A.of('test()').assert(1, 'v:val != ''''',
                    \            'the first argument should be non empty string')
@@ -331,7 +324,7 @@ function! s:suite.__of__()
                    \            'the third argument should be non empty string')
                    \.assert(4, 'v:val != ''''',
                    \            'the fourth argument?')
-                   \.type(T.STRING, T.OPTARG, T.STRING, T.STRING)
+                   \.type(v:t_string, 'option', v:t_string, v:t_string)
   endfunction
 
 endfunction

--- a/test/Validator/Args.vim
+++ b/test/Validator/Args.vim
@@ -3,6 +3,30 @@ scriptencoding utf-8
 let s:suite = themis#suite('Validator.Args')
 let s:assert = themis#helper('assert')
 
+function! s:assert_null_support() abort
+  if !exists('v:null')
+    Skip "this version of vim/neovim does not support v:null"
+  endif
+endfunction
+
+function! s:assert_job_support() abort
+  if !exists('*test_null_job')
+    Skip "this version of vim does not support job"
+  endif
+endfunction
+
+function! s:assert_channel_support() abort
+  if !exists('*test_null_channel')
+    Skip "this version of vim does not support channel"
+  endif
+endfunction
+
+function! s:assert_blob_support() abort
+  if !exists('*test_null_blob')
+    Skip "this version of vim does not support blob"
+  endif
+endfunction
+
 function! s:suite.before()
   let s:A = vital#vital#import('Validator.Args')
 endfunction
@@ -25,12 +49,16 @@ function! s:suite.__of__()
     \ A.of(3.14)
     Throws /^vital: Validator.Args: of(): expected string argument but got bool/
     \ A.of(v:false)
+    call s:assert_null_support()
     Throws /^vital: Validator.Args: of(): expected string argument but got none/
     \ A.of(v:null)
+    call s:assert_job_support()
     Throws /^vital: Validator.Args: of(): expected string argument but got job/
     \ A.of(test_null_job())
+    call s:assert_channel_support()
     Throws /^vital: Validator.Args: of(): expected string argument but got channel/
     \ A.of(test_null_channel())
+    call s:assert_blob_support()
     Throws /^vital: Validator.Args: of(): expected string argument but got blob/
     \ A.of(test_null_blob())
   endfunction
@@ -79,12 +107,16 @@ function! s:suite.__of__()
     \ A.of('test()').type([v:t_string, v:t_func]).validate([3.14])
     Throws /^test(): invalid type arguments were given (expected: string or func, got: bool)/
     \ A.of('test()').type([v:t_string, v:t_func]).validate([v:false])
+    call s:assert_null_support()
     Throws /^test(): invalid type arguments were given (expected: string or func, got: none)/
     \ A.of('test()').type([v:t_string, v:t_func]).validate([v:null])
+    call s:assert_job_support()
     Throws /^test(): invalid type arguments were given (expected: string or func, got: job)/
     \ A.of('test()').type([v:t_string, v:t_func]).validate([test_null_job()])
+    call s:assert_channel_support()
     Throws /^test(): invalid type arguments were given (expected: string or func, got: channel)/
     \ A.of('test()').type([v:t_string, v:t_func]).validate([test_null_channel()])
+    call s:assert_blob_support()
     Throws /^test(): invalid type arguments were given (expected: string or func, got: blob)/
     \ A.of('test()').type([v:t_string, v:t_func]).validate([test_null_blob()])
   endfunction
@@ -97,9 +129,13 @@ function! s:suite.__of__()
     call s:A.of('test()').type('any').validate([{}])
     call s:A.of('test()').type('any').validate([3.14])
     call s:A.of('test()').type('any').validate([v:false])
+    call s:assert_null_support()
     call s:A.of('test()').type('any').validate([v:null])
+    call s:assert_job_support()
     call s:A.of('test()').type('any').validate([test_null_job()])
+    call s:assert_channel_support()
     call s:A.of('test()').type('any').validate([test_null_channel()])
+    call s:assert_blob_support()
     call s:A.of('test()').type('any').validate([test_null_blob()])
   endfunction
 
@@ -118,12 +154,16 @@ function! s:suite.__of__()
     \ A.of('test()').type(v:t_string).validate([3.14])
     Throws /^test(): invalid type arguments were given (expected: string, got: bool)/
     \ A.of('test()').type(v:t_string).validate([v:false])
+    call s:assert_null_support()
     Throws /^test(): invalid type arguments were given (expected: string, got: none)/
     \ A.of('test()').type(v:t_string).validate([v:null])
+    call s:assert_job_support()
     Throws /^test(): invalid type arguments were given (expected: string, got: job)/
     \ A.of('test()').type(v:t_string).validate([test_null_job()])
+    call s:assert_channel_support()
     Throws /^test(): invalid type arguments were given (expected: string, got: channel)/
     \ A.of('test()').type(v:t_string).validate([test_null_channel()])
+    call s:assert_blob_support()
     Throws /^test(): invalid type arguments were given (expected: string, got: blob)/
     \ A.of('test()').type(v:t_string).validate([test_null_blob()])
   endfunction
@@ -143,12 +183,16 @@ function! s:suite.__of__()
     \ A.of('test()').type('any').validate(3.14)
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got bool/
     \ A.of('test()').type('any').validate(v:false)
+    call s:assert_null_support()
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got none/
     \ A.of('test()').type('any').validate(v:null)
+    call s:assert_job_support()
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got job/
     \ A.of('test()').type('any').validate(test_null_job())
+    call s:assert_channel_support()
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got channel/
     \ A.of('test()').type('any').validate(test_null_channel())
+    call s:assert_blob_support()
     Throws /^vital: Validator.Args: Validator.validate(): expected list argument but got blob/
     \ A.of('test()').type('any').validate(test_null_blob())
   endfunction


### PR DESCRIPTION
* BLOB 型をサポートしました
* Mod.TYPE は `v:t_*` 変数が使える事に気付き削除しました。 `ANY`, `OPTARG` はそれぞれ文字列で `'any'`, `'option'` のように渡すインターフェースに変更しました