### PR TITLE
Deprecated.Text.Sexp: skip the before block in test

### DIFF
--- a/test/Deprecated/Text/Sexp.vim
+++ b/test/Deprecated/Text/Sexp.vim
@@ -19,7 +19,13 @@ function! s:suite.parse()
   if !s:has_lua
     call s:assert.skip('Vital.Deprecated.Text.Sexp: any function call needs if_lua')
   endif
-  call s:assert.equals(
-        \ s:S.parse('(a b c)'),
-        \ [[{'label': 'identifier', 'col': 2.0, 'matched_text': 'a'}, {'label': 'whitespace', 'col': 3.0, 'matched_text': ' '}, {'label': 'identifier', 'col': 4.0, 'matched_text': 'b'}, {'label': 'whitespace', 'col': 5.0, 'matched_text': ' '}, {'label': 'identifier', 'col': 6.0, 'matched_text': 'c'}]])
+  if has('patch-8.2.0775')
+    call s:assert.equals(
+          \ s:S.parse('(a b c)'),
+          \ [[{'label': 'identifier', 'col': 2, 'matched_text': 'a'}, {'label': 'whitespace', 'col': 3, 'matched_text': ' '}, {'label': 'identifier', 'col': 4, 'matched_text': 'b'}, {'label': 'whitespace', 'col': 5, 'matched_text': ' '}, {'label': 'identifier', 'col': 6, 'matched_text': 'c'}]])
+  else
+    call s:assert.equals(
+          \ s:S.parse('(a b c)'),
+          \ [[{'label': 'identifier', 'col': 2.0, 'matched_text': 'a'}, {'label': 'whitespace', 'col': 3.0, 'matched_text': ' '}, {'label': 'identifier', 'col': 4.0, 'matched_text': 'b'}, {'label': 'whitespace', 'col': 5.0, 'matched_text': ' '}, {'label': 'identifier', 'col': 6.0, 'matched_text': 'c'}]])
+  endif
 endfunction

--- a/test/Deprecated/Text/Sexp.vim
+++ b/test/Deprecated/Text/Sexp.vim
@@ -2,8 +2,12 @@ scriptencoding utf-8
 
 let s:suite = themis#suite('Deprecated.Text.Sexp')
 let s:assert = themis#helper('assert')
+let s:has_lua = has('lua') && exists('*luaeval')
 
 function! s:suite.before()
+  if !s:has_lua
+    return
+  endif
   let s:S = vital#vital#new().import('Deprecated.Text.Sexp')
 endfunction
 
@@ -12,7 +16,7 @@ function! s:suite.after()
 endfunction
 
 function! s:suite.parse()
-  if !has('lua') || !exists('*luaeval')
+  if !s:has_lua
     call s:assert.skip('Vital.Deprecated.Text.Sexp: any function call needs if_lua')
   endif
   call s:assert.equals(


### PR DESCRIPTION
Because error throws in the before block when `has('lua') == 0`.