### PR TITLE
ci: fix reviewdog Git v2.35.2 spec changes issue

### DIFF
--- a/.github/actions/vital-throw-message/entrypoint.sh
+++ b/.github/actions/vital-throw-message/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-cd "$GITHUB_WORKSPACE"
+if [ -n "${GITHUB_WORKSPACE}" ] ; then
+  cd "${GITHUB_WORKSPACE}" || exit
+  git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit 1
+fi
 
 export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 

--- a/.github/actions/vital-throw-message/entrypoint.sh
+++ b/.github/actions/vital-throw-message/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -n "${GITHUB_WORKSPACE}" ] ; then
-  cd "${GITHUB_WORKSPACE}" || exit
+  cd "${GITHUB_WORKSPACE}" || exit 1
   git config --global --add safe.directory "${GITHUB_WORKSPACE}" || exit 1
 fi
 


### PR DESCRIPTION
# Pull Request detail
Git v2.35.2 spec changes are causing nvcheck action to error during run.

```log
reviewdog: PullRequest needs 'git' command: failed to run 'git rev-parse --show-prefix': exit status 128
```

## Related issues

`https://github.com/reviewdog/reviewdog/issues/1158#`

## Remain problem

`lint-throw.go` do not good work in current go env -> fix in #789

---

この変更がなくても、現在のreviewdogの使い方的にはエラーは出ていません。
ただ修正しておくことで、今後他のrepoterを使うようになったときに出る問題を未然に防ぎます。