### PR TITLE
Add Data.List.count()

### DIFF
--- a/autoload/vital/__vital__/Data/List.vim
+++ b/autoload/vital/__vital__/Data/List.vim
@@ -373,6 +373,17 @@ function! s:foldr1(f, xs) abort
   return s:foldr(a:f, a:xs[-1], a:xs[0:-2])
 endfunction
 
+function! s:count(f, xs) abort
+  let num = 0
+  for x in a:xs
+    if a:f(x)
+      let num += 1
+    endif
+  endfor
+  return num
+endfunction
+
+
 " Similar to python's zip() .
 function! s:zip(...) abort
   return map(range(min(map(copy(a:000), 'len(v:val)'))), "map(copy(a:000), 'v:val['.v:val.']')")

--- a/doc/vital/Data/List.txt
+++ b/doc/vital/Data/List.txt
@@ -690,6 +690,30 @@ foldr1({function}, {xs})			*Vital.Data.List.foldr1()*
 
 	Non-destructive. This does not modify {xs}.
 
+count({f}, {xs})				*Vital.Data.List.count()*
+	NOTE: This is different to Vim script's native |count()| function.
+	NOTE: This is experimental. Unlike other Data.List functions, you
+	can't provide a string represated pseudo function to {f}.
+
+	Returns number of items in {xs} that satisfies the given predicate
+	function {f}.
+>
+	echo s:L.count({ x -> x == 2 }, [1, 2, 3, 4, 5])
+	"=> 1
+
+	echo s:L.count({ x -> x % 2 == 0 }, [1, 2, 3, 4, 5])
+	"=> 2
+
+	function! s:f(x)
+	  return a:x % 2 == 0
+	endfunction
+	echo s:L.count(function('s:f', [1, 2, 3, 4, 5])
+	"=> 2
+<
+	It scans from left to right. O(n).
+
+	Non-destructive. This does not modify {xs}.
+
 zip(...)				*Vital.Data.List.zip()*
 	Unifies lists in parallel. If the length of the lists is different,
 	adjusts for shorter list, longer list is sliced.

--- a/test/Data/List.vimspec
+++ b/test/Data/List.vimspec
@@ -578,6 +578,19 @@ Describe Data.List
     End
   End
 
+  Describe .count()
+    It always returns 0 for empty list
+      Assert Equals(List.count({ _ -> 1 }, []), 0)
+    End
+
+    It counts num truethy satisfying the predicate for each values
+      Assert Equals(List.count({ n -> n % 2 == 0 }, [1, 2, 3, 4, 5, 6, 7]), 3)
+      Assert Equals(List.count(function('Even'), [1, 2, 3, 4, 5, 6, 7]), 3)
+
+      Assert Equals(List.count({ n -> n % 3 == 0 }, [1, 2, 3, 4, 5, 6, 7]), 2)
+    End
+  End
+
   Describe .zip()
     It returns mixed list from arguments
       Assert Equals(List.zip([1,2,3]), [[1],[2],[3]])


### PR DESCRIPTION
```
count({f}, {xs})				*Vital.Data.List.count()*
	NOTE: This is different to Vim script's native |count()| function.
	NOTE: This is experimental. Unlike other Data.List functions, you
	can't provide a string represated pseudo function to {f}.

	Returns number of items in {xs} that satisfies the given predicate
	function {f}.
>
	echo s:L.count({ x -> x == 2 }, [1, 2, 3, 4, 5])
	"=> 1

	echo s:L.count({ x -> x % 2 == 0 }, [1, 2, 3, 4, 5])
	"=> 2

	function! s:f(x)
	  return a:x % 2 == 0
	endfunction
	echo s:L.count(function('s:f', [1, 2, 3, 4, 5])
	"=> 2
<
	It scans from left to right. O(n).

	Non-destructive. This does not modify {xs}.
```