### PR TITLE
Suggestion: separation of python code for Web.HTTP

### DIFF
--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -1,6 +1,8 @@
 let s:save_cpo = &cpo
 set cpo&vim
 
+let s:py2source = expand('<sfile>:h') . '/HTTP_python2.py'
+let s:py3source = expand('<sfile>:h') . '/HTTP_python3.py'
 
 function! s:_vital_loaded(V) abort
   let s:V = a:V
@@ -10,7 +12,10 @@ function! s:_vital_loaded(V) abort
 endfunction
 
 function! s:_vital_depends() abort
-  return ['Prelude', 'Data.String', 'Process']
+   return {
+    \ 'modules':['Prelude', 'Data.String', 'Process'] ,
+    \ 'files':  ['HTTP_python2.py', 'HTTP_python3.py'],
+    \}
 endfunction
 
 function! s:__urlencode_char(c) abort
@@ -576,100 +581,7 @@ function! s:clients.python3.request(settings) abort
 
   " TODO: retry, outputFile
   let responses = []
-  python3 << ENDPYTHON3
-try:
-    class DummyClassForLocalScope:
-        def main():
-            try:
-                from StringIO import StringIO
-            except ImportError:
-                from io import StringIO
-            import vim, urllib.request, urllib.error, socket, gzip
-
-            responses = vim.bindeval('responses')
-
-            class CustomHTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
-                def __init__(self, max_redirect):
-                    self.max_redirect = max_redirect
-
-                def redirect_request(self, req, fp, code, msg, headers, newurl):
-                    if self.max_redirect == 0:
-                        return None
-                    if 0 < self.max_redirect:
-                        self.max_redirect -= 1
-                    header_list = list(filter(None, str(headers).split("\r\n")))
-                    responses.extend([[[status(code, msg)] + header_list, fp.read()]])
-                    return urllib.request.HTTPRedirectHandler.redirect_request(self, req, fp, code, msg, headers, newurl)
-
-            def vimlist2str(list):
-                if not list:
-                    return None
-                return "\n".join([s.replace("\n", "\0") for s in list])
-
-            def status(code, msg):
-                return "HTTP/1.0 %d %s\r\n" % (code, msg)
-
-            def access():
-                settings = vim.eval('a:settings')
-                data = vimlist2str(settings.get('data'))
-                timeout = settings.get('timeout')
-                if timeout:
-                    timeout = float(timeout)
-                request_headers = settings.get('headers')
-                max_redirect = int(settings.get('maxRedirect'))
-                director = urllib.request.build_opener(CustomHTTPRedirectHandler(max_redirect))
-                if 'username' in settings:
-                    passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-                    passman.add_password(
-                        None,
-                        settings['url'],
-                        settings['username'],
-                        settings.get('password', ''))
-                    basicauth = urllib.request.HTTPBasicAuthHandler(passman)
-                    digestauth = urllib.request.HTTPDigestAuthHandler(passman)
-                    director.add_handler(basicauth)
-                    director.add_handler(digestauth)
-                if 'bearerToken' in settings:
-                    request_headers.setdefault('Authorization', 'Bearer ' + settings['bearerToken'])
-                req = urllib.request.Request(settings['url'], data, request_headers)
-                req.get_method = lambda: settings['method']
-                default_timeout = socket.getdefaulttimeout()
-                try:
-                    # for Python 2.5 or before <- Is this needed?
-                    socket.setdefaulttimeout(timeout)
-                    res = director.open(req, timeout=timeout)
-                except urllib.error.HTTPError as res:
-                    pass
-                except urllib.error.URLError:
-                    return ('', '')
-                except socket.timeout:
-                    return ('', '')
-                finally:
-                    socket.setdefaulttimeout(default_timeout)
-
-                st = status(res.code, res.msg)
-                response_headers = st + ''.join(res.headers)
-                response_body = res.read()
-
-                gzip_decompress = settings.get('gzipDecompress', False)
-                if gzip_decompress:
-                    buf = StringIO(response_body)
-                    f = gzip.GzipFile(fileobj=buf)
-                    response_body = f.read()[:-1]
-
-                return (response_headers, response_body)
-
-            (header, body) = access()
-            responses.extend([[header.split("\r\n"), body]])
-
-        main()
-        raise RuntimeError("Exit from local scope")
-
-except RuntimeError as exception:
-    if exception.args != ("Exit from local scope",):
-        raise exception
-
-ENDPYTHON3
+  py3file s:py3source
   return responses
 endfunction
 
