### PR TITLE
Improve performance of Promise especially in Windows

### DIFF
--- a/autoload/vital/__vital__/Async/Later.vim
+++ b/autoload/vital/__vital__/Async/Later.vim
@@ -9,7 +9,7 @@ function! s:call(fn, ...) abort
   endif
 endfunction
 
-function! s:get_max_workers(n) abort
+function! s:get_max_workers() abort
   return s:max_workers
 endfunction
 

--- a/autoload/vital/__vital__/Async/Later.vim
+++ b/autoload/vital/__vital__/Async/Later.vim
@@ -1,0 +1,32 @@
+let s:tasks = []
+let s:timer = v:null
+
+function! s:call(fn, ...) abort
+  call add(s:tasks, [a:fn, a:000])
+  call s:_emit()
+endfunction
+
+function! s:_emit() abort
+  if v:dying || s:timer isnot# v:null || empty(s:tasks)
+    return
+  endif
+  let s:timer = timer_start(0, funcref('s:_callback'))
+endfunction
+
+function! s:_callback(timer) abort
+  let s:timer = v:null
+  if v:dying || empty(s:tasks)
+    return
+  endif
+  try
+    call call('call', remove(s:tasks, 0))
+  catch
+    let ms = split(v:exception . "\n" . v:throwpoint, '\n')
+    echohl ErrorMsg
+    for m in ms
+      echomsg m
+    endfor
+    echohl None
+  endtry
+  call s:_emit()
+endfunction

--- a/autoload/vital/__vital__/Async/Later.vim
+++ b/autoload/vital/__vital__/Async/Later.vim
@@ -2,7 +2,7 @@ let s:tasks = []
 let s:workers = []
 let s:max_workers = 50
 
-function! s:call(fn, ...) abort dict
+function! s:call(fn, ...) abort
   call add(s:tasks, [a:fn, a:000])
   if empty(s:workers)
     call add(s:workers, timer_start(0, s:Worker, { 'repeat': -1 }))

--- a/autoload/vital/__vital__/Async/Later.vim
+++ b/autoload/vital/__vital__/Async/Later.vim
@@ -14,6 +14,9 @@ function! s:get_max_workers(n) abort
 endfunction
 
 function! s:set_max_workers(n) abort
+  if a:n <= 0
+    throw 'vital: Async.Later: the n must be a positive integer'
+  endif
   let s:max_workers = a:n
 endfunction
 

--- a/autoload/vital/__vital__/Async/Promise.vim
+++ b/autoload/vital/__vital__/Async/Promise.vim
@@ -24,7 +24,7 @@ function! s:noop(resolve, reject) abort
 endfunction
 " @vimlint(EVL103, 0, a:resolve)
 " @vimlint(EVL103, 0, a:reject)
-let s:NOOP = function('s:noop')
+let s:NOOP = funcref('s:noop')
 
 " Internal APIs
 
@@ -120,8 +120,8 @@ function! s:_handle_thenable(promise, thenable) abort
     call s:_subscribe(
          \   a:thenable,
          \   v:null,
-         \   function('s:_resolve', [a:promise]),
-         \   function('s:_reject', [a:promise]),
+         \   funcref('s:_resolve', [a:promise]),
+         \   funcref('s:_reject', [a:promise]),
          \ )
   endif
 endfunction
@@ -142,7 +142,7 @@ function! s:_fulfill(promise, value) abort
   let a:promise._result = a:value
   let a:promise._state = s:FULFILLED
   if !empty(a:promise._children)
-    call timer_start(0, function('s:_publish', [a:promise]))
+    call timer_start(0, funcref('s:_publish', [a:promise]))
   endif
 endfunction
 
@@ -152,7 +152,7 @@ function! s:_reject(promise, ...) abort
   endif
   let a:promise._result = a:0 > 0 ? a:1 : v:null
   let a:promise._state = s:REJECTED
-  call timer_start(0, function('s:_publish', [a:promise]))
+  call timer_start(0, funcref('s:_publish', [a:promise]))
 endfunction
 
 function! s:_notify_done(wg, index, value) abort
