### PR TITLE
Prelude: Add `is_infinity()`.

### DIFF
--- a/autoload/vital/__vital__/Prelude.vim
+++ b/autoload/vital/__vital__/Prelude.vim
@@ -61,6 +61,25 @@ function! s:is_float(Value) abort
   return type(a:Value) ==# s:__TYPE_FLOAT
 endfunction
 
+" Infinity
+if exists('*isinf')
+  function! s:is_infinity(Value) abort
+    return isinf(a:Value)
+  endfunction
+else
+  function! s:is_infinity(Value) abort
+    if type(a:Value) ==# s:__TYPE_FLOAT
+      let s = string(a:Value)
+      if s ==# 'inf'
+        return 1
+      elseif s ==# '-inf'
+        return -1
+      endif
+    endif
+    return 0
+  endfunction
+endif
+
 
 function! s:truncate_skipping(str, max, footer_width, separator) abort
   call s:_warn_deprecated('truncate_skipping', 'Data.String.truncate_skipping')

--- a/doc/vital/Prelude.txt
+++ b/doc/vital/Prelude.txt
@@ -71,6 +71,19 @@ is_float({value})				*Vital.Prelude.is_float()*
 		:echo s:P.is_float("hoge")
 <		0
 
+is_infinity({value})				*Vital.Prelude.is_infinity()*
+	Return 1 if {expr} is a positive infinity, or -1 a negative
+	infinity, otherwise 0.
+		Examples: >
+		:let s:V = vital#{plugin-name}#new()
+		:let s:P = s:V.import('Prelude')
+		:echo s:P.is_infinity(1.0 / 0)
+<		1 >
+		:echo s:P.is_infinity(-1.0 / 0)
+<		-1 >
+		:echo s:P.is_infinity(123.0)
+<		0
+
 is_string({value})				*Vital.Prelude.is_string()*
 	Returns non-zero if {value} is a String (|expr-string|), zero otherwise.
 

--- a/test/Prelude.vimspec
+++ b/test/Prelude.vimspec
@@ -38,6 +38,19 @@ Describe Prelude
     End
   End
 
+  Describe .is_infinity()
+    It checks if the argument is a float that infinity
+      Assert Equals(P.is_infinity(1.0/0), 1)
+      Assert Equals(P.is_infinity(-1.0/0), -1)
+      Assert Equals(P.is_infinity(0.0/0), 0)
+      Assert Equals(P.is_infinity(3.14159), 0)
+      Assert Equals(P.is_infinity(""), 0)
+      Assert Equals(P.is_infinity(function('tr')), 0)
+      Assert Equals(P.is_infinity([]), 0)
+      Assert Equals(P.is_infinity({}), 0)
+    End
+  End
+
   Describe .is_string()
     It checks if the argument is a string
       Assert Equals(P.is_string(3), 0)


### PR DESCRIPTION
Builtin function `isinf()` is added at v8.1.1111 (vim/vim@fda1bff).
Add an equivalent function `is_infinity()` to Prelude.