@@ -700,100 +612,7 @@ function! s:clients.python2.request(settings) abort
 
   " TODO: retry, outputFile
   let responses = []
-  python << ENDPYTHON
-try:
-    class DummyClassForLocalScope:
-        def main():
-            try:
-                from StringIO import StringIO
-            except ImportError:
-                from io import StringIO
-            import vim, urllib2, socket, gzip
-
-            responses = vim.bindeval('responses')
-
-            class CustomHTTPRedirectHandler(urllib2.HTTPRedirectHandler):
-                def __init__(self, max_redirect):
-                    self.max_redirect = max_redirect
-
-                def redirect_request(self, req, fp, code, msg, headers, newurl):
-                    if self.max_redirect == 0:
-                        return None
-                    if 0 < self.max_redirect:
-                        self.max_redirect -= 1
-                    header_list = filter(None, str(headers).split("\r\n"))
-                    responses.extend([[[status(code, msg)] + header_list, fp.read()]])
-                    return urllib2.HTTPRedirectHandler.redirect_request(self, req, fp, code, msg, headers, newurl)
-
-            def vimlist2str(list):
-                if not list:
-                    return None
-                return "\n".join([s.replace("\n", "\0") for s in list])
-
-            def status(code, msg):
-                return "HTTP/1.0 %d %s\r\n" % (code, msg)
-
-            def access():
-                settings = vim.eval('a:settings')
-                data = vimlist2str(settings.get('data'))
-                timeout = settings.get('timeout')
-                if timeout:
-                    timeout = float(timeout)
-                request_headers = settings.get('headers')
-                max_redirect = int(settings.get('maxRedirect'))
-                director = urllib2.build_opener(CustomHTTPRedirectHandler(max_redirect))
-                if settings.has_key('username'):
-                    passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
-                    passman.add_password(
-                        None,
-                        settings['url'],
-                        settings['username'],
-                        settings.get('password', ''))
-                    basicauth = urllib2.HTTPBasicAuthHandler(passman)
-                    digestauth = urllib2.HTTPDigestAuthHandler(passman)
-                    director.add_handler(basicauth)
-                    director.add_handler(digestauth)
-                if settings.has_key('bearerToken'):
-                    request_headers.setdefault('Authorization', 'Bearer ' + settings['bearerToken'])
-                req = urllib2.Request(settings['url'], data, request_headers)
-                req.get_method = lambda: settings['method']
-                default_timeout = socket.getdefaulttimeout()
-                try:
-                    # for Python 2.5 or before
-                    socket.setdefaulttimeout(timeout)
-                    res = director.open(req, timeout=timeout)
-                except urllib2.HTTPError as res:
-                    pass
-                except urllib2.URLError:
-                    return ('', '')
-                except socket.timeout:
-                    return ('', '')
-                finally:
-                    socket.setdefaulttimeout(default_timeout)
-
-                st = status(res.code, res.msg)
-                response_headers = st + ''.join(res.info().headers)
-                response_body = res.read()
-
-                gzip_decompress = settings.get('gzipDecompress', False)
-                if gzip_decompress:
-                    buf = StringIO(response_body)
-                    f = gzip.GzipFile(fileobj=buf)
-                    response_body = f.read()[:-1]
-
-                return (response_headers, response_body)
-
-            (header, body) = access()
-            responses.extend([[header.split("\r\n"), body]])
-
-        main()
-        raise RuntimeError("Exit from local scope")
-
-except RuntimeError as exception:
-    if exception.args != ("Exit from local scope",):
-        raise exception
-
-ENDPYTHON
+  pyfile s:py2source
   return responses
 endfunction
 

