### PR TITLE
vitalizer: Liberate from 'redir'

### DIFF
--- a/test/Interpreter/Brainf__k.vimspec
+++ b/test/Interpreter/Brainf__k.vimspec
@@ -7,9 +7,8 @@ Describe Interpreter.Brainf__k
 
   Describe .run_vim_parse_execute()
     It shows hello world
-      redir => output
-        silent call BF.run_vim_parse_execute("++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.")
-      redir END
+      let script = '++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.'
+      let output = execute(printf('call BF.run_vim_parse_execute("%s")', script))
       Assert Equals(output, "Hello World!\n")
     End
   End


### PR DESCRIPTION
'redir' cannnot be nested and cannot be used in execute() function.

The main reason why vital.vim used 'redir' has solved on Vim 8.0.1425 and vital.vim
now supports Vim 8.1 or later thus we can use execute() instead.

Fix #724 