### PR TITLE
fix: Web.HTTP: outputFile in Windows like tempfile

### DIFF
--- a/autoload/vital/__vital__/Web/HTTP.vim
+++ b/autoload/vital/__vital__/Web/HTTP.vim
@@ -172,7 +172,11 @@ function! s:_make_postfile(data) abort
 endfunction
 
 function! s:_tempname() abort
-  return tr(tempname(), '\', '/')
+  return s:_file_resolve(tempname())
+endfunction
+
+function! s:_file_resolve(file) abort
+  return tr(a:file, '\', '/')
 endfunction
 
 function! s:_postdata(data) abort
@@ -388,7 +392,7 @@ function! s:clients.curl.request(settings) abort
   let command .= ' --dump-header ' . quote . a:settings._file.header . quote
   let has_output_file = has_key(a:settings, 'outputFile')
   if has_output_file
-    let output_file = a:settings.outputFile
+    let output_file = s:_file_resolve(a:settings.outputFile)
   else
     let output_file = s:_tempname()
     let a:settings._file.content = output_file
@@ -499,7 +503,7 @@ function! s:clients.wget.request(settings) abort
   let command .= ' -o ' . quote . a:settings._file.header . quote
   let has_output_file = has_key(a:settings, 'outputFile')
   if has_output_file
-    let output_file = a:settings.outputFile
+    let output_file = s:_file_resolve(a:settings.outputFile)
   else
     let output_file = s:_tempname()
     let a:settings._file.content = output_file


### PR DESCRIPTION
## Detail
Error happen Vim with https://github.com/lambdalisue/vim-protocol in Windows.

Researched to vim-protocol and vital.vim, Web.HTTP with `client outputFile`.
Resolved issue.

## Reason
curl/wget support outputFile. and these clients use tempfile in client implements.

Inner tempfile was successful but external supply were failed.
Differenent both files are using `tr()` that replace from backslash to slash. 

This PR  apply `tr()` to external supply `outputFile` param.

## Test

local vim-protocol with replaced `outputFile` (in HTTP.request param) and updated vital are success.