### PR TITLE
System.Process.Vimproc: fix timeout unit

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+8ebc53cf1ed6c53ee793e31611829fa57ae7c06d
+	Modules: System.Process.Vimproc
+	Documents as wrote seconds, but it was actually treated as milliseconds.
+	Fix inner timeout unit, timeout set as seconds, call function as milliseconds at value x1000.
 97e8cf8b230cd69720e130742859b51f5761196c
 	Modules: Web.HTTP
 	Added python3 to HTTP client, and refined its default value.

--- a/autoload/vital/__vital__/System/Process/Vimproc.vim
+++ b/autoload/vital/__vital__/System/Process/Vimproc.vim
@@ -51,10 +51,13 @@ function! s:execute(args, options) abort
     " background process via Builtin always return exit_code:0 so mimic
     let status = 0
   else
+    " System.Process.execute() {options} timeout unit as second.
+    " convert to
+    " vimproc#system {timeout} unit as millisecond.
     let output = vimproc#system(
           \ cmdline,
           \ s:Prelude.is_string(a:options.input) ? a:options.input : '',
-          \ a:options.timeout,
+          \ a:options.timeout * 1000,
           \)
     let status = vimproc#get_last_status()
   endif

--- a/test/System/Process/Vimproc.vimspec
+++ b/test/System/Process/Vimproc.vimspec
@@ -29,12 +29,14 @@ Describe System.Process.Vimproc
           " Not sure but 'sleep' doesn't properly works in AppVeyor?
           " The code below worked on Windows 10 + PowerShell
           It DOES NOT throws an exception when {options.timeout} is specified
-            let options.timeout = 100
-            let args = s:cmd + ['sleep', '10']
+            " timeout 1 second = 1000 millisoconds
+            let options.timeout = 1
+            " sleep command 100 seconds wait
+            let args = s:cmd + ['sleep', '100']
             let result = Process.execute(args, options)
             " While the execution time reachs the timeout, the success is 0.
             Assert Equals(result.success, 0)
-          Assert Equals(result.status, 15)
+            Assert Equals(result.status, 15)
           End
         endif
 
@@ -157,8 +159,10 @@ Describe System.Process.Vimproc
     Context [Unix]
       Describe .execute({args}[, {options}])
         It DOES NOT throws an exception when {options.timeout} is specified
-          let options.timeout = 100
-          let args = ['sleep', '10']
+          " timeout 1 second = 1000 millisoconds
+          let options.timeout = 1
+          " sleep command 100 seconds wait
+          let args = ['sleep', '100']
           let result = Process.execute(args, options)
           " While the execution time reachs the timeout, the success is 0.
           Assert Equals(result.success, 0)


### PR DESCRIPTION
## in vimproc help

```
vimproc#system({expr} [, {input} [, {timeout}]])	*vimproc#system()*

(...)

		If you set {timeout}, vimproc will kill the process after
		{timeout} and throw "vimproc: vimproc#system(): Timeout."
		exception.
		The unit is millisecond.
```

timeout unit as millisecond.

## in System.Process.execute() help

```
				*Vital.System.Process.execute()*
execute({args}[, {options}])

(...)

	The following attributes are supported in {options}

(...)

		"timeout"
		A process timeout in seconds (|Number|). A system process
		client does not support this option, mean that vimproc is
		required to be available.
		Default: 0
```

timeout unit as second.

## current implementation.

https://github.com/vim-jp/vital.vim/blob/1b9fab508176efd8bc3fcbc435afd8d7b928ef53/autoload/vital/__vital__/System/Process/Vimproc.vim#L37-L70


call `vimproc#system()` with options.timeout directly.

use second value to millisecond.

This PR fix it(and test value).
But this fixing are breaking change.

After PR test done, `Changes` changing commit add.
