### PR TITLE
Data.Optional: stop evaluation of {alternative} of get_or when it has some value

### DIFF
--- a/autoload/vital/__vital__/Data/Optional.vim
+++ b/autoload/vital/__vital__/Data/Optional.vim
@@ -74,7 +74,7 @@ function! s:get_unsafe(o) abort
 endfunction
 
 function! s:get_or(o, alt) abort
-  return get(a:o, s:SOME_KEY, a:alt())
+  return has_key(a:o, s:SOME_KEY) ? a:o[s:SOME_KEY] : a:alt()
 endfunction
 
 function! s:has(o, type) abort


### PR DESCRIPTION
I think `get_or(some(value), { -> 42 })` should not evaluate `{ -> 42 }`. Current implementation need not the default value is a function.