### PR TITLE
ci: misspell use both US/UK

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: ${{ steps.reporter.outputs.value }}
-          locale: "US"
+            # vital.vim allows both US/UK.
   vital-throw-message:
     name: runner / vital-throw-message
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fis is error

https://github.com/vim-jp/vital.vim/runs/3157022032

English is valid, but current misspell setting "US" detect "UK" type miss spell.

This project accept US/UK, change setting.
