### PR TITLE
fix: document & comment typo

### DIFF
--- a/autoload/vital/__vital__/System/Process/System.vim
+++ b/autoload/vital/__vital__/System/Process/System.vim
@@ -41,7 +41,7 @@ endfunction
 function! s:execute(args, options) abort
   " NOTE:
   " execute() is a command for executing program WITHOUT using shell.
-  " so mimic that behaviour with shell
+  " so mimic that behavior with shell
   let guard = s:Guard.store(filter([
         \ '&shell',
         \ '&shellcmdflag',

--- a/doc/vital/ConcurrentProcess.txt
+++ b/doc/vital/ConcurrentProcess.txt
@@ -154,7 +154,7 @@ PRINCIPLE			*Vital.ConcurrentProcess-principle*
 * Synchronous (asynchronous in Vim always makes trouble)
 * Don't show lower layer too much easily, but don't hide completely. No
   perfect abstraction exists in the world.
-* Avoid tricky specification. Function name and behaviour itself should
+* Avoid tricky specification. Function name and behavior itself should
   explain what it does.
 >
 ==============================================================================

--- a/doc/vital/Text/LTSV.txt
+++ b/doc/vital/Text/LTSV.txt
@@ -14,7 +14,7 @@ INTERFACE			|Vital.Text.LTSV-interface|
 ==============================================================================
 INTRODUCTION			*Vital.Text.LTSV-introduction*
 
-*Vital.Text.LTSV* is a parser and dumper for Labelled Tab-separated
+*Vital.Text.LTSV* is a parser and dumper for Labeled Tab-separated
 Values(LTSV).
 
 http://ltsv.org/


### PR DESCRIPTION
fix below

In comment
- System.Process.System

In document
- ConcurrentProcess
- Text.LTSV