@@ -198,8 +198,8 @@ function! s:new(resolver) abort
   try
     if a:resolver != s:NOOP
       call a:resolver(
-      \   function('s:_resolve', [promise]),
-      \   function('s:_reject', [promise]),
+      \   funcref('s:_resolve', [promise]),
+      \   funcref('s:_reject', [promise]),
       \ )
     endif
   catch
@@ -212,11 +212,11 @@ function! s:new(resolver) abort
 endfunction
 
 function! s:all(promises) abort
-  return s:new(function('s:_all', [a:promises]))
+  return s:new(funcref('s:_all', [a:promises]))
 endfunction
 
 function! s:race(promises) abort
-  return s:new(function('s:_race', [a:promises]))
+  return s:new(funcref('s:_race', [a:promises]))
 endfunction
 
 function! s:resolve(...) abort
@@ -269,21 +269,21 @@ function! s:_promise_then(...) dict abort
   let l:Res = a:0 > 0 ? a:1 : v:null
   let l:Rej = a:0 > 1 ? a:2 : v:null
   if state == s:FULFILLED
-    call timer_start(0, function('s:_invoke_callback', [state, child, Res, parent._result]))
+    call timer_start(0, funcref('s:_invoke_callback', [state, child, Res, parent._result]))
   elseif state == s:REJECTED
-    call timer_start(0, function('s:_invoke_callback', [state, child, Rej, parent._result]))
+    call timer_start(0, funcref('s:_invoke_callback', [state, child, Rej, parent._result]))
   else
     call s:_subscribe(parent, child, Res, Rej)
   endif
   return child
 endfunction
-let s:PROMISE.then = function('s:_promise_then')
+let s:PROMISE.then = funcref('s:_promise_then')
 
 " .catch() is just a syntax sugar of .then()
 function! s:_promise_catch(...) dict abort
   return self.then(v:null, a:0 > 0 ? a:1 : v:null)
 endfunction
-let s:PROMISE.catch = function('s:_promise_catch')
+let s:PROMISE.catch = funcref('s:_promise_catch')
 
 function! s:_on_finally(CB, parent, Result) abort
   call a:CB()
@@ -300,15 +300,15 @@ function! s:_promise_finally(...) dict abort
   if a:0 == 0
     let l:CB = v:null
   else
-    let l:CB = function('s:_on_finally', [a:1, parent])
+    let l:CB = funcref('s:_on_finally', [a:1, parent])
   endif
   if state != s:PENDING
-    call timer_start(0, function('s:_invoke_callback', [state, child, CB, parent._result]))
+    call timer_start(0, funcref('s:_invoke_callback', [state, child, CB, parent._result]))
   else
     call s:_subscribe(parent, child, CB, CB)
   endif
   return child
 endfunction
-let s:PROMISE.finally = function('s:_promise_finally')
+let s:PROMISE.finally = funcref('s:_promise_finally')
 
 " vim:set et ts=2 sts=2 sw=2 tw=0:

--- a/doc/vital/Async/Later.txt
+++ b/doc/vital/Async/Later.txt
@@ -49,13 +49,14 @@ Vim and Neovim.
 =============================================================================
 FUNCTION 				*Vital.Async.Later-function*
 
-						*Vital.Async.Later.call()*
+				*Vital.Async.Later.call()*
 .call({task} [, {arglist} [, {dict}]])
 	Similar to |call()| but it calls {task} a bit later, when Vim is not
 	busy. For convenience, {arglist} can be omit.
 
 	When an exception is thrown in {task}, the exception is caught and
-	echomsg with |hl-ErrorMsg|.
+	echomsg with |hl-ErrorMsg| by a default error handler.
+	Use |Vital.Async.Later.set_error_handler()| to change this behavior.
 
 	Internally, it enqueues a {task} into an internal task queue. Tasks
 	in the queue will be dequeued and processed by internal workers. The
@@ -64,14 +65,29 @@ FUNCTION 				*Vital.Async.Later-function*
 	Once the queue become empty, the number of internal workers are
 	gradually decrease so that no workers exists at the end.
 
