### PR TITLE
ci: fix brew update to upgrade

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup lua
         if: matrix.type == 'macvim'
         run: |
-          brew update
+          brew upgrade
           brew install lua
       - name: Setup pip
         run: |


### PR DESCRIPTION
close #791 

## Fix MacVim Lua Update process.

Now, MacVim CI was failed.
Bacause, Lua install process (`brew update && brew install lua`) return NG.
NG reason: outdated installed packages.

## Fix method
Use `upgrade` instead of `update`.

### other result
Fix in other repo result.
- https://github.com/tsuyoshicho/vital-codec/pull/245
- https://github.com/tsuyoshicho/vital-globe/pull/33