### PR TITLE
ci: fix windows download method

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -167,7 +167,7 @@ jobs:
           if (Test-Path $zip) {
             Write-Host cache hit
           } else {
-            (New-Object Net.WebClient).DownloadFile('${{ steps.files.outputs.url }}', $zip)
+            Invoke-WebRequest '${{ steps.files.outputs.url }}' -UserAgent 'pwsh' -OutFile $zip
           }
           [Reflection.Assembly]::LoadWithPartialName('System.IO.Compression.FileSystem') > $null
           [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $lua)


### PR DESCRIPTION
# Summary

Windowsでのlua dllダウンロードエラーを修正します

# Detail

## Changes

- CI でのダウンロードを [WebClient](https://learn.microsoft.com/ja-jp/dotnet/api/system.net.webclient) から [Invoke-WebRequest](https://learn.microsoft.com/ja-jp/powershell/module/microsoft.powershell.utility/invoke-webrequest) に変更、あわせて UserAgentを明記
  - > WebRequest、HttpWebRequest、ServicePoint、WebClient は廃止されており、新しい開発には使用しないでください。 代わりに [HttpClient](https://learn.microsoft.com/ja-jp/dotnet/api/system.net.http.httpclient?view=net-9.0) を使用してください。
  - [ここ](https://stackoverflow.com/questions/69386094/error-403-when-trying-to-access-url-able-to-access-through-browser-without-erro)にあるように UserAgent 指定がないとエラーが出やすいみたいなので
  - 今回の動作のエラーも、UserAgent指定がないことが由来と思われます

## Tests

CIを参照