-					*Vital.Async.Later.get_max_workers()*
+				*Vital.Async.Later.get_max_workers()*
 .get_max_workers()
 	Return a maximum number of workers.
 	Default: 50
 
-					*Vital.Async.Later.set_max_workers()*
+				*Vital.Async.Later.set_max_workers()*
 .set_max_workers({n})
 	Set a maximum number of workers to {n}.
+
+				*Vital.Async.Later.get_error_handler()*
+.get_error_handler()
+	Return an error handler (|Funcref|).
+	Default: |Vital.Async.Later.default_error_handler()|
+					
+				*Vital.Async.Later.set_error_handler()*
+.set_error_handler({handler})
+	Set an error handler (|Funcref|) which is called when tasks throws
+	errors. Use |v:exception| and |v:throwpoint| in the {handler} to
+	access cought errors.
+
+				*Vital.Async.Later.default_error_handler()*
+.default_error_handler()
+	A default error handler which |echomsg| cought errors.
 
 
 ==============================================================================

--- a/doc/vital/Async/Later.txt
+++ b/doc/vital/Async/Later.txt
@@ -76,18 +76,15 @@ FUNCTION 				*Vital.Async.Later-function*
 
 				*Vital.Async.Later.get_error_handler()*
 .get_error_handler()
-	Return an error handler (|Funcref|).
-	Default: |Vital.Async.Later.default_error_handler()|
+	Return an error handler (|Funcref|) or |v:null| if no custom error
+	handler has specified.
+	Default: |v:null|
 					
 				*Vital.Async.Later.set_error_handler()*
 .set_error_handler({handler})
 	Set an error handler (|Funcref|) which is called when tasks throws
 	errors. Use |v:exception| and |v:throwpoint| in the {handler} to
-	access cought errors.
-
-				*Vital.Async.Later.default_error_handler()*
-.default_error_handler()
-	A default error handler which |echomsg| cought errors.
+	access cought errors. Set |v:null| to use a default error handler.
 
 
 ==============================================================================

--- a/doc/vital/Async/Later.txt
+++ b/doc/vital/Async/Later.txt
@@ -57,6 +57,9 @@ FUNCTION 				*Vital.Async.Later-function*
 	When an exception is thrown in {task}, the exception is caught and
 	echomsg with |hl-ErrorMsg| by a default error handler.
 	Use |Vital.Async.Later.set_error_handler()| to change this behavior.
+	Note that this error handler exists as a safety-net. Developers should
+	NOT rely on the behavior of the error handler and SHOULD catch errors
+	by themselves in each {task}.
 
 	Internally, it enqueues a {task} into an internal task queue. Tasks
 	in the queue will be dequeued and processed by internal workers. The

--- a/doc/vital/Async/Later.txt
+++ b/doc/vital/Async/Later.txt
@@ -8,6 +8,7 @@ CONTENTS				*Vital.Async.Later-contents*
 
 INTRODUCTION			|Vital.Async.Later-introduction|
 FUNCTION			|Vital.Async.Later-function|
+VARIABLE			|Vital.Async.Later-variable|
 
 
 ==============================================================================
@@ -56,13 +57,22 @@ FUNCTION 				*Vital.Async.Later-function*
 	When an exception is thrown in {task}, the exception is caught and
 	echomsg with |hl-ErrorMsg|.
 
-	Internally, it queues {task} in an internal task queue and start an
-	internal timer to execute a task. If the internal timer is already
-	started, it won't start a new timer. When the internal timer is
-	emitted, the timer calls a first task in the internal queue and
-	start a new internal timer again if there are more tasks.
+	Internally, it enqueues a {task} into an internal task queue. Tasks
+	in the queue will be dequeued and processed by internal workers. The
+	number of internal workers are gradually increase until all tasks in
+	the queue are completed or reached to the value of "max_workers".
+	Once the queue become empty, the number of internal workers are
+	gradually decrease so that no workers exists at the end.
+
+					*Vital.Async.Later.get_max_workers()*
+.get_max_workers()
+	Return a maximum number of workers.
+	Default: 50
+
+					*Vital.Async.Later.set_max_workers()*
+.set_max_workers({n})
+	Set a maximum number of workers to {n}.
 
 
 ==============================================================================
 vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl
