### PR TITLE
ci: Update codecov action v3

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -102,7 +102,7 @@ jobs:
           covimerage write_coverage "${THEMIS_PROFILE}"
           coverage xml
       - name: Send coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           env_vars: OS,VIMVER
@@ -218,7 +218,7 @@ jobs:
           covimerage write_coverage ${Env:THEMIS_PROFILE}
           coverage xml
       - name: Send coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           env_vars: OS,VIMVER


### PR DESCRIPTION
codecovのactionを更新

v3でnode16になるようです。
(node12はwarningが出ています。)

そしてそれ以外は大きな変更はなさそうです。
https://github.com/codecov/codecov-action/releases/tag/v3.0.0

