### PR TITLE
Async.Promise: Add l: prefix to variable for funcref

### DIFF
--- a/autoload/vital/__vital__/Async/Promise.vim
+++ b/autoload/vital/__vital__/Async/Promise.vim
@@ -278,7 +278,7 @@ function! s:_chain(promise_factories, results) abort
   if len(a:promise_factories) is# 0
     return s:resolve(a:results)
   endif
-  let Factory = remove(a:promise_factories, 0)
+  let l:Factory = remove(a:promise_factories, 0)
   try
     return Factory()
           \.then({ v -> add(a:results, v) })


### PR DESCRIPTION
Without l: prefix, "E705: Variable name conflicts with existing function" will be thrown if user defines same name global function.

```vim
let s:root = fnamemodify(expand('<sfile>'), ':p:h')
execute printf('set runtimepath+=%s', fnameescape(s:root))

let s:Promise = vital#vital#import('Async.Promise')

function! Factory(a, b, c) abort
endfunction

call s:Promise.chain([{ -> s:Promise.resolve() }])
```

### Before

```
function <SNR>316_chain[1]..<SNR>316__chain, line 4
E705: Variable name conflicts with existing function: Factory
```

### After

```
```