### PR TITLE
Data.String.Interpolation: fix float handling after 8.2.2948

### DIFF
--- a/autoload/vital/__vital__/Data/String/Interpolation.vim
+++ b/autoload/vital/__vital__/Data/String/Interpolation.vim
@@ -11,8 +11,9 @@ function! s:interpolate(string, ...) abort
     let expr = str[(s + len(s:_parser_config._ps)):(e - len(s:_parser_config._pend))]
     let V = s:_context_eval(expr, context)
     let str = (s > 0 ? str[0:(s-1)] : '') . V . str[(e+1):]
-    let ps = s:_parse_first_idx_range(str, s + len(V))
-    unlet V
+    let vlen = type(V) is# type(1.0) ? len(string(V)) : len(V)
+    let ps = s:_parse_first_idx_range(str, s + vlen)
+    unlet V vlen
   endwhile
   return str
 endfunction

--- a/autoload/vital/__vital__/Data/String/Interpolation.vim
+++ b/autoload/vital/__vital__/Data/String/Interpolation.vim
@@ -11,7 +11,7 @@ function! s:interpolate(string, ...) abort
     let expr = str[(s + len(s:_parser_config._ps)):(e - len(s:_parser_config._pend))]
     let V = s:_context_eval(expr, context)
     let str = (s > 0 ? str[0:(s-1)] : '') . V . str[(e+1):]
-    let vlen = type(V) is# type(1.0) ? len(string(V)) : len(V)
+    let vlen = type(V) is# v:t_string ? len(V) : len(string(V))
     let ps = s:_parse_first_idx_range(str, s + vlen)
     unlet V vlen
   endwhile

--- a/autoload/vital/__vital__/Data/String/Interpolation.vim
+++ b/autoload/vital/__vital__/Data/String/Interpolation.vim
@@ -13,7 +13,6 @@ function! s:interpolate(string, ...) abort
     let str = (s > 0 ? str[0:(s-1)] : '') . V . str[(e+1):]
     let vlen = type(V) is# v:t_string ? len(V) : len(string(V))
     let ps = s:_parse_first_idx_range(str, s + vlen)
-    unlet V vlen
   endwhile
   return str
 endfunction

--- a/test/Data/String/Interpolation.vimspec
+++ b/test/Data/String/Interpolation.vimspec
@@ -51,7 +51,11 @@ Describe Data.String.Interpolation
     End
     It handle reassignment different type
       Assert Equals(g:I.interpolate('${a} ${b}', {'a': 1, 'b': '1'}), '1 1')
-      Throws /Vim(let):E806:/ g:I.interpolate('${a} ${b}', {'a': 1, 'b': 1.0E-6})
+      if !has('patch-8.2.2948')
+        Throws /Vim(let):E806:/ g:I.interpolate('${a} ${b}', {'a': 1, 'b': 1.0E-6})
+      else
+        Assert Equals(g:I.interpolate('${a} ${b}', {'a': 1, 'b': 1.0E-6}), '1 1.0e-6')
+      endif
     End
     It doesn't raise Vim(let):E704: Funcref variable name must start with a capital
       Throws /Vim(let):E729:/ g:I.interpolate('${Funcref}', {'Funcref': function('InterpolationFunc')})


### PR DESCRIPTION
Vim [8.2.2948](https://github.com/vim/vim/commit/7a2217bedd223df4c8bbebe731bf0b5fe8532533)
による修正で、floatの文字列結合挙動が変りました。

Data.String.Interpolationに影響がありましたので、修正を作成しました。

ただ、アドホックな面があるので、これが最適かについてはレビューにて調整できたらと考えます。

Travis CIはクレジット不足のはずですので、手元でGHAで実行した結果がありますので添付します。
https://github.com/tsuyoshicho/vital.vim/actions/runs/1010662757
(Windows latestの別問題はとりあえず置いておくとして)

参考 NG時
https://github.com/tsuyoshicho/vital.vim/runs/3015278186?check_suite_focus=true