### PR TITLE
fix: System.Filepath.expand_home() fix for completeslash

### DIFF
--- a/autoload/vital/__vital__/System/Filepath.vim
+++ b/autoload/vital/__vital__/System/Filepath.vim
@@ -15,7 +15,7 @@ let s:is_cygwin = has('win32unix')
 let s:is_mac = !s:is_windows && !s:is_cygwin
       \ && (has('mac') || has('macunix') || has('gui_macvim') ||
       \   (!isdirectory('/proc') && executable('sw_vers')))
-" windows expand follow do not need for file extention
+" windows expand follow do not need for file extension
 let s:is_case_tolerant = filereadable(expand('<sfile>:r') . '.VIM')
 
 if s:is_windows
@@ -237,7 +237,7 @@ endfunction
 
 if s:is_windows
   function! s:realpath(path) abort
-    if exists('&shellslash') && &shellslash
+    if exists('+shellslash') && &shellslash
       return s:unixpath(a:path)
     else
       return s:winpath(a:path)
@@ -280,7 +280,7 @@ function! s:contains(path, base) abort
   return pathlist[: baselistlen - 1] ==# baselist
 endfunction
 
-if s:is_windows && exists('&completeslash')
+if s:is_windows && exists('+completeslash')
   function! s:expand(path) abort
     let backup_completeslash = &completeslash
     try

--- a/autoload/vital/__vital__/System/Filepath.vim
+++ b/autoload/vital/__vital__/System/Filepath.vim
@@ -15,7 +15,7 @@ let s:is_cygwin = has('win32unix')
 let s:is_mac = !s:is_windows && !s:is_cygwin
       \ && (has('mac') || has('macunix') || has('gui_macvim') ||
       \   (!isdirectory('/proc') && executable('sw_vers')))
-" windows expand follow do not need for file extension
+
 let s:is_case_tolerant = filereadable(expand('<sfile>:r') . '.VIM')
 
 if s:is_windows

--- a/autoload/vital/__vital__/System/Filepath.vim
+++ b/autoload/vital/__vital__/System/Filepath.vim
@@ -280,7 +280,8 @@ function! s:contains(path, base) abort
   return pathlist[: baselistlen - 1] ==# baselist
 endfunction
 
-if s:is_windows && exists('+completeslash')
+if exists('+completeslash')
+  " completeslash bug in Windows and specific version range (Vim 8.1.1769 - Vim 8.2.1746)
   function! s:expand(path) abort
     let backup_completeslash = &completeslash
     try

--- a/autoload/vital/__vital__/System/Filepath.vim
+++ b/autoload/vital/__vital__/System/Filepath.vim
@@ -15,6 +15,7 @@ let s:is_cygwin = has('win32unix')
 let s:is_mac = !s:is_windows && !s:is_cygwin
       \ && (has('mac') || has('macunix') || has('gui_macvim') ||
       \   (!isdirectory('/proc') && executable('sw_vers')))
+" windows expand follow do not need for file extention
 let s:is_case_tolerant = filereadable(expand('<sfile>:r') . '.VIM')
 
 if s:is_windows
@@ -203,8 +204,8 @@ function! s:expand_home(path) abort
   endif
   let post_home_idx = match(a:path, s:path_sep_pattern)
   return post_home_idx is# -1
-        \ ? s:remove_last_separator(expand(a:path))
-        \ : s:remove_last_separator(expand(a:path[0 : post_home_idx - 1]))
+        \ ? s:remove_last_separator(s:expand(a:path))
+        \ : s:remove_last_separator(s:expand(a:path[0 : post_home_idx - 1]))
         \   . a:path[post_home_idx :]
 endfunction
 
@@ -278,6 +279,22 @@ function! s:contains(path, base) abort
   endif
   return pathlist[: baselistlen - 1] ==# baselist
 endfunction
+
+if s:is_windows && exists('&completeslash')
+  function! s:expand(path) abort
+    let backup_completeslash = &completeslash
+    try
+      set completeslash&
+      return expand(a:path)
+    finally
+      let &completeslash = backup_completeslash
+    endtry
+  endfunction
+else
+  function! s:expand(path) abort
+    return expand(a:path)
+  endfunction
+endif
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -124,13 +124,13 @@ Describe System.Filepath
 
   Describe .expand_home()
     if s:is_windows
-      It [windows] non home path arre no expanded, there are same.
+      It [windows] non home path are no expanded, there are same.
         let path = 'C:/Hoge'
         let ret = FP.expand_home(path)
         Assert Equals(ret, path)
       End
     else
-      It [unix] non home path arre no expanded, there are same.
+      It [unix] non home path are no expanded, there are same.
         let path = '/Hoge'
         let ret = FP.expand_home(path)
         Assert Equals(ret, path)

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -143,7 +143,6 @@ Describe System.Filepath
     End
     It  include .. in path no-expand, but head ~ home expanded.
       if s:is_windows
-        " base shellslash not set need
         let target = '~\Hoge\..\Fuga'
       else
         let target = '~/Hoge/../Fuga'
