### PR TITLE
Prelude: Remove escape_file_searching()

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+2690a79e5110ec347131de6a634a944d841b5d9e
+	Modules: Prelude
+	Prelude.escape_file_searching() is gone. Use `escape(buffer_name, '*[]?{}, ')` instead.
 a9a3520e4b48c020a3c4802578e10e9682738e7a
 	Modules: Data.Collection
 	Data.Collection is gone. If you used Data.Collection.get_f, replace it with following:

--- a/autoload/vital/__vital__/Prelude.vim
+++ b/autoload/vital/__vital__/Prelude.vim
@@ -176,7 +176,7 @@ function! s:smart_execute_command(action, word) abort
   execute a:action . ' ' . (a:word ==# '' ? '' : '`=a:word`')
 endfunction
 
-function! s:escape_file_searching(buffer_name) abort
+function! s:_escape_file_searching(buffer_name) abort
   return escape(a:buffer_name, '*[]?{}, ')
 endfunction
 
@@ -250,7 +250,7 @@ function! s:_path2project_directory_svn(path) abort
   let search_directory = a:path
   let directory = ''
 
-  let find_directory = s:escape_file_searching(search_directory)
+  let find_directory = s:_escape_file_searching(search_directory)
   let d = finddir('.svn', find_directory . ';')
   if d ==# ''
     return ''
@@ -275,7 +275,7 @@ function! s:_path2project_directory_others(vcs, path) abort
   let vcs = a:vcs
   let search_directory = a:path
 
-  let find_directory = s:escape_file_searching(search_directory)
+  let find_directory = s:_escape_file_searching(search_directory)
   let d = finddir(vcs, find_directory . ';')
   if d ==# ''
     return ''
@@ -307,7 +307,7 @@ function! s:path2project_directory(path, ...) abort
     for d in ['build.xml', 'prj.el', '.project', 'pom.xml', 'package.json',
           \ 'Makefile', 'configure', 'Rakefile', 'NAnt.build',
           \ 'P4CONFIG', 'tags', 'gtags']
-      let d = findfile(d, s:escape_file_searching(search_directory) . ';')
+      let d = findfile(d, s:_escape_file_searching(search_directory) . ';')
       if d !=# ''
         let directory = fnamemodify(d, ':p:h')
         break

--- a/doc/vital/Prelude.txt
+++ b/doc/vital/Prelude.txt
@@ -129,9 +129,6 @@ smart_execute_command({action}, {word})	*Vital.Prelude.smart_execute_command()*
 	execute 'echo' 123
 <
 
-escape_file_searching({str})		*Vital.Prelude.escape_file_searching()*
-	TODO
-
 escape_pattern({str})			*Vital.Prelude.escape_pattern()*
 	Use |Vital.Data.String.escape_pattern()| instead.
 	Note that |Vital.Data.String.escape_pattern()| does not escape a


### PR DESCRIPTION
* This has been undocumented
* This function doesn't seem to be actively directly used from Vim plugins,
  but only used from within Prelude
* I'd like to shrink Prelude module gradually, so let's deprecate this one for now.