### PR TITLE
Data.Base16: fix encode test vector

### DIFF
--- a/test/Data/Base16.vimspec
+++ b/test/Data/Base16.vimspec
@@ -14,19 +14,19 @@ Describe Data.Base16
       Assert Equals(B.encode("f"     ), '66'          )
     End
     It encode string RFC Test Vector 3. (reverse pattern)
-      Assert Equals(B.encode("fo"    ), '666F'        )
+      Assert Equals(B.encode("fo"    ), '666f'        )
     End
     It encode string RFC Test Vector 4. (reverse pattern)
-      Assert Equals(B.encode("foo"   ), '666F6F'      )
+      Assert Equals(B.encode("foo"   ), '666f6f'      )
     End
     It encode string RFC Test Vector 5. (reverse pattern)
-      Assert Equals(B.encode("foob"  ), '666F6F62'    )
+      Assert Equals(B.encode("foob"  ), '666f6f62'    )
     End
     It encode string RFC Test Vector 6. (reverse pattern)
-      Assert Equals(B.encode("fooba" ), '666F6F6261'  )
+      Assert Equals(B.encode("fooba" ), '666f6f6261'  )
     End
     It encode string RFC Test Vector 7. (reverse pattern)
-      Assert Equals(B.encode("foobar"), '666F6F626172')
+      Assert Equals(B.encode("foobar"), '666f6f626172')
     End
   End
 

--- a/test/Data/Base16.vimspec
+++ b/test/Data/Base16.vimspec
@@ -7,26 +7,26 @@ Describe Data.Base16
     It encode string to base16 encoded string.
       Assert Equals(B.encode("hello, world!"), '68656c6c6f2c20776f726c6421')
     End
-    It decode string RFC Test Vector 1.
-      Assert Equals(B.decode(""            ), ''      )
+    It encode string RFC Test Vector 1. (reverse pattern)
+      Assert Equals(B.encode(""      ), ''            )
     End
-    It decode string RFC Test Vector 2.
-      Assert Equals(B.decode("66"          ), 'f'     )
+    It encode string RFC Test Vector 2. (reverse pattern)
+      Assert Equals(B.encode("f"     ), '66'          )
     End
-    It decode string RFC Test Vector 3.
-      Assert Equals(B.decode("666F"        ), 'fo'    )
+    It encode string RFC Test Vector 3. (reverse pattern)
+      Assert Equals(B.encode("fo"    ), '666F'        )
     End
-    It decode string RFC Test Vector 4.
-      Assert Equals(B.decode("666F6F"      ), 'foo'   )
+    It encode string RFC Test Vector 4. (reverse pattern)
+      Assert Equals(B.encode("foo"   ), '666F6F'      )
     End
-    It decode string RFC Test Vector 5.
-      Assert Equals(B.decode("666F6F62"    ), 'foob'  )
+    It encode string RFC Test Vector 5. (reverse pattern)
+      Assert Equals(B.encode("foob"  ), '666F6F62'    )
     End
-    It decode string RFC Test Vector 6.
-      Assert Equals(B.decode("666F6F6261"  ), 'fooba' )
+    It encode string RFC Test Vector 6. (reverse pattern)
+      Assert Equals(B.encode("fooba" ), '666F6F6261'  )
     End
-    It decode string RFC Test Vector 7.
-      Assert Equals(B.decode("666F6F626172"), 'foobar')
+    It encode string RFC Test Vector 7. (reverse pattern)
+      Assert Equals(B.encode("foobar"), '666F6F626172')
     End
   End
 


### PR DESCRIPTION
Base16 のテストにミスがあったので修正しています。

単純な hex string の扱いの部分のため、test vector が不足しているので補填していたのですが、
補填時にミスっていました。

---

現在Windowsは別問題でNGになります