### PR TITLE
fix: broken test for latest vim.

### DIFF
--- a/test/Async/Later.vimspec
+++ b/test/Async/Later.vimspec
@@ -89,7 +89,7 @@ Describe Async.Later
       Assert Equals(exception, v:null)
       Assert Match(
             \ messages,
-            \ '^\nHello World\nfunction .*<SNR>\d\+_throw, line 1',
+            \ '^\nHello World\n.*function .*<SNR>\d\+_throw, line 1',
             \)
     End
 

--- a/test/vital.vimspec
+++ b/test/vital.vimspec
@@ -221,11 +221,11 @@ Describe vital
       End
 
       It can handle error stack in s:_vital_loaded(V)
-        let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\_.*\n'
+        let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\(\_.*\n'
         \ . 'function \S*_vital_loaded(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
         \ . (has('lambda') ? 'function <lambda>\d\+(\.\.\.) Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n' : '')
         \ . 'function \d\+(\.\.\.) dict abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
-        \ . 'function \S*_throwFOO(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$/'
+        \ . 'function \S*_throwFOO(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\)\?\n\?$/'
         execute 'Throws' errorpat ':call V.import("ErrorSelfmodule")'
       End
 
@@ -310,11 +310,11 @@ Describe vital
 
       It can handle error stack in s:_vital_loaded(V)
         let V = vital#{g:testplugin_name}#new()
-        let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\_.*\n'
+        let errorpat = '/^vital: fail to call \._vital_loaded(): FOO from:\(\_.*\n'
         \ . 'function \S*_vital_loaded(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
         \ . (has('lambda') ? 'function <lambda>\d\+(\.\.\.) Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n' : '')
         \ . 'function \d\+(\.\.\.) dict abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\n'
-        \ . 'function \S*_throwFOO(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$/'
+        \ . 'function \S*_throwFOO(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\)\?\n\?$/'
         execute 'Throws' errorpat ':call V.load("ErrorSelfmodule")'
       End
 


### PR DESCRIPTION
Detect test broken

see
https://travis-ci.org/github/vim-jp/vital.vim/jobs/715004455

- Async.Later .call() echomsg an exception when a task throws an exception
  > Hello World
  > VimEnter Autocommands for "*"..function <SNR>1_main[9]..<SNR>1_start[14]..themis#command#start[10]..themis#run[4]..11[23]..15[6]..16[2]..17[7]..17[7]..17[7]..17[5]..18[3]..19[5]..111[1]..2435[10]..<SNR>151__worker[12]..<lambda>4137[1]..<SNR>107_throw, line 1'
- vital vital-Vital-object .import can handle error stack in s:_vital_loaded(V)
  >          expected exception: '^vital: fail to call \._vital_loaded(): FOO from:\_.*\nfunction \S*_vital_loaded(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\nfunction <lambda>\d\+(\.\.\.) Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\nfunction \d\+(\.\.\.) dict abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\nfunction \S*_throwFOO(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$'
  >          thrown exception: 'vital: fail to call ._vital_loaded(): FOO from:
- vital vital-Vital-object .load can handle error stack in s:_vital_loaded(V)
  >          expected exception: '^vital: fail to call \._vital_loaded(): FOO from:\_.*\nfunction \S*_vital_loaded(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\nfunction <lambda>\d\+(\.\.\.) Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\nfunction \d\+(\.\.\.) dict abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)\nfunction \S*_throwFOO(\.\.\.) abort Line:\d\+ (.*\/ErrorSelfmodule\.vim\( Line:\d\+\)\?)$'
  >          thrown exception: 'vital: fail to call ._vital_loaded(): FOO from:
