### PR TITLE
fix: Update tests for Async.Promise .wait

### DIFF
--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -795,17 +795,17 @@ Describe Async.Promise
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), ['resolved', v:null])
       let done = reltimefloat(reltime(s)) * 1000
+      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+      " detect time range |                   +------+
+      " complete timing   |---------------o 500
+      " lower limit : 600, upper limit : 800
       if has('mac')
         " Because of unstable result time on mac, we will expand the judgment range for the time test
         " It underflows and overflows.
         Assert Compare(done, '>=', 400)
         Assert Compare(done, '<=', 1000)
       else
-        " interval period   | 1  | 2    | 3    | 4    | 5    | 6
-        " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
-        " detect time range |                   +------+
-        " complete timing   |---------------o 500
-        " lower limit : 600, upper limit : 800
         Assert Compare(done, '>=', 600)
         Assert Compare(done, '<=', 800)
       endif
@@ -816,17 +816,17 @@ Describe Async.Promise
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), ['resolved', v:null])
       let done = reltimefloat(reltime(s)) * 1000
+      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+      " detect time range |                          +------+
+      " complete timing   |----------------------o 700
+      " lower limit : 800, upper limit : 1000
       if has('mac')
         " Because of unstable result time on mac, we will expand the judgment range for the time test
         " It underflows and overflows.
         Assert Compare(done, '>=', 600)
         Assert Compare(done, '<=', 1200)
       else
-        " interval period   | 1  | 2    | 3    | 4    | 5    | 6
-        " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
-        " detect time range |                          +------+
-        " complete timing   |----------------------o 700
-        " lower limit : 800, upper limit : 1000
         Assert Compare(done, '>=', 800)
         Assert Compare(done, '<=', 1000)
       endif
@@ -839,17 +839,17 @@ Describe Async.Promise
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), [v:null, 'rejected'])
       let done = reltimefloat(reltime(s)) * 1000
+      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+      " detect time range |                   +------+
+      " complete timing   |---------------o 500
+      " lower limit : 600, upper limit : 800
       if has('mac')
         " Because of unstable result time on mac, we will expand the judgment range for the time test
         " It underflows and overflows.
         Assert Compare(done, '>=', 400)
         Assert Compare(done, '<=', 1000)
       else
-        " interval period   | 1  | 2    | 3    | 4    | 5    | 6
-        " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
-        " detect time range |                   +------+
-        " complete timing   |---------------o 500
-        " lower limit : 600, upper limit : 800
         Assert Compare(done, '>=', 600)
         Assert Compare(done, '<=', 800)
       endif
@@ -860,17 +860,17 @@ Describe Async.Promise
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), [v:null, 'rejected'])
       let done = reltimefloat(reltime(s)) * 1000
+      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+      " detect time range |                          +------+
+      " complete timing   |----------------------o 700
+      " lower limit : 800, upper limit : 1000
       if has('mac')
         " Because of unstable result time on mac, we will expand the judgment range for the time test
         " It underflows and overflows.
         Assert Compare(done, '>=', 600)
         Assert Compare(done, '<=', 1200)
       else
-        " interval period   | 1  | 2    | 3    | 4    | 5    | 6
-        " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
-        " detect time range |                          +------+
-        " complete timing   |----------------------o 700
-        " lower limit : 800, upper limit : 1000
         Assert Compare(done, '>=', 800)
         Assert Compare(done, '<=', 1000)
       endif

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -822,8 +822,8 @@ Describe Async.Promise
       " complete timing   |----------------------o 700
       " lower limit : 800, upper limit : 1000
       if has('mac')
-        " Because of unstable result time on mac, we will expand the judgment range for the time test
-        " It underflows and overflows.
+        " Because the time required for a result is not stable on mac, we will expand the wait time range to test the time test
+        " It can either underflow or overflow.
         Assert Compare(done, '>=', 600)
         Assert Compare(done, '<=', 1200)
       else
@@ -845,8 +845,8 @@ Describe Async.Promise
       " complete timing   |---------------o 500
       " lower limit : 600, upper limit : 800
       if has('mac')
-        " Because of unstable result time on mac, we will expand the judgment range for the time test
-        " It underflows and overflows.
+        " Because the time required for a result is not stable on mac, we will expand the wait time range to test the time test
+        " It can either underflow or overflow.
         Assert Compare(done, '>=', 400)
         Assert Compare(done, '<=', 1000)
       else