-

--- a/doc/vital/Async/Later.txt
+++ b/doc/vital/Async/Later.txt
@@ -1,0 +1,68 @@
+*Vital/Async/Later.txt*		FIFO task queue for calling function later
+
+Maintainer : Alisue <lambdalisue@hashnote.net>
+
+
+==============================================================================
+CONTENTS				*Vital.Async.Later-contents*
+
+INTRODUCTION			|Vital.Async.Later-introduction|
+FUNCTION			|Vital.Async.Later-function|
+
+
+==============================================================================
+INTRODUCTION				*Vital.Async.Later-introduction*
+
+*Vital.Async.Later* provides a FIFO task queue. While Vim uses FILO way to
+execute a task registered by |timer_start()|, the following code become
+opposite in Vim and Neovim.
+>
+	let rs = []
+	call timer_start(0, { -> add(rs, 1) })
+	call timer_start(0, { -> add(rs, 2) })
+	call timer_start(0, { -> add(rs, 3) })
+	call timer_start(0, { -> timer_start(0, { -> add(rs, 4) }) })
+	call timer_start(0, { -> timer_start(0, { -> add(rs, 5) }) })
+	call timer_start(0, { -> timer_start(0, { -> add(rs, 6) }) })
+	" Vim:    [3, 2, 1, 4, 5, 6]
+	" Neovim: [1, 2, 3, 4, 5, 6]
+>
+To solve this difference, |Vital.Async.Later| uses an internal task queue
+to controls the order of the execution. The following code works both on
+Vim and Neovim.
+>
+	let s:Later = vital#vital#import('Async.Later')
+
+	let rs = []
+	call s:Later.call({ -> add(rs, 1) })
+	call s:Later.call({ -> add(rs, 2) })
+	call s:Later.call({ -> add(rs, 3) })
+	call s:Later.call({ -> s:Later.call({ -> add(rs, 4) }) })
+	call s:Later.call({ -> s:Later.call({ -> add(rs, 5) }) })
+	call s:Later.call({ -> s:Later.call({ -> add(rs, 6) }) })
+	" Vim:    [1, 2, 3, 4, 5, 6]
+	" Neovim: [1, 2, 3, 4, 5, 6]
+<
+
+
+=============================================================================
+FUNCTION 				*Vital.Async.Later-function*
+
+						*Vital.Async.Later.call()*
+.call({task} [, {arglist} [, {dict}]])
+	Similar to |call()| but it calls {task} a bit later, when Vim is not
+	busy. For convenience, {arglist} can be omit.
+
+	When an exception is thrown in {task}, the exception is caught and
+	echomsg with |hl-ErrorMsg|.
+
+	Internally, it queues {task} in an internal task queue and start an
+	internal timer to execute a task. If the internal timer is already
+	started, it won't start a new timer. When the internal timer is
+	emitted, the timer calls a first task in the internal queue and
+	start a new internal timer again if there are more tasks.
+
+
+==============================================================================
+vim:tw=78:fo=tcq2mM:ts=8:ft=help:norl
+

--- a/test/Async/Later.vimspec
+++ b/test/Async/Later.vimspec
@@ -1,6 +1,8 @@
 Describe Async.Later
-  Before
+  Before all
     let Later = vital#vital#import('Async.Later')
+    " NOTE: To start event-loop, call void function here
+    call Later.call({ -> 0 })
   End
 
   Describe .call()

