### PR TITLE
Async.Promise: Remove test helper wait_has_key_with_timeout

### DIFF
--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -1,17 +1,14 @@
 function! s:wait_has_key(obj, name) abort
-  return s:wait_has_key_with_timeout(a:obj, a:name, 5)
-endfunction
-
-function! s:wait_has_key_with_timeout(obj, name, timeout_sec) abort
+  let timeout_sec = 5
   let i = 0
-  while i < a:timeout_sec * 100
+  while i < timeout_sec * 100
     sleep 10m
     if has_key(a:obj, a:name)
       return
     endif
     let i += 1
   endwhile
-  throw printf("s:wait_has_key(): After %ds, the given object does not have key '%s': %s", a:timeout_sec, a:name, a:obj)
+  throw printf("s:wait_has_key(): After %ds, the given object does not have key '%s': %s", timeout_sec, a:name, a:obj)
 endfunction
 
 function! s:resolver(resolve, reject) abort


### PR DESCRIPTION
* I needed this to fix a flaky test, but after fixing the root cause instead,
  we no longer need to specify the timeout from each test case.
* Not having many helper functions in the test increases the maintainability
    * https://github.com/vim-jp/vital.vim/pull/713#discussion_r368769255
* I kept the `timeout` as a hard-coded local var instead of hard-coding into the logic as its original form,
  for the ease of debug in the future. The runtime cost is ignorable.