### PR TITLE
Update golang image for action

### DIFF
--- a/.github/actions/vital-throw-message/Dockerfile
+++ b/.github/actions/vital-throw-message/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.20
 
 ENV REVIEWDOG_VERSION=v0.14.1
 


### PR DESCRIPTION
他のリポジトリで renovate より更新があったので展開。

影響はよくもわるくも無いので、折を見て更新でよいかと。