### PR TITLE
Add Promise.on_unhandled_rejection

### DIFF
--- a/autoload/vital/__vital__/Async/Promise.vim
+++ b/autoload/vital/__vital__/Async/Promise.vim
@@ -90,6 +90,9 @@ function! s:_publish(promise, ...) abort
   endif
 
   if empty(a:promise._children)
+    if settled == s:REJECTED
+      call s:_on_unhandled_rejection(a:promise._result)
+    endif
     return
   endif
 
@@ -268,6 +271,11 @@ function! s:wait(promise, ...) abort
   else
     return [v:null, a:promise._result]
   endif
+endfunction
+
+let s:_on_unhandled_rejection = s:NOOP
+function! s:on_unhandled_rejection(on_unhandled_rejection) abort
+  let s:_on_unhandled_rejection = a:on_unhandled_rejection
 endfunction
 
 function! s:_promise_then(...) dict abort

--- a/doc/vital/Async/Promise.txt
+++ b/doc/vital/Async/Promise.txt
@@ -377,6 +377,13 @@ wait({promise}[, {options}])		*Vital.Async.Promise.wait()*
 	call Promise.wait(p, 1000)
 	" Is equivalent to call Promise.wait(p, {'timeout': 1000})
 >
+on_unhandled_rejection({callback})	*Vital.Async.Promise.on_unhandled_rejection*
+
+ 	Set callback to catch all unhandled rejected promise's result.
+
+	Note:
+	This callback will called even if you using |Vital.Async.Promise.wait()|.
+
 
 is_promise({value})			*Vital.Async.Promise.is_promise()*
 

--- a/doc/vital/Async/Promise.txt
+++ b/doc/vital/Async/Promise.txt
@@ -380,6 +380,7 @@ wait({promise}[, {options}])		*Vital.Async.Promise.wait()*
 on_unhandled_rejection({callback})	*Vital.Async.Promise.on_unhandled_rejection*
 
  	Set callback to catch all unhandled rejected promise's result.
+	If {callback} throws error, |Async.Promise| does not handle it.
 
 	The {callback} is |Funcref|, it's argument can be unhandled thrown error or unhandled rejected value.
 

--- a/doc/vital/Async/Promise.txt
+++ b/doc/vital/Async/Promise.txt
@@ -381,9 +381,15 @@ on_unhandled_rejection({callback})	*Vital.Async.Promise.on_unhandled_rejection*
 
  	Set callback to catch all unhandled rejected promise's result.
 
+	The {callback} is |Funcref|, it's argument can be unhandled thrown error or unhandled rejected value.
+
 	Note:
 	This callback will called even if you using |Vital.Async.Promise.wait()|.
+	If you want to clear callback, you can use following codes.
 
+>
+	call Promise.on_unhandled_rejection(Promise.noop)
+<
 
 is_promise({value})			*Vital.Async.Promise.is_promise()*
 

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -804,6 +804,56 @@ Describe Async.Promise
       endif
     End
   End
+
+  Describe .on_unhandled_rejection
+    It should call when promsie does not catch
+      let l = l:
+      call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
+
+      let p = P.resolve().then({ -> execute('throw "error"') })
+      call s:wait_has_key(l, 'result')
+      Assert HasKey(result, 'exception')
+      Assert HasKey(result, 'throwpoint')
+    End
+
+    It should call when promise does not catch with finally
+      let l = l:
+      call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
+
+      let p = P.resolve().then({ -> execute('throw "error"') }).finally({ -> {} })
+      call s:wait_has_key(l, 'result')
+      Assert HasKey(result, 'exception')
+      Assert HasKey(result, 'throwpoint')
+    End
+
+    It should call when promise does not catch with children
+      let l = l:
+      call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
+
+      let p = P.resolve().then({ -> execute('throw "error"') }).then({ -> {} })
+      call s:wait_has_key(l, 'result')
+      Assert HasKey(result, 'exception')
+      Assert HasKey(result, 'throwpoint')
+    End
+
+    It should call when promise does not catch with wait
+      let l = l:
+      call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
+
+      let p = P.resolve().then({ -> execute('throw "error"') }).then({ -> {} })
+      let [_, error] = P.wait(p)
+      Assert Equals(error, result)
+    End
+
+    It should not call when promise catched
+      let l = l:
+      call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
+
+      let p = P.resolve().then({ -> execute('throw "error"') }).catch({ -> {} })
+      call P.wait(Wait(100))
+      Assert KeyNotExists(l, 'result')
+    End
+  End
 End
 
 " vim:et ts=2 sts=2 sw=2 tw=0:

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -864,6 +864,15 @@ Describe Async.Promise
       let l = l:
       call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
 
+      let p = P.reject({ 'error': 'error' }).catch({ -> {} })
+      call P.wait(Wait(100))
+      Assert KeyNotExists(l, 'result')
+    End
+
+    It should not call when promise catched
+      let l = l:
+      call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
+
       let p = P.resolve().then({ -> execute('throw "error"') }).catch({ -> {} })
       call P.wait(Wait(100))
       Assert KeyNotExists(l, 'result')

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -806,7 +806,12 @@ Describe Async.Promise
   End
 
   Describe .on_unhandled_rejection
-    It should call when promsie does not catch
+
+    After each
+      call P.on_unhandled_rejection(P.noop)
+    End
+
+    It should call when promise throw error but unhandled
       let l = l:
       call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
 
@@ -814,6 +819,16 @@ Describe Async.Promise
       call s:wait_has_key(l, 'result')
       Assert HasKey(result, 'exception')
       Assert HasKey(result, 'throwpoint')
+    End
+
+    It should call when promise rejected but unhandled
+      let l = l:
+      call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
+
+      let p = P.reject({ 'error': 'error' })
+      call s:wait_has_key(l, 'result')
+      Assert HasKey(result, 'error')
+      Assert Equals(result.error, 'error')
     End
 
     It should call when promise does not catch with finally
@@ -850,6 +865,15 @@ Describe Async.Promise
       call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
 
       let p = P.resolve().then({ -> execute('throw "error"') }).catch({ -> {} })
+      call P.wait(Wait(100))
+      Assert KeyNotExists(l, 'result')
+    End
+
+    It should not call when promise does not throw error
+      let l = l:
+      call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
+
+      let p = P.resolve().then({ -> { 'success': 'success' } })
       call P.wait(Wait(100))
       Assert KeyNotExists(l, 'result')
     End

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -860,7 +860,7 @@ Describe Async.Promise
       Assert Equals(error, result)
     End
 
-    It should not call when promise catched
+    It should not call when catched rejected promise
       let l = l:
       call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
 
@@ -869,7 +869,7 @@ Describe Async.Promise
       Assert KeyNotExists(l, 'result')
     End
 
-    It should not call when promise catched
+    It should not call when catched thrown error
       let l = l:
       call P.on_unhandled_rejection({ result -> extend(l, { 'result': result }) })
 


### PR DESCRIPTION
This PR aims to able to catch all unhandled rejection on Async.Promise.

It will be useful for logging plugin's errors, I think.
