### PR TITLE
fix: http python3 fliter not list

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 97e8cf8b230cd69720e130742859b51f5761196c
 	Modules: Web.HTTP
-	Added python3 to HTTP client, and refine its default value.
+	Added python3 to HTTP client, and refined its default value.
 	Now 'python' client selects python3 or python2 automatically (python3 has a higher priority).
 b2dd494bd56486ef898fdb49467e5763e81cde71
 	Modules: Text.TOML

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+97e8cf8b230cd69720e130742859b51f5761196c
+	Modules: Web.HTTP
+	HTTP client add python3, and refine default value.
+	Client 'python' are auto-selecting to python3 or python2 (python3 are high-priority).
 b2dd494bd56486ef898fdb49467e5763e81cde71
 	Modules: Text.TOML
 	TOML support version v0.4.0 compliant -> v0.5.0 compliant

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 97e8cf8b230cd69720e130742859b51f5761196c
 	Modules: Web.HTTP
-	HTTP client add python3, and refine default value.
-	Client 'python' are auto-selecting to python3 or python2 (python3 are high-priority).
+	Added python3 to HTTP client, and refine its default value.
+	Now 'python' client selects python3 or python2 automatically (python3 has a higher priority).
 b2dd494bd56486ef898fdb49467e5763e81cde71
 	Modules: Text.TOML
 	TOML support version v0.4.0 compliant -> v0.5.0 compliant

--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -597,7 +597,7 @@ try:
                         return None
                     if 0 < self.max_redirect:
                         self.max_redirect -= 1
-                    header_list = filter(None, str(headers).split("\r\n"))
+                    header_list = list(filter(None, str(headers).split("\r\n")))
                     responses.extend([[[status(code, msg)] + header_list, fp.read()]])
                     return urllib.request.HTTPRedirectHandler.redirect_request(self, req, fp, code, msg, headers, newurl)
 


### PR DESCRIPTION
Fix python3 filter gen list.

and changes modify.

---

#703 のマージした状態で、他プラグイン( https://github.com/y0za/vim-reading-vimrc )にPRを作成しようとして気付きました。
変更の考慮が不足していたようです。

Python3では2とは違い、filterがlistを返さないので、問題がありました。[1](https://it-engineer-lab.com/archives/124)

この修正と、あわせてChangesを準備しています。

以下のテスト確認していましたが、www.google.com だと問題なかったようで...
上記プラグインが使うvimrc readingのjsonで発生、修正もそれで確認しました。

```vim
let HTTP = g:V.import('Web.HTTP')

" let url = 'https://www.google.com'
let url = 'http://vim-jp.org/reading-vimrc/json/next.json'
let res = HTTP.request('GET', url, {
          \ 'client'      : ['python'],
          \})
echo res
```

vital.vim の HEAD で通信NGとなってしまうので、お手数ですが早めの確認をおねがいしたいです。