--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -581,7 +581,7 @@ function! s:clients.python3.request(settings) abort
 
   " TODO: retry, outputFile
   let responses = []
-  py3file s:py3source
+  execute 'py3file' s:py3source
   return responses
 endfunction
 
@@ -612,7 +612,7 @@ function! s:clients.python2.request(settings) abort
 
   " TODO: retry, outputFile
   let responses = []
-  pyfile s:py2source
+  execute 'pyfile' s:py2source
   return responses
 endfunction
 

--- a/autoload/vital/__vital__/Web/HTTP_python2.py
+++ b/autoload/vital/__vital__/Web/HTTP_python2.py
@@ -1,0 +1,91 @@
+try:
+    class DummyClassForLocalScope:
+        def main():
+            try:
+                from StringIO import StringIO
+            except ImportError:
+                from io import StringIO
+            import vim, urllib2, socket, gzip
+
+            responses = vim.bindeval('responses')
+
+            class CustomHTTPRedirectHandler(urllib2.HTTPRedirectHandler):
+                def __init__(self, max_redirect):
+                    self.max_redirect = max_redirect
+
+                def redirect_request(self, req, fp, code, msg, headers, newurl):
+                    if self.max_redirect == 0:
+                        return None
+                    if 0 < self.max_redirect:
+                        self.max_redirect -= 1
+                    header_list = filter(None, str(headers).split("\r\n"))
+                    responses.extend([[[status(code, msg)] + header_list, fp.read()]])
+                    return urllib2.HTTPRedirectHandler.redirect_request(self, req, fp, code, msg, headers, newurl)
+
+            def vimlist2str(list):
+                if not list:
+                    return None
+                return "\n".join([s.replace("\n", "\0") for s in list])
+
+            def status(code, msg):
+                return "HTTP/1.0 %d %s\r\n" % (code, msg)
+
+            def access():
+                settings = vim.eval('a:settings')
+                data = vimlist2str(settings.get('data'))
+                timeout = settings.get('timeout')
+                if timeout:
+                    timeout = float(timeout)
+                request_headers = settings.get('headers')
+                max_redirect = int(settings.get('maxRedirect'))
+                director = urllib2.build_opener(CustomHTTPRedirectHandler(max_redirect))
+                if settings.has_key('username'):
+                    passman = urllib2.HTTPPasswordMgrWithDefaultRealm()
+                    passman.add_password(
+                        None,
+                        settings['url'],
+                        settings['username'],
+                        settings.get('password', ''))
+                    basicauth = urllib2.HTTPBasicAuthHandler(passman)
+                    digestauth = urllib2.HTTPDigestAuthHandler(passman)
+                    director.add_handler(basicauth)
+                    director.add_handler(digestauth)
+                if settings.has_key('bearerToken'):
+                    request_headers.setdefault('Authorization', 'Bearer ' + settings['bearerToken'])
+                req = urllib2.Request(settings['url'], data, request_headers)
+                req.get_method = lambda: settings['method']
+                default_timeout = socket.getdefaulttimeout()
+                try:
+                    # for Python 2.5 or before
+                    socket.setdefaulttimeout(timeout)
+                    res = director.open(req, timeout=timeout)
+                except urllib2.HTTPError as res:
+                    pass
+                except urllib2.URLError:
+                    return ('', '')
+                except socket.timeout:
+                    return ('', '')
+                finally:
+                    socket.setdefaulttimeout(default_timeout)
+
+                st = status(res.code, res.msg)
+                response_headers = st + ''.join(res.info().headers)
+                response_body = res.read()
+
+                gzip_decompress = settings.get('gzipDecompress', False)
+                if gzip_decompress:
+                    buf = StringIO(response_body)
+                    f = gzip.GzipFile(fileobj=buf)
+                    response_body = f.read()[:-1]
+
+                return (response_headers, response_body)
+
+            (header, body) = access()
+            responses.extend([[header.split("\r\n"), body]])
+
+        main()
+        raise RuntimeError("Exit from local scope")
+
+except RuntimeError as exception:
+    if exception.args != ("Exit from local scope",):
+        raise exception

