### PR TITLE
vital: fix import error handling

### DIFF
--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -186,7 +186,9 @@ function! s:_format_throwpoint(throwpoint) abort
 endfunction
 
 function! s:_get_file_by_func_name(name) abort
-  let body = execute(printf('verbose function %s', a:name))
+  " If name is digits, it is anonymous-function
+  let name = (a:name =~# '^\d\+$') ? printf('{%s}', a:name) : a:name
+  let body = execute(printf('verbose function %s', name))
   let lines = split(body, "\n")
   let signature = matchstr(lines[0], '^\s*\zs.*')
   let file = matchstr(lines[1], '^\t\%(Last set from\|.\{-}:\)\s*\zs.*$')

--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -167,18 +167,18 @@ let s:Vital._import = function('s:_import')
 
 function! s:_format_throwpoint(throwpoint) abort
   let funcs = []
-  let stack = matchstr(a:throwpoint, '^function \zs.*\ze, line \d\+$')
+  let stack = matchstr(a:throwpoint, '^function \zs.*, .\{-} \d\+$')
   for line in split(stack, '\.\.')
-    let m = matchlist(line, '^\%(<SNR>\(\d\+\)_\)\?\(.\+\)\[\(\d\+\)\]$')
+    let m = matchlist(line, '^\(.\+\)\%(\[\(\d\+\)\]\|, .\{-} \(\d\+\)\)$')
     if empty(m)
       call add(funcs, line)
       continue
     endif
-    let [sid, name, lnum] = m[1:3]
-    let attr = ''
-    if !empty(sid)
-      let name = printf('<SNR>%d_%s', sid, name)
+    let [name, lnum, lnum2] = m[1:3]
+    if empty(lnum)
+      let lnum = lnum2
     endif
+    let attr = ''
     let file = s:_get_file_by_func_name(name)
     call add(funcs, printf('function %s(...)%s Line:%d (%s)', name, attr, lnum, file))
   endfor

--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -191,8 +191,12 @@ function! s:_format_throwpoint(throwpoint) abort
 endfunction
 
 function! s:_get_func_info(name) abort
-  " If name is digits, it is anonymous-function
-  let name = (a:name =~# '^\d\+$') ? printf('{%s}', a:name) : a:name
+  let name = a:name
+  if a:name =~# '^\d\+$'  " is anonymous-function
+    let name = printf('{%s}', a:name)
+  elseif a:name =~# '^<lambda>\d\+$'  " is lambda-function
+    let name = printf("{'%s'}", a:name)
+  endif
   if !exists('*' . name)
     return {}
   endif

--- a/autoload/vital/vital.vim
+++ b/autoload/vital/vital.vim
@@ -149,7 +149,7 @@ function! s:_import(name) abort dict
     call module._vital_created(module)
   endif
   let export_module = filter(copy(module), 'v:key =~# "^\\a"')
-  " Cache module before calling module.vital_loaded() to avoid cyclic
+  " Cache module before calling module._vital_loaded() to avoid cyclic
   " dependences but remove the cache if module._vital_loaded() fails.
   " let s:loaded[a:name] = export_module
   let s:loaded[a:name] = export_module

--- a/test/_testdata/vital/testplugin/autoload/vital/__testplugin__/ErrorSelfmodule.vim
+++ b/test/_testdata/vital/testplugin/autoload/vital/__testplugin__/ErrorSelfmodule.vim
@@ -1,8 +1,17 @@
+let s:Obj = {}
+
 function! s:_vital_loaded(V) abort
-  call s:Obj._anonymous_func()
+  if exists('s:Lambda')
+    call s:Lambda()
+  else
+    call s:Obj._anonymous_func()
+  endif
 endfunction
 
-let s:Obj = {}
+if has('lambda')
+  let s:Lambda = {-> s:Obj._anonymous_func()}
+endif
+
 function! s:Obj._anonymous_func() dict abort
   call s:_throwFOO()
 endfunction

--- a/test/_testdata/vital/testplugin/autoload/vital/__testplugin__/ErrorSelfmodule.vim
+++ b/test/_testdata/vital/testplugin/autoload/vital/__testplugin__/ErrorSelfmodule.vim
@@ -1,0 +1,12 @@
+function! s:_vital_loaded(V) abort
+  call s:Obj._anonymous_func()
+endfunction
+
+let s:Obj = {}
+function! s:Obj._anonymous_func() dict abort
+  call s:_throwFOO()
+endfunction
+
+function! s:_throwFOO() abort
+  throw 'FOO'
+endfunction

--- a/test/vital.vimspec
+++ b/test/vital.vimspec
@@ -221,11 +221,11 @@ Describe vital
       End
 
       It can handle error stack in s:_vital_loaded(V)
-        Throws /^vital: fail to call \._vital_loaded(): FOO from:\_.*\n
-        \function \S*_vital_loaded(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 1)\n
-        \function \d\+(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 6)\n
-        \function \S*_throwFOO(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 10)/
-        \ :call V.import('ErrorSelfmodule')
+        let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\_.*\n'
+        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim.*)\n'
+        \ . 'function \d\+(\.\.\.) dict abort Line:1 (.*\/ErrorSelfmodule\.vim.*)\n'
+        \ . 'function \S*_throwFOO(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim.*)$/'
+        execute 'Throws' errorpat ':call V.import("ErrorSelfmodule")'
       End
 
       It supports s:_vital_created(V)
@@ -307,11 +307,11 @@ Describe vital
 
       It can handle error stack in s:_vital_loaded(V)
         let V = vital#{g:testplugin_name}#new()
-        Throws /^vital: fail to call \._vital_loaded(): FOO from:\_.*\n
-        \function \S*_vital_loaded(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 1)\n
-        \function \d\+(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 6)\n
-        \function \S*_throwFOO(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 10)/
-        \ :call V.load('ErrorSelfmodule')
+        let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\_.*\n'
+        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim.*)\n'
+        \ . 'function \d\+(\.\.\.) dict abort Line:1 (.*\/ErrorSelfmodule\.vim.*)\n'
+        \ . 'function \S*_throwFOO(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim.*)$/'
+        execute 'Throws' errorpat ':call V.load("ErrorSelfmodule")'
       End
 
       It supports s:_vital_created(V)

