### PR TITLE
Web.HTTP: Fix endmarker

### DIFF
--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -301,7 +301,7 @@ function! s:clients.python.request(settings) abort
 
   " TODO: retry, outputFile
   let responses = []
-  python << endpython
+  python << ENDPYTHON
 try:
     class DummyClassForLocalScope:
         def main():
@@ -394,7 +394,7 @@ except RuntimeError as exception:
     if exception.args != ("Exit from local scope",):
         raise exception
 
-endpython
+ENDPYTHON
   return responses
 endfunction
 


### PR DESCRIPTION
`{endmarker}` cannot start with a lower case character.