--- a/test/Async/Later.vimspec
+++ b/test/Async/Later.vimspec
@@ -1,0 +1,75 @@
+Describe Async.Later
+  Before
+    let Later = vital#vital#import('Async.Later')
+  End
+
+  Describe .call()
+    It registers a task and call it a bit later
+      let rs = []
+      call Later.call({ -> add(rs, 1) })
+      Assert Equals(rs, [])
+      sleep 10m
+      Assert Equals(rs, [1])
+    End
+
+    It calls tasks in FIFO manner
+      let rs = []
+      call Later.call({ -> add(rs, 1) })
+      call Later.call({ -> add(rs, 2) })
+      call Later.call({ -> add(rs, 3) })
+      Assert Equals(rs, [])
+      sleep 10m
+      Assert Equals(rs, [1, 2, 3])
+    End
+
+    It calls tasks in FIFO manner (nest)
+      let rs = []
+      call Later.call({ -> add(rs, 1) })
+      call Later.call({ -> Later.call({ -> add(rs, 3) }) })
+      call Later.call({ -> Later.call({ -> Later.call({ -> add(rs, 5) }) }) })
+      call Later.call({ -> Later.call({ -> add(rs, 4) }) })
+      call Later.call({ -> add(rs, 2) })
+      Assert Equals(rs, [])
+      sleep 10m
+      Assert Equals(rs, [1, 2, 3, 4, 5])
+    End
+
+    It calls task in FIFO manner (block)
+      function! s:block(time) abort
+        let s = reltime()
+        while reltimefloat(reltime(s)) * 1000 < a:time
+        endwhile
+      endfunction
+
+      let rs = []
+      call Later.call({ -> [s:block(30), add(rs, 1)] })
+      call Later.call({ -> [s:block(10), add(rs, 2)] })
+      call Later.call({ -> [s:block(20), add(rs, 3)] })
+      call Later.call({ -> add(rs, 4) })
+      sleep 100m
+      Assert Equals(rs, [1, 2, 3, 4])
+    End
+
+    It echomsg an exception when a task throws an exception
+      function! s:throw(message) abort
+        throw a:message
+      endfunction
+
+      let exception = v:null
+      try
+        redir => messages
+        call Later.call({ -> s:throw('Hello World') })
+        sleep 10m
+      catch
+        let exception = v:exception
+      finally
+        redir END
+      endtry
+      Assert Equals(exception, v:null)
+      Assert Match(
+            \ messages,
+            \ '^\nHello World\nfunction .*<SNR>\d\+_throw, line 1',
+            \)
+    End
+  End
+End

--- a/test/Async/Later.vimspec
+++ b/test/Async/Later.vimspec
@@ -52,6 +52,25 @@ Describe Async.Later
       Assert Equals(rs, [1, 2, 3, 4])
     End
 
+    It calls tasks in FIFO manner (max_workers << tasks)
+      let default_max_workers = Later.get_max_workers()
+      call Later.set_max_workers(2)
+      sleep 100m
+
+      let rs = []
+      call map(
+            \ range(20),
+            \ { _, v -> Later.call({ -> add(rs, v) }) },
+            \)
+
+      Assert Equals(rs, [])
+      sleep 1000m
+      Assert Equals(rs, range(20))
+
+      call Later.set_max_workers(default_max_workers)
+      sleep 100m
+    End
+
     It echomsg an exception when a task throws an exception
       function! s:throw(message) abort
         throw a:message

--- a/test/Async/Later.vimspec
+++ b/test/Async/Later.vimspec
@@ -4,6 +4,10 @@ Describe Async.Later
   End
 
   Describe .call()
+    After
+      call Later.set_error_handler(v:null)
+    End
+
     It registers a task and call it a bit later
       let rs = []
       call Later.call({ -> add(rs, 1) })
@@ -106,7 +110,6 @@ Describe Async.Later
       call Later.call({ -> s:throw('Hello World') })
       sleep 10m
       Assert Equals(errors, ['Hello World'])
-      call Later.set_error_handler(Later.default_error_handler)
     End
   End
 End

--- a/test/Async/Later.vimspec
+++ b/test/Async/Later.vimspec
@@ -1,8 +1,6 @@
 Describe Async.Later
-  Before all
+  Before
     let Later = vital#vital#import('Async.Later')
-    " NOTE: To start event-loop, call void function here
-    call Later.call({ -> 0 })
   End
 
   Describe .call()

--- a/test/Async/Later.vimspec
+++ b/test/Async/Later.vimspec
@@ -92,5 +92,23 @@ Describe Async.Later
             \ '^\nHello World\nfunction .*<SNR>\d\+_throw, line 1',
             \)
     End
