### PR TITLE
Add check v:version

### DIFF
--- a/plugin/vitalizer.vim
+++ b/plugin/vitalizer.vim
@@ -2,6 +2,8 @@
 
 if exists('g:loaded_vitalizer')
   finish
+elseif v:version < 800
+  echoerr "vital.vim does not work this version of Vim"
 endif
 let g:loaded_vitalizer = 1
 


### PR DESCRIPTION
Hi!
In this `README.md`, vital.vim support ` Vim 8.1 or later`.
Therefore, I added checking about v:version < 800 in plugin dir.
Could you check this Pull Request?