### PR TITLE
fix: Web.HTTP: python3 client fix unhandled error to handle

### DIFF
--- a/autoload/vital/__vital__/Web/HTTP_python2.py
+++ b/autoload/vital/__vital__/Web/HTTP_python2.py
@@ -55,18 +55,22 @@ try:
                 req = urllib2.Request(settings['url'], data, request_headers)
                 req.get_method = lambda: settings['method']
                 default_timeout = socket.getdefaulttimeout()
+                res = None
                 try:
                     # for Python 2.5 or before
                     socket.setdefaulttimeout(timeout)
                     res = director.open(req, timeout=timeout)
-                except urllib2.HTTPError as res:
-                    pass
+                except urllib2.HTTPError as e:
+                    res = e
                 except urllib2.URLError:
                     return ('', '')
                 except socket.timeout:
                     return ('', '')
                 finally:
                     socket.setdefaulttimeout(default_timeout)
+
+                if res is None:
+                    return ('', '')
 
                 st = status(res.code, res.msg)
                 response_headers = st + ''.join(res.info().headers)

--- a/autoload/vital/__vital__/Web/HTTP_python3.py
+++ b/autoload/vital/__vital__/Web/HTTP_python3.py
@@ -63,10 +63,15 @@ try:
                     pass
                 except urllib.error.URLError:
                     return ('', '')
+                except urllib.error.ContentTooShortError:
+                    return ('', '')
                 except socket.timeout:
                     return ('', '')
                 finally:
                     socket.setdefaulttimeout(default_timeout)
+
+                if res is None:
+                    return ('', '')
 
                 st = status(res.code, res.msg)
                 response_headers = st + ''.join(res.headers)

--- a/autoload/vital/__vital__/Web/HTTP_python3.py
+++ b/autoload/vital/__vital__/Web/HTTP_python3.py
@@ -55,15 +55,14 @@ try:
                 req = urllib.request.Request(settings['url'], data, request_headers)
                 req.get_method = lambda: settings['method']
                 default_timeout = socket.getdefaulttimeout()
+                res = None
                 try:
                     # for Python 2.5 or before <- Is this needed?
                     socket.setdefaulttimeout(timeout)
                     res = director.open(req, timeout=timeout)
-                except urllib.error.HTTPError as res:
-                    pass
-                except urllib.error.URLError:
-                    return ('', '')
-                except urllib.error.ContentTooShortError:
+                except urllib.error.HTTPError as e:
+                    res = e
+                except (urllib.error.URLError, urllib.error.ContentTooShortError):
                     return ('', '')
                 except socket.timeout:
                     return ('', '')


### PR DESCRIPTION
close #760 

This PR include below fix:

- Web.HTTP Python3 client handle ContentTooShortError
- Web.HTTP Python3 client check res is `None`
  (https://docs.python.org/ja/3/library/urllib.request.html#urllib.request.urlopen urlopen may return `None`)

And more

- add HTTPError object handling
- same fix in Python2