### PR TITLE
Fix throws error on on_unhandled_rejection

### DIFF
--- a/autoload/vital/__vital__/Async/Promise.vim
+++ b/autoload/vital/__vital__/Async/Promise.vim
@@ -26,12 +26,8 @@ function! s:_vital_depends() abort
   return ['Async.Later']
 endfunction
 
-" @vimlint(EVL103, 1, a:resolve)
-" @vimlint(EVL103, 1, a:reject)
-function! s:noop(resolve, reject) abort
+function! s:noop(...) abort
 endfunction
-" @vimlint(EVL103, 0, a:resolve)
-" @vimlint(EVL103, 0, a:reject)
 let s:NOOP = funcref('s:noop')
 
 " Internal APIs


### PR DESCRIPTION
Fixes #733

@tsuyoshicho 見つけてくださってありがとうございます。

手元でも下記のコードでエラーが発生するのが再現できました。

```viml
let Promise = vital#plugin_name#import('Async.Promise')
call Promise.on_unhandled_rejection(Promise.noop)
call Promise.new({ resolve -> execute('throw "error"') })
```

修正方法としては、noop は可変長引数を受け付けるものとし、引数の個数は無視することとしました。

テストケースに関しては、timer 中に発生してキャッチできていない例外に関してのテストは書けないのではないだろうか...？と考えています。
なにかテスト記述するいい方法がある場合はご指摘いただければ PR を更新いたします。