### PR TITLE
CI: Work around macOS errors

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -47,7 +47,11 @@ jobs:
           brew install lua
       - name: Setup pip
         run: |
-          sudo pip3 install -U pip
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            sudo pip3 install -U pip --break-system-packages
+          else
+            sudo pip3 install -U pip
+          fi
       - name: Get pip cache
         id: pip-cache
         run: |
@@ -61,7 +65,11 @@ jobs:
             ${{ runner.os }}-pip-
       - name: Setup cached item
         run: |
-          pip3 install --user -r requirements.txt
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            pip3 install --user -r requirements.txt --break-system-packages
+          else
+            pip3 install --user -r requirements.txt
+          fi
       - name: Setup Vim
         id: 'vim'
         uses: thinca/action-setup-vim@v1

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -18,6 +18,10 @@ jobs:
             # linux only vim/ macvim run as mac os
             type: macvim
           - os: macos-latest
+            type: vim
+            # v8.2.1310 or later is required to build on macos-latest
+            vim: v8.2.0020
+          - os: macos-latest
             type: macvim
             # macvim only head
             vim: v8.2.0020


### PR DESCRIPTION
* pip の更新で `error: externally-managed-environment` が発生する問題に `--break-system-packages` を指定することで対処。(venv を使う方がよいかもしれない。)
* 最新の macOS では Vim v8.2.1310 以降しかビルドできなくなってしまったので、v8.2.0020 をスキップ。