@@ -866,8 +866,8 @@ Describe Async.Promise
       " complete timing   |----------------------o 700
       " lower limit : 800, upper limit : 1000
       if has('mac')
-        " Because of unstable result time on mac, we will expand the judgment range for the time test
-        " It underflows and overflows.
+        " Because the time required for a result is not stable on mac, we will expand the wait time range to test the time test
+        " It can either underflow or overflow.
         Assert Compare(done, '>=', 600)
         Assert Compare(done, '<=', 1200)
       else

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -788,34 +788,65 @@ Describe Async.Promise
       Assert Compare(done, '<=', 2000)
     End
 
-    It waits at least the interval milliseconds (interval < epoch)
-      let p = Wait(1000).then({ -> 'resolved' })
+    It waits within interval range ((interval * n) <= epoch <= (interval * (n + 1))), resolved pattern
+      let p = Wait(500).then({ -> 'resolved' })
       let s = reltime()
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
-      Assert Equals(P.wait(p, { 'interval': 340 }), ['resolved', v:null])
+      Assert Equals(P.wait(p, { 'interval': 200 }), ['resolved', v:null])
       let done = reltimefloat(reltime(s)) * 1000
-      Assert Compare(done, '>=', 1000)
-      if has('mac')
-        " TODO: I know this is a terrible IDEA, but this assert makes osx test fails.
-        " Let's disable until we figure out why and how.
-      else
-      	Assert Compare(done, '<=', 1360)
-      endif
+      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+      " detect time range |                   +------+
+      " complete timing   |---------------o 500
+      " lower limit : 600, upper limit : 800
+      Assert Compare(done, '>=', 600)
+      Assert Compare(done, '<=', 800)
 
-      let p = Wait(1000).then({ -> P.reject('rejected') })
+      let p = Wait(700).then({ -> 'resolved' })
       let s = reltime()
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
-      Assert Equals(P.wait(p, { 'interval': 340 }), [v:null, 'rejected'])
+      Assert Equals(P.wait(p, { 'interval': 200 }), ['resolved', v:null])
       let done = reltimefloat(reltime(s)) * 1000
-      Assert Compare(done, '>=', 1000)
-      if has('mac')
-        " TODO: I know this is a terrible IDEA, but this assert makes osx test fails.
-        " Let's disable until we figure out why and how.
-      else
-      	Assert Compare(done, '<=', 1360)
-      endif
+      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+      " detect time range |                          +------+
+      " complete timing   |----------------------o 700
+      " lower limit : 800, upper limit : 1000
+      Assert Compare(done, '>=', 800)
+      Assert Compare(done, '<=', 1000)
+    End
+
+    It waits within interval range ((interval * n) <= epoch <= (interval * (n + 1))), rejected pattern
+      let p = Wait(500).then({ -> P.reject('rejected') })
+      let s = reltime()
+      Assert Equals(p._state, PENDING)
+      " Timer accuracy fixing need
+      Assert Equals(P.wait(p, { 'interval': 200 }), [v:null, 'rejected'])
+      let done = reltimefloat(reltime(s)) * 1000
+      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+      " detect time range |                   +------+
+      " complete timing   |---------------o 500
+      " lower limit : 600, upper limit : 800
+      Assert Compare(done, '>=', 600)
+      Assert Compare(done, '<=', 800)
+
+
+      let p = Wait(700).then({ -> P.reject('rejected') })
+      let s = reltime()
+      Assert Equals(p._state, PENDING)
+      " Timer accuracy fixing need
+      Assert Equals(P.wait(p, { 'interval': 200 }), [v:null, 'rejected'])
+      let done = reltimefloat(reltime(s)) * 1000
+      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+      " detect time range |                          +------+
+      " complete timing   |----------------------o 700
+      " lower limit : 800, upper limit : 1000
+      Assert Compare(done, '>=', 800)
+      Assert Compare(done, '<=', 1000)
     End
   End
 

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -788,7 +788,7 @@ Describe Async.Promise
       Assert Compare(done, '<=', 2000)
     End
 
