### PR TITLE
Feature request: Web.HTTP support OAuth bearer token

### DIFF
--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -354,6 +354,8 @@ try:
                     digestauth = urllib2.HTTPDigestAuthHandler(passman)
                     director.add_handler(basicauth)
                     director.add_handler(digestauth)
+                if settings.has_key('bearerToken'):
+                    request_headers.setdefault('Authorization', 'Bearer ' + settings['bearerToken'])
                 req = urllib2.Request(settings['url'], data, request_headers)
                 req.get_method = lambda: settings['method']
                 default_timeout = socket.getdefaulttimeout()
@@ -531,6 +533,10 @@ function! s:clients.curl.request(settings) abort
     endif
     let command .= ' --' . method . ' --user ' . quote . auth . quote
   endif
+  if has_key(a:settings, 'bearerToken')
+        \ && has_key(a:settings, 'authMethod') && (a:settings.authMethod ==? 'oauth2')
+    let command .= ' --oauth2-bearer '  . quote . a:settings.bearerToken . quote
+  endif
   if has_key(a:settings, 'data')
     let a:settings._file.post = s:_make_postfile(a:settings.data)
     let command .= ' --data-binary @' . quote . a:settings._file.post . quote
@@ -622,6 +628,9 @@ function! s:clients.wget.request(settings) abort
   endif
   if has_key(a:settings, 'password')
     let command .= ' --http-password=' . quote . escape(a:settings.password, quote) . quote
+  endif
+  if has_key(a:settings, 'bearerToken')
+    let command .= ' --header=' . quote . 'Authorization: Bearer ' . a:settings.bearerToken . quote
   endif
   let command .= ' ' . quote . a:settings.url . quote
   if has_key(a:settings, 'data')

--- a/doc/vital/Web/HTTP.txt
+++ b/doc/vital/Web/HTTP.txt
@@ -74,6 +74,9 @@ request({method}, {url} [, {settings}])
 	"password"	Default: (None)
 		Password for an HTTP authentication.
 
+	"bearerToken"	Default: (None)
+		Bearer token for an HTTP authentication (OAuth2).
+
 	"maxRedirect"	Default: 20
 		Maximum number of redirections.
 		The default is 20, which is usually far more than necessary.
@@ -100,7 +103,8 @@ request({method}, {url} [, {settings}])
 	"authMethod"	Default: (None)
 		(This is only valid for "curl" interface.)
 		Specify the authorization method.
-		The value must be in ['basic', 'digest', 'ntlm', 'negotiate']
+		The value must be in ['basic', 'digest', 'ntlm', 'negotiate',
+		'oauth2']
 		The default value is None, and then use "anyauth".
 
 	"gzipDecompress"	Default: 0


### PR DESCRIPTION
In curl

```
--oauth2-bearer <token> OAuth 2 Bearer Token
```

I'm trying to this support.