@@ -154,6 +153,32 @@ Describe System.Filepath
     End
     if s:is_windows
       " need completeslash test
+      if exists('&completeslash')
+        It [windows] completeslash not set home expand test
+          let backup_completeslash = &completeslash
+          set completeslash&
+          let path = '~/Hoge'
+          let ret = FP.expand_home(path)
+          Assert Equals(ret, $HOME . FP.separator() . 'Hoge')
+          let &completeslash = backup_completeslash
+        End
+        It [windows] completeslash=slash home expand test
+          let backup_completeslash = &completeslash
+          set completeslash=slash
+          let path = '~/Hoge'
+          let ret = FP.expand_home(path)
+          Assert Equals(ret, $HOME . FP.separator() . 'Hoge')
+          let &completeslash = backup_completeslash
+        End
+        It [windows] completeslash=backslash home expand test
+          let backup_completeslash = &completeslash
+          set completeslash=backslash
+          let path = '~/Hoge'
+          let ret = FP.expand_home(path)
+          Assert Equals(ret, $HOME . FP.separator() . 'Hoge')
+          let &completeslash = backup_completeslash
+        End
+      endif
     else
       " need ~user test
       It [unix] ~user expand check

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -1,5 +1,6 @@
 let s:V = vital#vital#new()
 let s:is_windows = has('win32')
+let s:is_mac = has('mac')
 
 Describe System.Filepath
   Before all
@@ -119,6 +120,53 @@ Describe System.Filepath
       Assert NotSame(ret, path)
       Assert Equals(ret, 'C:/Foo/Bar/Hoge.txt')
     End
+  End
+
+  Describe .expand_home()
+    if s:is_windows
+      It [windows] non home path arre no expanded, there are same.
+        let path = 'C:/Hoge'
+        let ret = FP.expand_home(path)
+        Assert Equals(ret, path)
+      End
+    else
+      It [unix] non home path arre no expanded, there are same.
+        let path = '/Hoge'
+        let ret = FP.expand_home(path)
+        Assert Equals(ret, path)
+      End
+    endif
+    It expand head ~ home path
+      let path = '~/Hoge'
+      let ret = FP.expand_home(path)
+      Assert Equals(ret, $HOME . FP.separator() . 'Hoge')
+    End
+    It  include .. in path no-expand, but head ~ home expanded.
+      if s:is_windows
+        " base shellslash not set need
+        let target = '~\Hoge\..\Fuga'
+      else
+        let target = '~/Hoge/../Fuga'
+      endif
+      let path = '~' . FP.separator() . target
+      let ret = FP.expand_home(path)
+      Assert Equals(ret, $HOME . FP.separator() . target)
+    End
+    if s:is_windows
+      " need completeslash test
+    else
+      " need ~user test
+      It [unix] ~user expand check
+        let path = '~root/Hoge'
+        let ret = FP.expand_home(path)
+        if s:is_mac
+          let expect = '/var/root/Hoge'
+        else
+          let expect = '/root/Hoge'
+        endif
+        Assert Equals(ret, expect)
+      End
+    endif
   End
 
   Describe .winpath()

--- a/test/System/Filepath.vimspec
+++ b/test/System/Filepath.vimspec
@@ -137,7 +137,11 @@ Describe System.Filepath
       End
     endif
     It expand head ~ home path
-      let path = '~/Hoge'
+      if s:is_windows
+        let path = '~\Hoge'
+      else
+        let path = '~/Hoge'
+      endif
       let ret = FP.expand_home(path)
       Assert Equals(ret, $HOME . FP.separator() . 'Hoge')
     End
@@ -157,7 +161,7 @@ Describe System.Filepath
         It [windows] completeslash not set home expand test
           let backup_completeslash = &completeslash
           set completeslash&
-          let path = '~/Hoge'
+          let path = '~\Hoge'
           let ret = FP.expand_home(path)
           Assert Equals(ret, $HOME . FP.separator() . 'Hoge')
           let &completeslash = backup_completeslash
@@ -165,7 +169,7 @@ Describe System.Filepath
         It [windows] completeslash=slash home expand test
           let backup_completeslash = &completeslash
           set completeslash=slash
-          let path = '~/Hoge'
+          let path = '~\Hoge'
           let ret = FP.expand_home(path)
           Assert Equals(ret, $HOME . FP.separator() . 'Hoge')
           let &completeslash = backup_completeslash
@@ -173,7 +177,7 @@ Describe System.Filepath
         It [windows] completeslash=backslash home expand test
           let backup_completeslash = &completeslash
           set completeslash=backslash
-          let path = '~/Hoge'
+          let path = '~\Hoge'
           let ret = FP.expand_home(path)
           Assert Equals(ret, $HOME . FP.separator() . 'Hoge')
           let &completeslash = backup_completeslash


### PR DESCRIPTION
rel https://github.com/lambdalisue/fern.vim/issues/226
(And I used it as a base for the correction code)

`shellslash` not care in vital.vim.
But `completeslash` option affect  to only `expand()` result  and  non controled.

This PR is fix it.