-    It waits within interval range ((interval * n) <= epoch <= (interval * (n + 1))), resolved pattern
+    It waits within the interval range ((interval * n) <= epoch <= (interval * (n + 1))) until resolve
       let p = Wait(500).then({ -> 'resolved' })
       let s = reltime()
       Assert Equals(p._state, PENDING)
@@ -801,8 +801,8 @@ Describe Async.Promise
       " complete timing   |---------------o 500
       " lower limit : 600, upper limit : 800
       if has('mac')
-        " Because of unstable result time on mac, we will expand the judgment range for the time test
-        " It underflows and overflows.
+        " Because the time required for a result is not stable on mac, we will expand the wait time range to test the time test
+        " It can either underflow or overflow.
         Assert Compare(done, '>=', 400)
         Assert Compare(done, '<=', 1000)
       else
@@ -832,7 +832,7 @@ Describe Async.Promise
       endif
     End
 
-    It waits within interval range ((interval * n) <= epoch <= (interval * (n + 1))), rejected pattern
+    It waits within the interval range ((interval * n) <= epoch <= (interval * (n + 1))), until reject
       let p = Wait(500).then({ -> P.reject('rejected') })
       let s = reltime()
       Assert Equals(p._state, PENDING)

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -794,28 +794,42 @@ Describe Async.Promise
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), ['resolved', v:null])
-      let done = reltimefloat(reltime(s)) * 1000
-      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
-      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
-      " detect time range |                   +------+
-      " complete timing   |---------------o 500
-      " lower limit : 600, upper limit : 800
-      Assert Compare(done, '>=', 600)
-      Assert Compare(done, '<=', 800)
+      if has('mac')
+        " Because of unstable result time on mac, we will expand the judgment range for the time test
+        " It underflows and overflows.
+        Assert Compare(done, '>=', 400)
+        Assert Compare(done, '<=', 1000)
+      else
+        let done = reltimefloat(reltime(s)) * 1000
+        " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+        " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+        " detect time range |                   +------+
+        " complete timing   |---------------o 500
+        " lower limit : 600, upper limit : 800
+        Assert Compare(done, '>=', 600)
+        Assert Compare(done, '<=', 800)
+      endif
 
       let p = Wait(700).then({ -> 'resolved' })
       let s = reltime()
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), ['resolved', v:null])
-      let done = reltimefloat(reltime(s)) * 1000
-      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
-      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
-      " detect time range |                          +------+
-      " complete timing   |----------------------o 700
-      " lower limit : 800, upper limit : 1000
-      Assert Compare(done, '>=', 800)
-      Assert Compare(done, '<=', 1000)
+      if has('mac')
+        " Because of unstable result time on mac, we will expand the judgment range for the time test
+        " It underflows and overflows.
+        Assert Compare(done, '>=', 600)
+        Assert Compare(done, '<=', 1200)
+      else
+        let done = reltimefloat(reltime(s)) * 1000
+        " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+        " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+        " detect time range |                          +------+
+        " complete timing   |----------------------o 700
+        " lower limit : 800, upper limit : 1000
+        Assert Compare(done, '>=', 800)
+        Assert Compare(done, '<=', 1000)
+      endif
     End
 
     It waits within interval range ((interval * n) <= epoch <= (interval * (n + 1))), rejected pattern
