### PR TITLE
fix: Vitalizer non-module files do not process need at s:autoloadablize

### DIFF
--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -488,9 +488,13 @@ function! vitalizer#vitalize(name, to, modules, hash) abort
       " Install modules.
       for [from, to] in s:install_module_files(module_files, vital_data.name, a:to)
         call s:copy(from, to)
-        let module_name = s:file2module_name(to)
-        if !empty(module_name) && has_key(all_modules, module_name)
-          call s:autoloadablize(to, vital_data.name, all_modules[module_name])
+        " .vim is module file/otherwise data file
+        " module file need autoloadablize process
+        if -1 !=? match(to, '\.vim$')
+          let module_name = s:file2module_name(to)
+          if has_key(all_modules, module_name)
+            call s:autoloadablize(to, vital_data.name, all_modules[module_name])
+          endif
         endif
       endfor
       let content = [vital_data.name, hash, ''] + installing_modules

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -488,8 +488,10 @@ function! vitalizer#vitalize(name, to, modules, hash) abort
       " Install modules.
       for [from, to] in s:install_module_files(module_files, vital_data.name, a:to)
         call s:copy(from, to)
-        let raw_module = all_modules[s:file2module_name(to)]
-        call s:autoloadablize(to, vital_data.name, raw_module)
+        let module_name = s:file2module_name(to)
+        if !empty(module_name) && has_key(all_modules, module_name)
+          call s:autoloadablize(to, vital_data.name, all_modules[module_name])
+        endif
       endfor
       let content = [vital_data.name, hash, ''] + installing_modules
       call writefile(content, vital_data.vital_file)

--- a/autoload/vitalizer.vim
+++ b/autoload/vitalizer.vim
@@ -490,7 +490,7 @@ function! vitalizer#vitalize(name, to, modules, hash) abort
         call s:copy(from, to)
         " .vim is module file/otherwise data file
         " module file need autoloadablize process
-        if -1 !=? match(to, '\.vim$')
+        if fnamemodify(to, ':e') ==# 'vim'
           let module_name = s:file2module_name(to)
           if has_key(all_modules, module_name)
             call s:autoloadablize(to, vital_data.name, all_modules[module_name])

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -14,9 +14,11 @@ let g:testplugin_name = 'testplugin'
 let g:testplugin_root = g:root . '/test/_testdata/vital/' . g:testplugin_name . '/'
 let g:cyclic_module_root = g:root . '/test/_testdata/vital/cyclic/'
 let g:symlinkplugin_root = g:root . '/test/_testdata/vital/symlink_root/symlink/'
+let g:datafile_module_root = g:root . '/test/_testdata/vital/datatest/'
 call themis#option('runtimepath', g:testplugin_root)
 call themis#option('runtimepath', g:cyclic_module_root)
 call themis#option('runtimepath', g:symlinkplugin_root)
+call themis#option('runtimepath', g:datafile_module_root)
 
 if $THEMIS_PROFILE !=# ''
   execute 'profile' 'start' $THEMIS_PROFILE

--- a/test/_testdata/vital/datatest/autoload/vital/__latest__/DataTest.txt
+++ b/test/_testdata/vital/datatest/autoload/vital/__latest__/DataTest.txt
@@ -1,0 +1,1 @@
+Test Data

--- a/test/_testdata/vital/datatest/autoload/vital/__latest__/DataTest.vim
+++ b/test/_testdata/vital/datatest/autoload/vital/__latest__/DataTest.vim
@@ -1,0 +1,12 @@
+function! s:_vital_loaded(V) abort
+  let s:V = a:V
+endfunction
+
+function! s:_vital_depends() abort
+  return {'modules':[], 'files':['DataTest.txt']}
+endfunction
+
+function! s:dummy() abort
+  return 0
+endfunction
+

--- a/test/vital.vimspec
+++ b/test/vital.vimspec
@@ -6,7 +6,7 @@ Describe vital
     let Filepath = Vital.import('System.Filepath')
     let Prelude = Vital.import('Prelude')
 
-    let vitalize_modules  = ['Data.List', 'Data.LazyList', 'Data.String', 'Web.JSON', 'Cyclic1']
+    let vitalize_modules  = ['Data.List', 'Data.LazyList', 'Data.String', 'Web.JSON', 'Cyclic1', 'DataTest']
     call vitalizer#vitalize(g:testplugin_name, g:testplugin_root, vitalize_modules, '')
   End
 
@@ -177,6 +177,7 @@ Describe vital
         Assert NotEmpty(vital#vital#import('Data.List'))
         Assert NotEmpty(vital#vital#import('Selfmodule'))
         Assert NotEmpty(vital#vital#import('Cyclic1'))
+        Assert NotEmpty(vital#vital#import('DataTest'))
       End
     End
 
@@ -238,6 +239,10 @@ Describe vital
         Assert True(V.import('Cyclic1').return1())
       End
 
+      It supports datafile dependencies
+        Assert True(1 == len(readfile(Filepath.join(g:testplugin_root, 'autoload/vital/' . '_' . g:testplugin_name . '/DataTest.txt'))))
+      End
+
       Context wildignore handling
         Before all
           set wildignore+=*.vim
@@ -274,6 +279,7 @@ Describe vital
           Assert NotEmpty(V.import('Data.List'))
           Assert NotEmpty(V.import('Selfmodule'))
           Assert NotEmpty(V.import('Cyclic1'))
+          Assert NotEmpty(V.import('DataTest'))
         End
       End
     End
@@ -311,6 +317,10 @@ Describe vital
         let V = vital#{g:testplugin_name}#new()
         Assert Equals(V.load('Cyclic1'), V)
         Assert True(V.Cyclic1.return1())
+      End
+
+      It supports datafile dependencies
+        Assert True(1 == len(readfile(Filepath.join(g:testplugin_root, 'autoload/vital/' . '_' . g:testplugin_name . '/DataTest.txt'))))
       End
 
       Context wildignore handling


### PR DESCRIPTION
vitalのdependsの仕様として、データファイルを入れれますが、それを無条件でmoduleとしての処理に流していました。

モジュール名生成でミスした場合(=モジュールでないもの)はautoloadable処理をスキップするようにして対処しました。