### PR TITLE
Data.Closure: fix test in latest Windows/mac exception error E1085

### DIFF
--- a/test/Data/Closure.vimspec
+++ b/test/Data/Closure.vimspec
@@ -240,8 +240,8 @@ Describe Data.Closure
       Throws /^vital: Data.Closure:/ Func1(20)
       Throws /^vital: Data.Closure:/ Func2(20)
       call C.sweep_functions()
-      Throws /^Vim(\w\+):E\(117\|1085\):/ Func1(20)
-      Throws /^Vim(\w\+):E\(117\|1085\):/ Func2(20)
+      Throws /^Vim(\w\+):E\%(117\|1085\):/ Func1(20)
+      Throws /^Vim(\w\+):E\%(117\|1085\):/ Func2(20)
     End
   End
 
@@ -316,7 +316,7 @@ Describe Data.Closure
           Assert Equals(Func(20), 30)
           Throws /^vital: Data.Closure:/ Equals(Func(20), 30)
           call C.sweep_functions()
-          Throws /^Vim(\w\+):E\(117\|1085\):/ Equals(Func(20), 30)
+          Throws /^Vim(\w\+):E\%(117\|1085\):/ Equals(Func(20), 30)
         End
       End
     End
@@ -328,7 +328,7 @@ Describe Data.Closure
         Assert IsFunc(Func)
         Assert Equals(Func(20), 30)
         call closure.delete_function()
-        Throws /^Vim(\w\+):E\(117\|1085\):/ Equals(Func(20), 30)
+        Throws /^Vim(\w\+):E\%(117\|1085\):/ Equals(Func(20), 30)
       End
     End
   End

--- a/test/Data/Closure.vimspec
+++ b/test/Data/Closure.vimspec
@@ -240,8 +240,8 @@ Describe Data.Closure
       Throws /^vital: Data.Closure:/ Func1(20)
       Throws /^vital: Data.Closure:/ Func2(20)
       call C.sweep_functions()
-      Throws /^Vim(\w\+):E117:/ Func1(20)
-      Throws /^Vim(\w\+):E117:/ Func2(20)
+      Throws /^Vim(\w\+):E\(117\|1085\):/ Func1(20)
+      Throws /^Vim(\w\+):E\(117\|1085\):/ Func2(20)
     End
   End
 
@@ -316,7 +316,7 @@ Describe Data.Closure
           Assert Equals(Func(20), 30)
           Throws /^vital: Data.Closure:/ Equals(Func(20), 30)
           call C.sweep_functions()
-          Throws /^Vim(\w\+):E117:/ Equals(Func(20), 30)
+          Throws /^Vim(\w\+):E\(117\|1085\):/ Equals(Func(20), 30)
         End
       End
     End
@@ -328,7 +328,7 @@ Describe Data.Closure
         Assert IsFunc(Func)
         Assert Equals(Func(20), 30)
         call closure.delete_function()
-        Throws /^Vim(\w\+):E117:/ Equals(Func(20), 30)
+        Throws /^Vim(\w\+):E\(117\|1085\):/ Equals(Func(20), 30)
       End
     End
   End


### PR DESCRIPTION
Fix latest Windows/mac test failure.

## Reason:

In latest Vim,  exception raise E1085 instead E117 in Data.Closure's "target function check after gc" test .

NOTE: But, kept E117 in linux.

---

E1085 の情報がなく、このエラーが発生することが意図する所なのか、想定外が出ているのかが明確ではありません。
ただ利用側から見て、利用不可能になったfuncrefとしてこのエラーとなっているようなので、対応しました。

```vim
let F = {-> 'echo'}
echo string(F)
let F = v:null
call F()
```

```
|| 
|| function('<lambda>47042')
|| function quickrun#command#execute[10]..quickrun#run[10]..548[10]..543[3]..<SNR>775_execute[9]..script C:\Users\tsuyoshi\AppData\Local\Temp\V008BC1.tmp, 行 4
|| E1085: Not a callable type: F
```

in Vim
```
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Dec 22 2021 21:36:41)
MS-Windows 64 ビット GUI/コンソール 版 with OLE サポート
適用済パッチ: 1-3875
```