--- a/autoload/vital/__vital__/Web/HTTP_python3.py
+++ b/autoload/vital/__vital__/Web/HTTP_python3.py
@@ -1,0 +1,91 @@
+try:
+    class DummyClassForLocalScope:
+        def main():
+            try:
+                from StringIO import StringIO
+            except ImportError:
+                from io import StringIO
+            import vim, urllib.request, urllib.error, socket, gzip
+
+            responses = vim.bindeval('responses')
+
+            class CustomHTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
+                def __init__(self, max_redirect):
+                    self.max_redirect = max_redirect
+
+                def redirect_request(self, req, fp, code, msg, headers, newurl):
+                    if self.max_redirect == 0:
+                        return None
+                    if 0 < self.max_redirect:
+                        self.max_redirect -= 1
+                    header_list = list(filter(None, str(headers).split("\r\n")))
+                    responses.extend([[[status(code, msg)] + header_list, fp.read()]])
+                    return urllib.request.HTTPRedirectHandler.redirect_request(self, req, fp, code, msg, headers, newurl)
+
+            def vimlist2str(list):
+                if not list:
+                    return None
+                return "\n".join([s.replace("\n", "\0") for s in list])
+
+            def status(code, msg):
+                return "HTTP/1.0 %d %s\r\n" % (code, msg)
+
+            def access():
+                settings = vim.eval('a:settings')
+                data = vimlist2str(settings.get('data'))
+                timeout = settings.get('timeout')
+                if timeout:
+                    timeout = float(timeout)
+                request_headers = settings.get('headers')
+                max_redirect = int(settings.get('maxRedirect'))
+                director = urllib.request.build_opener(CustomHTTPRedirectHandler(max_redirect))
+                if 'username' in settings:
+                    passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+                    passman.add_password(
+                        None,
+                        settings['url'],
+                        settings['username'],
+                        settings.get('password', ''))
+                    basicauth = urllib.request.HTTPBasicAuthHandler(passman)
+                    digestauth = urllib.request.HTTPDigestAuthHandler(passman)
+                    director.add_handler(basicauth)
+                    director.add_handler(digestauth)
+                if 'bearerToken' in settings:
+                    request_headers.setdefault('Authorization', 'Bearer ' + settings['bearerToken'])
+                req = urllib.request.Request(settings['url'], data, request_headers)
+                req.get_method = lambda: settings['method']
+                default_timeout = socket.getdefaulttimeout()
+                try:
+                    # for Python 2.5 or before <- Is this needed?
+                    socket.setdefaulttimeout(timeout)
+                    res = director.open(req, timeout=timeout)
+                except urllib.error.HTTPError as res:
+                    pass
+                except urllib.error.URLError:
+                    return ('', '')
+                except socket.timeout:
+                    return ('', '')
+                finally:
+                    socket.setdefaulttimeout(default_timeout)
+
+                st = status(res.code, res.msg)
+                response_headers = st + ''.join(res.headers)
+                response_body = res.read()
+
+                gzip_decompress = settings.get('gzipDecompress', False)
+                if gzip_decompress:
+                    buf = StringIO(response_body)
+                    f = gzip.GzipFile(fileobj=buf)
+                    response_body = f.read()[:-1]
+
+                return (response_headers, response_body)
+
+            (header, body) = access()
+            responses.extend([[header.split("\r\n"), body]])
+
+        main()
+        raise RuntimeError("Exit from local scope")
+
+except RuntimeError as exception:
+    if exception.args != ("Exit from local scope",):
+        raise exception


### PR DESCRIPTION
#730 で付属ファイルが安定して扱えるようになったので、Web.HTTPでpythonコードを.pyに分離する提案です。

確認コード
```vim
let HTTP = g:V.import('Web.HTTP')

let url = 'http://vim-jp.org/reading-vimrc/json/next.json'
let res = HTTP.request('GET', url, { 'client' : ['python']})
echo res
```

また、プラグインとして導入して問題ないことも確認しています。

---

メンテナンス性のためなので、どう扱うかは協議してになるかな、と考えています。

(ファイル名とかかなりやっつけ感はあるので微妙ですが...)