@@ -824,29 +838,42 @@ Describe Async.Promise
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), [v:null, 'rejected'])
-      let done = reltimefloat(reltime(s)) * 1000
-      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
-      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
-      " detect time range |                   +------+
-      " complete timing   |---------------o 500
-      " lower limit : 600, upper limit : 800
-      Assert Compare(done, '>=', 600)
-      Assert Compare(done, '<=', 800)
-
+      if has('mac')
+        " Because of unstable result time on mac, we will expand the judgment range for the time test
+        " It underflows and overflows.
+        Assert Compare(done, '>=', 400)
+        Assert Compare(done, '<=', 1000)
+      else
+        let done = reltimefloat(reltime(s)) * 1000
+        " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+        " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+        " detect time range |                   +------+
+        " complete timing   |---------------o 500
+        " lower limit : 600, upper limit : 800
+        Assert Compare(done, '>=', 600)
+        Assert Compare(done, '<=', 800)
+      endif
 
       let p = Wait(700).then({ -> P.reject('rejected') })
       let s = reltime()
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), [v:null, 'rejected'])
-      let done = reltimefloat(reltime(s)) * 1000
-      " interval period   | 1  | 2    | 3    | 4    | 5    | 6
-      " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
-      " detect time range |                          +------+
-      " complete timing   |----------------------o 700
-      " lower limit : 800, upper limit : 1000
-      Assert Compare(done, '>=', 800)
-      Assert Compare(done, '<=', 1000)
+      if has('mac')
+        " Because of unstable result time on mac, we will expand the judgment range for the time test
+        " It underflows and overflows.
+        Assert Compare(done, '>=', 600)
+        Assert Compare(done, '<=', 1200)
+      else
+        let done = reltimefloat(reltime(s)) * 1000
+        " interval period   | 1  | 2    | 3    | 4    | 5    | 6
+        " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
+        " detect time range |                          +------+
+        " complete timing   |----------------------o 700
+        " lower limit : 800, upper limit : 1000
+        Assert Compare(done, '>=', 800)
+        Assert Compare(done, '<=', 1000)
+      endif
     End
   End
 

--- a/test/Async/Promise.vimspec
+++ b/test/Async/Promise.vimspec
@@ -794,13 +794,13 @@ Describe Async.Promise
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), ['resolved', v:null])
+      let done = reltimefloat(reltime(s)) * 1000
       if has('mac')
         " Because of unstable result time on mac, we will expand the judgment range for the time test
         " It underflows and overflows.
         Assert Compare(done, '>=', 400)
         Assert Compare(done, '<=', 1000)
       else
-        let done = reltimefloat(reltime(s)) * 1000
         " interval period   | 1  | 2    | 3    | 4    | 5    | 6
         " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
         " detect time range |                   +------+
@@ -815,13 +815,13 @@ Describe Async.Promise
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), ['resolved', v:null])
+      let done = reltimefloat(reltime(s)) * 1000
       if has('mac')
         " Because of unstable result time on mac, we will expand the judgment range for the time test
         " It underflows and overflows.
         Assert Compare(done, '>=', 600)
         Assert Compare(done, '<=', 1200)
       else
-        let done = reltimefloat(reltime(s)) * 1000
         " interval period   | 1  | 2    | 3    | 4    | 5    | 6
         " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
         " detect time range |                          +------+
@@ -838,13 +838,13 @@ Describe Async.Promise
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), [v:null, 'rejected'])
+      let done = reltimefloat(reltime(s)) * 1000
       if has('mac')
         " Because of unstable result time on mac, we will expand the judgment range for the time test
         " It underflows and overflows.
         Assert Compare(done, '>=', 400)
         Assert Compare(done, '<=', 1000)
       else
-        let done = reltimefloat(reltime(s)) * 1000
         " interval period   | 1  | 2    | 3    | 4    | 5    | 6
         " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
         " detect time range |                   +------+
@@ -859,13 +859,13 @@ Describe Async.Promise
       Assert Equals(p._state, PENDING)
       " Timer accuracy fixing need
       Assert Equals(P.wait(p, { 'interval': 200 }), [v:null, 'rejected'])
+      let done = reltimefloat(reltime(s)) * 1000
       if has('mac')
         " Because of unstable result time on mac, we will expand the judgment range for the time test
         " It underflows and overflows.
         Assert Compare(done, '>=', 600)
         Assert Compare(done, '<=', 1200)
       else
-        let done = reltimefloat(reltime(s)) * 1000
         " interval period   | 1  | 2    | 3    | 4    | 5    | 6
         " elapsed time      |* 0 |* 200 |* 400 |* 600 |* 800 |* 1000
         " detect time range |                          +------+


### PR DESCRIPTION
Close #809 

Update Async.Promise .wait test:

* Split test: resolved pattern and rejected pattern
* Update test timing pattern: complete 500 and 700
* Update assert : lower limit and upper limmit

---

他のテストとの兼ね合いはありそうですが、現在わかってる範囲で改善を行いました。
全体としてもうすこし細かく確認を分割したほうがいい気はしますね。

macについては、アンダーフロー、オーバーフローのどちらも出たので、精度的な問題として暫定で範囲を広げて対応しています。

ここを見そうな方を暫定でreviewer指定しています