### PR TITLE
ci: Update depup - PR create and commit author set as bot account

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -30,6 +30,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          author: 'github-actions <41898282+github-actions[bot]@users.noreply.github.com>'
           title: "chore(deps): update ${{ steps.depup.outputs.repo }} to ${{ steps.depup.outputs.latest }}"
           commit-message: "chore(deps): update ${{ steps.depup.outputs.repo }} to ${{ steps.depup.outputs.latest }}"
           body: |
@@ -59,6 +60,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          author: 'github-actions <41898282+github-actions[bot]@users.noreply.github.com>'
           title: "chore(deps): update ${{ steps.depup.outputs.repo }} to ${{ steps.depup.outputs.latest }}"
           commit-message: "chore(deps): update ${{ steps.depup.outputs.repo }} to ${{ steps.depup.outputs.latest }}"
           body: |


### PR DESCRIPTION
Update depup

PR create and commit author set as bot account.

see
https://github.com/tsuyoshicho/vital-codec/pull/200
This PR create after below PR merged.
https://github.com/tsuyoshicho/action-redpen/pull/61