+
+    It uses assigned error handler
+      function! s:throw(message) abort
+        throw a:message
+      endfunction
+
+      let errors = []
+
+      function! s:error_handler() abort closure
+        call add(errors, v:exception)
+      endfunction
+
+      call Later.set_error_handler(funcref('s:error_handler'))
+      call Later.call({ -> s:throw('Hello World') })
+      sleep 10m
+      Assert Equals(errors, ['Hello World'])
+      call Later.set_error_handler(Later.default_error_handler)
+    End
   End
 End

--- a/test/Async/Later.vimspec
+++ b/test/Async/Later.vimspec
@@ -1,13 +1,15 @@
 Describe Async.Later
-  Before
+  Before all
     let Later = vital#vital#import('Async.Later')
+    let default_max_workers = Later.get_max_workers()
+  End
+
+  After
+    call Later.set_error_handler(v:null)
+    call Later.set_max_workers(default_max_workers)
   End
 
   Describe .call()
-    After
-      call Later.set_error_handler(v:null)
-    End
-
     It registers a task and call it a bit later
       let rs = []
       call Later.call({ -> add(rs, 1) })
@@ -55,7 +57,6 @@ Describe Async.Later
     End
 
     It calls tasks in FIFO manner (max_workers << tasks)
-      let default_max_workers = Later.get_max_workers()
       call Later.set_max_workers(2)
       sleep 100m
 
@@ -68,9 +69,6 @@ Describe Async.Later
       Assert Equals(rs, [])
       sleep 1000m
       Assert Equals(rs, range(20))
-
-      call Later.set_max_workers(default_max_workers)
-      sleep 100m
     End
 
     It echomsg an exception when a task throws an exception


### PR DESCRIPTION
I've relied on `Async.Promise` to make [fern.vim](https://github.com/lambdalisue/fern.vim) but the performance issue occurred in Windows.

https://github.com/lambdalisue/fern.vim/pull/57

This PR introduces an event loop and workers to execute tasks. Approx. 20x performance improvement has observed in above plugin.

# Regression tests

```vim
let s:Promise = vital#vital#import('Async.Promise')

function! s:tick() abort
  let promise = s:Promise.resolve(reltime())
  for i in range(1000)
    let promise = promise.then({ s -> s })
  endfor
  return promise.then({ s -> reltimestr(reltime(s)) })
endfunction

function! s:test() abort
  new
  let bufnr = bufnr('%')
  let promise = s:Promise.all([
        \ s:tick(),
        \ s:tick(),
        \ s:tick(),
        \ s:tick(),
        \ s:tick(),
        \ s:tick(),
        \ s:tick(),
        \ s:tick(),
        \ s:tick(),
        \ s:tick(),
        \])
  call promise.then({ vs -> setbufline(bufnr, 1, map(vs, { _, v -> v })) })
endfunction

call s:test()
```

## Summary

- Slight performance regressions has observed in Neovim on macOS (approx 1.1 -> 1.9)
- Slight performance improveoment has observed in Vim on macOS (approx 2.3 -> 1.7)
- Significant performance improveoment has observed in Vim on Windows (approx. 18.1 -> 3.9)

## Before
```
Neovim v0.4 macOS
1.357061
1.316463
1.264815
1.229064
1.192373
1.154427
1.119024
1.082092
1.041670
0.994399

Vim 8.1 macOS
2.510612
2.465745
2.425529
2.385125
2.342392
2.288333
2.246469
2.204589
2.163871
2.123382

Vim 8.2 Windows
18.334129
18.291351
18.250988
18.196796
18.157503
18.116416
18.075665
18.031709
17.991818
17.951131
```

## After

```
Neovim v0.4 macOS
2.130478
2.092259
2.058482
2.023667
1.990111
1.939237
1.903443
1.868484
1.835093
1.795646

Vim 8.1 macOS
1.939646
1.891795
1.850817
1.809631
1.768790
1.729066
1.687586
1.643133
1.596527
1.554153

Vim 8.2 Windows
4.146574
4.101837
4.060613
4.021967
3.984135
3.946313
3.909356
3.862812
3.818288
3.776003
```

