### PR TITLE
ci: fix requiremnets (click 8.0.0 limit Already unnecessary)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ###### Requirements without Version Specifiers ######
-
+#
+click
+covimerage
 ###### Requirements with Version Specifiers ######
-click<8.0.0
-covimerage==0.2.1
+#

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ###### Requirements without Version Specifiers ######
 #
-click
 covimerage
 ###### Requirements with Version Specifiers ######
 #


### PR DESCRIPTION
requirements update

History
1. covimerage==0.2.1 only
2. add click<8.0.0 see issue https://github.com/Vimjas/covimerage/issues/95
3. now fix click ver. 8 / latest https://github.com/Vimjas/covimerage/pull/97