--- a/test/vital.vimspec
+++ b/test/vital.vimspec
@@ -222,9 +222,10 @@ Describe vital
 
       It can handle error stack in s:_vital_loaded(V)
         let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\_.*\n'
-        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
-        \ . 'function \d\+(\.\.\.) dict abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
-        \ . 'function \S*_throwFOO(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$/'
+        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
+        \ . (has('lambda') ? 'function <lambda>\d\+(\.\.\.) Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n' : '')
+        \ . 'function \d\+(\.\.\.) dict abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
+        \ . 'function \S*_throwFOO(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$/'
         execute 'Throws' errorpat ':call V.import("ErrorSelfmodule")'
       End
 
@@ -308,9 +309,10 @@ Describe vital
       It can handle error stack in s:_vital_loaded(V)
         let V = vital#{g:testplugin_name}#new()
         let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\_.*\n'
-        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
-        \ . 'function \d\+(\.\.\.) dict abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
-        \ . 'function \S*_throwFOO(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$/'
+        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
+        \ . (has('lambda') ? 'function <lambda>\d\+(\.\.\.) Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n' : '')
+        \ . 'function \d\+(\.\.\.) dict abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
+        \ . 'function \S*_throwFOO(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$/'
         execute 'Throws' errorpat ':call V.load("ErrorSelfmodule")'
       End
 

--- a/test/vital.vimspec
+++ b/test/vital.vimspec
@@ -220,6 +220,14 @@ Describe vital
         Assert Equals(JSON.decode('[1, "ni"]'), [1, "ni"])
       End
 
+      It can handle error stack in s:_vital_loaded(V)
+        Throws /^vital: fail to call \._vital_loaded(): FOO from:\_.*\n
+        \function \S*_vital_loaded(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 1)\n
+        \function \d\+(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 6)\n
+        \function \S*_throwFOO(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 10)/
+        \ :call V.import('ErrorSelfmodule')
+      End
+
       It supports s:_vital_created(V)
         let JSON = V.import('Web.JSON')
         Assert HasKey(JSON, 'true')
@@ -295,6 +303,15 @@ Describe vital
         let V = vital#{g:testplugin_name}#new()
         Assert Equals(V.load('Web.JSON'), V)
         Assert Equals(V.Web.JSON.decode('[1, "ni"]'), [1, "ni"])
+      End
+
+      It can handle error stack in s:_vital_loaded(V)
+        let V = vital#{g:testplugin_name}#new()
+        Throws /^vital: fail to call \._vital_loaded(): FOO from:\_.*\n
+        \function \S*_vital_loaded(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 1)\n
+        \function \d\+(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 6)\n
+        \function \S*_throwFOO(\.\.\.) Line:1 (.*\/ErrorSelfmodule\.vim .* 10)/
+        \ :call V.load('ErrorSelfmodule')
       End
 
       It supports s:_vital_created(V)

--- a/test/vital.vimspec
+++ b/test/vital.vimspec
@@ -222,9 +222,9 @@ Describe vital
 
       It can handle error stack in s:_vital_loaded(V)
         let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\_.*\n'
-        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim.*)\n'
-        \ . 'function \d\+(\.\.\.) dict abort Line:1 (.*\/ErrorSelfmodule\.vim.*)\n'
-        \ . 'function \S*_throwFOO(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim.*)$/'
+        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
+        \ . 'function \d\+(\.\.\.) dict abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
+        \ . 'function \S*_throwFOO(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$/'
         execute 'Throws' errorpat ':call V.import("ErrorSelfmodule")'
       End
 
@@ -308,9 +308,9 @@ Describe vital
       It can handle error stack in s:_vital_loaded(V)
         let V = vital#{g:testplugin_name}#new()
         let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\_.*\n'
-        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim.*)\n'
-        \ . 'function \d\+(\.\.\.) dict abort Line:1 (.*\/ErrorSelfmodule\.vim.*)\n'
-        \ . 'function \S*_throwFOO(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim.*)$/'
+        \ . 'function \S*_vital_loaded(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
+        \ . 'function \d\+(\.\.\.) dict abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
+        \ . 'function \S*_throwFOO(\.\.\.) abort Line:1 (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$/'
         execute 'Throws' errorpat ':call V.load("ErrorSelfmodule")'
       End
 

--- a/test/vital.vimspec
+++ b/test/vital.vimspec
@@ -327,6 +327,7 @@ Describe vital
       End
 
       It does not supports invalid self module which is in __latest__ dir
+        let V = vital#{g:testplugin_name}#new()
         Throws /vital: module not found: InvalidSelfmodule/ :call V.import('InvalidSelfmodule')
       End
 


### PR DESCRIPTION
Vital shows stacktrace, when error throws in `module._vital_loaded()`.
But the stacktrace formatter function has bugs.

* If anonymous or lambda function exists in stack, an error occurs in the formatter.
* Function attributes are not detected.

... and minor fixes.